### PR TITLE
Fix CI package lock sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -316,6 +316,29 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",


### PR DESCRIPTION
### Motivation

- The CI `npm ci` step was failing lockfile validation because optional transitive packages required by the Tailwind/Rolldown wasm tree were missing from `package-lock.json`.

### Description

- Added missing lockfile entries for `node_modules/@emnapi/core@1.10.0` including `resolved`, `integrity`, `optional`, and its `dependencies`.
- Added missing lockfile entries for `node_modules/@emnapi/runtime@1.10.0` including `resolved`, `integrity`, `optional`, and its `dependencies`.
- The additions restore the transitive optional dependency set referenced by `@tailwindcss/oxide` / wasm bindings so lockfile validation can succeed.

### Testing

- Ran `npm ci --dry-run --no-audit --no-fund --ignore-scripts` which completed without lockfile-sync errors.
- Attempted the full validation pipeline (`node` scripts that run `validate-*` and assembly tests), but those checks could not fully complete in this environment because a full install of dev dependencies could not finish (missing binaries such as `esbuild` / test runner), causing generated-structure checks to report missing packages; those checks are expected to pass once CI performs a normal `npm ci` install with network access and optional packages available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011498224c832aa48fb080d0010e7c)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync `package-lock.json` with current package dependencies
> Updates [package-lock.json](https://github.com/hondoentertainment/hoops-intel/pull/90/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519) to bring the lockfile back in sync, fixing CI failures caused by a lockfile mismatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dc7c70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->