### PR TITLE
Fix backfill workflow + upgrade all workflows to Node.js 22

### DIFF
--- a/.github/workflows/auto-retry.yml
+++ b/.github/workflows/auto-retry.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install Anthropic SDK
         run: npm install @anthropic-ai/sdk --no-save

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -6,13 +6,23 @@ on:
       dates:
         description: 'Space-separated dates to backfill (YYYY-MM-DD)'
         required: true
-        default: '2026-03-25 2026-03-26 2026-03-27'
+        default: '2026-04-06 2026-04-07'
+      anthropic_api_key:
+        description: 'Anthropic API key (leave blank to use repo secret ANTHROPIC_API_KEY)'
+        required: false
+        default: ''
+
+concurrency:
+  group: backfill
+  cancel-in-progress: false
 
 jobs:
   backfill:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout repository
@@ -23,14 +33,25 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install Anthropic SDK
         run: npm install @anthropic-ai/sdk --no-save
 
+      - name: Verify API key is available
+        env:
+          ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key || secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ERROR: No ANTHROPIC_API_KEY provided."
+            echo "Either pass it as a workflow input or set it as a repository secret."
+            exit 1
+          fi
+          echo "API key is set (${#ANTHROPIC_API_KEY} chars)"
+
       - name: Run backfill
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key || secrets.ANTHROPIC_API_KEY }}
         run: node scripts/backfill-days.mjs ${{ github.event.inputs.dates }}
         timeout-minutes: 30
 
@@ -46,7 +67,7 @@ jobs:
           git config user.email "bot@hoopsintel.net"
           git add client/src/lib/ public/feed.xml public/sitemap.xml
           git commit -m "Backfill editions: ${{ github.event.inputs.dates }}"
-          git push origin ${{ github.ref_name }}
+          git push origin main
 
       - name: No changes detected
         if: steps.changes.outputs.changed == 'false'

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install Anthropic SDK
         run: npm install @anthropic-ai/sdk --no-save

--- a/.github/workflows/email-digest.yml
+++ b/.github/workflows/email-digest.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Run health check
         id: health

--- a/.github/workflows/injury-check.yml
+++ b/.github/workflows/injury-check.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Check injury status changes

--- a/.github/workflows/midday-refresh.yml
+++ b/.github/workflows/midday-refresh.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install Anthropic SDK
         run: npm install @anthropic-ai/sdk --no-save

--- a/.github/workflows/scores-refresh.yml
+++ b/.github/workflows/scores-refresh.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Fetch latest ESPN scores
         id: fetch

--- a/.github/workflows/social-post.yml
+++ b/.github/workflows/social-post.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install social SDK dependencies
         run: npm install twitter-api-v2 @atproto/api --no-save

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Validate content
         run: node scripts/tests/validate-content.mjs

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install Anthropic SDK
         run: npm install @anthropic-ai/sdk --no-save


### PR DESCRIPTION
- Backfill now accepts ANTHROPIC_API_KEY as workflow input (fallback to secret)
- Add explicit API key verification step before running backfill
- Upgrade all 11 workflows from Node.js 20 to 22 (fixes deprecation warning)
- Push backfill commits to main branch explicitly

https://claude.ai/code/session_013KiWvV8PRT5rqbyMYa4yyC