### PR TITLE
Improve timeout handling for Edition generation script

### DIFF
--- a/scripts/backfill-days.mjs
+++ b/scripts/backfill-days.mjs
@@ -38,7 +38,9 @@ function runForDate(date) {
     });
 
     child.on("close", (code) => {
-      if (code === 0) {
+      if (code === 0 || code === 2) {
+        // code 0 = full success, code 2 = partial failure (edition OK, non-critical scripts failed)
+        if (code === 2) console.warn(`  ⚠ Partial failure for ${date} — edition generated, some non-critical scripts failed`);
         resolve();
       } else {
         reject(new Error(`generate-all-daily.mjs exited with code ${code} for date ${date}`));

--- a/scripts/generate-all-daily.mjs
+++ b/scripts/generate-all-daily.mjs
@@ -50,12 +50,14 @@ const PHASE_2 = [
   { name: "OG Images", script: "generate-og-images.mjs" },
 ];
 
-const SCRIPT_TIMEOUT = 180_000; // 3 minutes per script
+const SCRIPT_TIMEOUT = 180_000; // 3 minutes per script (default)
+const EDITION_TIMEOUT = 360_000; // 6 minutes for Edition (2 Claude API calls + ESPN fetches + retries)
 
 function runScript({ name, script }) {
   return new Promise((resolve) => {
     const scriptPath = join(__dirname, script);
     const start = Date.now();
+    const timeout = script === "generate-edition.mjs" ? EDITION_TIMEOUT : SCRIPT_TIMEOUT;
 
     const args = DRY_RUN ? [scriptPath, "--dry-run"] : [scriptPath];
     const child = spawn("node", args, {
@@ -66,12 +68,14 @@ function runScript({ name, script }) {
 
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
     child.stdout.on("data", (d) => { stdout += d; });
     child.stderr.on("data", (d) => { stderr += d; });
 
     const timer = setTimeout(() => {
+      timedOut = true;
       child.kill("SIGTERM");
-    }, SCRIPT_TIMEOUT);
+    }, timeout);
 
     child.on("close", (code) => {
       clearTimeout(timer);
@@ -81,7 +85,10 @@ function runScript({ name, script }) {
       } else {
         // Print stderr for failed scripts
         if (stderr) console.error(`  [${name}] ${stderr.trim()}`);
-        resolve({ name, status: "failed", elapsed, error: `exit code ${code}` });
+        const error = timedOut
+          ? `timed out after ${timeout / 1000}s`
+          : `exit code ${code}`;
+        resolve({ name, status: "failed", elapsed, error });
       }
     });
 


### PR DESCRIPTION
## Summary
Enhanced timeout and error handling for the daily generation pipeline to better accommodate the Edition script, which requires more time due to multiple Claude API calls and ESPN data fetches.

## Key Changes

- **Separate timeout configuration**: Added `EDITION_TIMEOUT` constant (6 minutes) specifically for the Edition generation script, while keeping the default timeout at 3 minutes for other scripts
- **Improved timeout tracking**: Added `timedOut` flag to distinguish between timeout failures and other exit code failures, providing clearer error messages
- **Better error reporting**: Timeout errors now display the actual timeout duration that was exceeded, making debugging easier
- **Partial success handling**: Modified `backfill-days.mjs` to treat exit code 2 as a partial success (Edition generated successfully, but non-critical scripts failed), allowing the backfill process to continue rather than fail completely

## Implementation Details

- The timeout selection logic checks if the script being run is `generate-edition.mjs` and applies the longer timeout accordingly
- Error messages now distinguish between "timed out after Xs" and "exit code X" failures
- Partial failures (code 2) are logged with a warning but don't block the backfill process, improving resilience of the daily generation pipeline

https://claude.ai/code/session_01Fmn9GZtzXDmn6ZHvasdMRC