### PR TITLE
Add empty-scoreboard fallback when ESPN API and cache are both unavai…

### DIFF
--- a/scripts/lib/espn-cache.mjs
+++ b/scripts/lib/espn-cache.mjs
@@ -45,7 +45,10 @@ export async function fetchESPNCached(espnDate) {
       console.warn(`  [espn] Using cached data for ${espnDate}`);
       return cached;
     } catch {
-      throw new Error(`ESPN API failed and no cached data for ${espnDate}: ${err.message}`);
+      // Last resort: return empty scoreboard so generation can proceed
+      // Claude will generate content without specific game data
+      console.warn(`  [espn] No cached data for ${espnDate} — using empty scoreboard`);
+      return { events: [], day: { date: espnDate }, leagues: [] };
     }
   }
 }


### PR DESCRIPTION
…lable

Instead of crashing when ESPN data can't be fetched and no cache exists, return an empty scoreboard ({events: []}). This lets Claude generate editions without specific game data (e.g., off-season, API outages).

https://claude.ai/code/session_01Fmn9GZtzXDmn6ZHvasdMRC