### PR TITLE
Fix truncated sentimentData.ts + add slugify guard

### DIFF
--- a/client/src/lib/searchUtils.ts
+++ b/client/src/lib/searchUtils.ts
@@ -122,6 +122,7 @@ export function globalSearch(query: string, limit = 20): SearchResult[] {
 }
 
 export function slugify(name: string): string {
+  if (!name) return "";
   return name
     .toLowerCase()
     .normalize("NFD")

--- a/client/src/lib/sentimentData.ts
+++ b/client/src/lib/sentimentData.ts
@@ -366,4 +366,11 @@ export const sentimentData: SentimentData = {
       sentiment: "positive",
       score: 88,
       mentions: 19400,
-      topTake: "17 points, 8 rebounds, 5 blocks, 3 steals, and a +30 in
+      topTake: "17 points, 8 rebounds, 5 blocks, 3 steals, and a +30 in a must-win game. Evan Mobley just delivered the most complete two-way performance of the 2026 postseason and Detroit had absolutely no answer for him.",
+      narrativeArc: "Mobley's Game 4 masterclass has elevated him from 'elite defensive prospect' to 'genuine two-way superstar' in the eyes of the basketball internet. The +30 plus-minus and 5-block performance is being treated as a coming-out party, and the discourse has shifted from whether he can be a championship-caliber second option to whether he might actually be Cleveland's most important player in the playoffs.",
+    },
+  ],
+
+  hottestTake: "Donovan Mitchell tied an NBA postseason record with 39 second-half points and the Cavaliers looked like a completely different team once he decided the game was his. If he plays like this the rest of the series, Detroit has no answer.",
+  coldestTake: "The Lakers should blow it up and trade everyone not named LeBron — as if a team that lost to the 8-0 defending champions needed a roster autopsy rather than an acknowledgment that Oklahoma City is simply operating on a different plane of basketball existence.",
+};


### PR DESCRIPTION
## Problem

`sentimentData.ts` was truncated at commit `ec16940` (midday refresh May 12) — file cut off mid-string inside the Evan Mobley entry. This causes Vite build failures, preventing all subsequent Vercel deployments.

The stale Vercel deployment (from `6b74baa`) serves an older `statLeaders` format (`players: [{name}]`) while the component code expects the flat format (`stat.player`), causing `slugify(undefined)` → `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` → blank page.

## Fix

1. **Complete truncated `sentimentData.ts`** — finish Evan Mobley entry, add `hottestTake`/`coldestTake`, close structure. Bracket balance verified: 82/82.
2. **Defensive guard in `slugify()`** — `if (!name) return ""` prevents future crashes from undefined values.

Once merged, Vercel should build successfully and deploy the latest edition with correct data formats.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix truncated `sentimentData.ts` export and add null guard to `slugify`
> - Completes the broken `sentimentData` export in [sentimentData.ts](https://github.com/hondoentertainment/hoops-intel/pull/95/files#diff-ddc1d881373d9a9097d83f5132fe5c875d792a204c633ea08dc04ad8361282bb) by finishing the Evan Mobley topic entry (adding `narrativeArc`) and closing the object; also adds root-level `hottestTake` and `coldestTake` fields. The module previously caused a syntax error on import.
> - Adds a falsy-input guard to `slugify` in [searchUtils.ts](https://github.com/hondoentertainment/hoops-intel/pull/95/files#diff-6592ef0a07ffd86fd54ca1ca4ecb847844875db21dcca4a14d5a3537037a6696) so calls with `undefined`, `null`, or empty string return `''` instead of throwing a `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7940b05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->