### PR TITLE
fix: unblock daily edition — accept 'F' seriesId + raise history token budget

### DIFF
--- a/PRODUCTION-OPS.md
+++ b/PRODUCTION-OPS.md
@@ -64,7 +64,7 @@ npx vercel deploy --prod --yes   # optional immediate CLI prod deploy
 
 ## Playoff series URL schema
 
-Series IDs use `{E|W}{roundRank}-{higherTeam}-{lowerTeam}` where the digit is **round** (1 = first round, 2 = semifinals, 3 = conference finals, 4 = finals), not seed. Example: `W2-SAS-MIN` and `W2-OKC-LAL` are both valid West semifinal series.
+Series IDs use `{E|W|F}{roundRank}-{higherTeam}-{lowerTeam}` where the digit is **round** (1 = first round, 2 = semifinals, 3 = conference finals, 4 = NBA Finals), not seed. The conference prefix is `E` for East and `W` for West through round 3; the NBA Finals belongs to neither conference and uses `F`. Examples: `W2-SAS-MIN` (West semifinal), `E3-NYK-CLE` (East conference final), `F4-SAS-NYK` (NBA Finals).
 
 ## Troubleshooting
 

--- a/references/data-schema.md
+++ b/references/data-schema.md
@@ -234,7 +234,7 @@ export interface PlayoffSeriesGame {
 }
 
 export interface PlayoffSeries {
-  seriesId: string;           // "E1-DET-ORL" / "W4-LAL-HOU"
+  seriesId: string;           // "E1-DET-ORL" (East R1) / "W3-OKC-SAS" (West conf finals) / "F4-SAS-NYK" (NBA Finals)
   conference: "east" | "west" | "finals";
   round: PlayoffRound;
   higherSeed: number;         // 1–8 (or 1 for Finals)

--- a/scripts/generate-history.mjs
+++ b/scripts/generate-history.mjs
@@ -99,7 +99,7 @@ Output ONLY the complete TypeScript file. No markdown fences, no explanation. Th
   async function generateOnce() {
     console.log("🤖 Calling Claude API...");
     const msg = await claudeGenerate("history", {
-      max_tokens: 12000,
+      max_tokens: 16384,
       messages: [{ role: "user", content: prompt }],
     });
     const content = msg.content[0]?.type === "text" ? msg.content[0].text : "";

--- a/scripts/validate-generated-structure.mjs
+++ b/scripts/validate-generated-structure.mjs
@@ -35,13 +35,14 @@ export function validatePlayoffStructure() {
 
   const ids = [...inner.matchAll(/seriesId:\s*"([^"]+)"/g)].map((m) => m[1]);
   const seen = new Set();
-  // Prefix digit is playoff round rank (E1/W1 first round … E4/W4 finals), not team seed.
-  const SERIES_ID_RE = /^[EW][1-4]-[A-Z]{3}-[A-Z]{3}$/;
+  // Prefix is conference (E/W) or F for the NBA Finals; digit is playoff round rank
+  // (E1/W1 first round … round 3 conference finals, F4 NBA Finals), not team seed.
+  const SERIES_ID_RE = /^[EWF][1-4]-[A-Z]{3}-[A-Z]{3}$/;
   for (const id of ids) {
     assertCond(!seen.has(id), `duplicate seriesId in playoff sync: "${id}"`);
     assertCond(
       SERIES_ID_RE.test(id),
-      `invalid seriesId "${id}" (expected E|W + round 1-4 + team pair, e.g. W2-SAS-MIN)`,
+      `invalid seriesId "${id}" (expected E|W|F + round 1-4 + team pair, e.g. W2-SAS-MIN or F4-SAS-NYK)`,
     );
     seen.add(id);
   }


### PR DESCRIPTION
## Why the site is stale

The daily edition has been stuck on **May 31 (Vol. 2026 · No. 158)** even though scores refreshed through June 3. Every `daily-update.yml` run since **June 1** failed. Two latent bugs surfaced at once when the season flipped into the **NBA Finals** (SAS vs NYK).

## Fix 1 — Validator rejects the Finals series-id prefix `F` (BLOCKER)

The Finals belongs to neither conference, so the pipeline's authoritative ID builder uses an `F` prefix:

- `scripts/fetch-playoff-series.mjs#buildSeriesId` → `round === "finals" ? "F" : …` ⇒ `F4-SAS-NYK`
- `scripts/sync-playoff-data.mjs` already filters with `/^[EWF][1-4]-…$/`

But `scripts/validate-generated-structure.mjs#validatePlayoffStructure` still only allowed `[EW]`. That function is called in **two** places, so the bug bit twice every morning:

1. **Preflight** (`generate-all-daily.mjs:62`) — rejected `F4-SAS-NYK` and **reverted `playoffData.ts` to the last committed version**, silently discarding the freshly-synced Finals series.
2. **Staging** (`stage-daily-edition.mjs`) — same rejection, but here it `exit 1`'d the whole job, so **no commit ever happened** even though the edition itself generated fine.

```
⚠ playoff sync structure invalid: invalid seriesId "F4-SAS-NYK" … ↩ Reverted playoffData.ts
❌ Generated structure validation failed: invalid seriesId "F4-SAS-NYK"
##[error]Process completed with exit code 1.
```

**Fix:** widen `SERIES_ID_RE` from `/^[EW][1-4]-…$/` to `/^[EWF][1-4]-…$/`, matching `buildSeriesId` and `sync-playoff-data.mjs`. One-file change.

## Fix 2 — History section consistently truncates (secondary)

`generate-history.mjs` capped Claude's output at `max_tokens: 12000`, but the last successfully-committed `historyData.ts` is ~46 KB (~13 K tokens). When the model produces a full file it overruns the cap and both retry attempts ended mid-string:

```
truncated: unexpected file ending (milestone: "Youngest player to win NBA Finals MVP in the shot-clock era, surpass)
truncated: unexpected file ending (needed: "Sustain his ECF three-point shooting (3.1 per game) and scoring average)
```

**Fix:** raise `max_tokens` to **16384**, matching `generate-edition.mjs` and `generate-community-pulse.mjs` (~25% headroom, well inside Sonnet 4.6's output ceiling).

## Verification

- `node scripts/validate-generated-structure.mjs` → ✅ playbook sync structure OK (against the live `F4-SAS-NYK` board)
- `npm run test:pre-push` → ✅ schema · structure · drift · content · vite build · dist embed
- `vitest run` → ✅ 196/196 · assembly → ✅ 5/5
- No other `[EW]` regex assumptions found across `scripts/` or `client/src/` — swept and clean.

Once merged, the preflight will keep the synced Finals series, staging will pass, and History will fit inside its budget. Next scheduled run (5 AM PST) — or a manual dispatch — will resume publishing daily Finals editions.

---

## ⚠️ One issue NOT fixed here — needs owner action

**Anthropic credits are depleted.** Late in the June 3 run the API returned:
```
❌ Refs — 400: "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing…"
```
Earlier sections (Edition, Watch Guide, Sentiment, Podcast) succeeded, then the balance ran dry mid-run. **Even with this PR merged, the daily job will keep partially failing until the Anthropic account is topped up.** This is a billing action only the owner can take. (I have no tools that can change billing state.)

https://claude.ai/code/session_01X7q5m7186NSUrHtqtLYEtw

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept 'F' seriesId prefix for NBA Finals and raise history token budget to 16384
> - Updates `SERIES_ID_RE` in [validate-generated-structure.mjs](https://github.com/hondoentertainment/hoops-intel/pull/151/files#diff-b7c732aefe0f39045b0a98415498492906326775416d91f664c9fb4911220ae5) from `/^[EW][1-4]-...$/` to `/^[EWF][1-4]-...$/` so NBA Finals series IDs pass validation.
> - Increases `max_tokens` in [generate-history.mjs](https://github.com/hondoentertainment/hoops-intel/pull/151/files#diff-ab7d36610606fe04068a9629ce653bda1cb05b3101750947c8f2ac95f99eafc5) from 12000 to 16384 to prevent truncated history generation.
> - Updates [PRODUCTION-OPS.md](https://github.com/hondoentertainment/hoops-intel/pull/151/files#diff-eb8a51cceb3ae68aa40e99ed606d75602f13d44c9bbb3ab467472a3e16782a89) and [data-schema.md](https://github.com/hondoentertainment/hoops-intel/pull/151/files#diff-86871d036be6a1da46c4ea0d5cfc89f232783cbf4b9a6db6d20035541297bda6) to document the `F` prefix convention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41f23e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->