### PR TITLE
ESPN-grade pass: scoreboard strip, team logos, card depth + UX/a11y hardening

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect } from "react";
-import { Route, Switch } from "wouter";
+import { Route, Switch, useLocation } from "wouter";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import AskHoopsIntel from "./components/AskHoopsIntel";
@@ -9,6 +9,7 @@ import BackToTop from "./components/BackToTop";
 import PwaInstallPrompt from "./components/PwaInstallPrompt";
 import KeyboardShortcutsHelp from "./components/KeyboardShortcutsHelp";
 import RouteSeo from "./components/RouteSeo";
+import RouteErrorBoundary from "./components/RouteErrorBoundary";
 import { incrementVisitCount } from "./lib/visitCount";
 import { syncEngagementBadges } from "./lib/badgeChecks";
 
@@ -102,6 +103,8 @@ function PageLoader() {
 }
 
 export default function App() {
+  const [location] = useLocation();
+
   useEffect(() => {
     incrementVisitCount();
     syncEngagementBadges();
@@ -120,6 +123,7 @@ export default function App() {
           color: "var(--hi-shell-text, rgba(255,255,255,0.85))",
         }}
       >
+        <RouteErrorBoundary resetKey={location}>
         <Suspense fallback={<PageLoader />}>
           <Switch>
             <Route path="/" component={Home} />
@@ -189,6 +193,7 @@ export default function App() {
             </Route>
           </Switch>
         </Suspense>
+        </RouteErrorBoundary>
         <AskHoopsIntel />
         <MobileBottomNav />
         <BackToTop />

--- a/client/src/__tests__/routeErrorBoundary.test.tsx
+++ b/client/src/__tests__/routeErrorBoundary.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RouteErrorBoundary from "../components/RouteErrorBoundary";
+
+function Boom({ message }: { message: string }): JSX.Element {
+  throw new Error(message);
+}
+
+describe("RouteErrorBoundary", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <RouteErrorBoundary resetKey="/">
+        <p>healthy page</p>
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByText("healthy page")).toBeInTheDocument();
+  });
+
+  it("shows a recoverable shell with a reload action when a route throws", () => {
+    render(
+      <RouteErrorBoundary resetKey="/">
+        <Boom message="render exploded" />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reload page/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /today/i })).toBeInTheDocument();
+  });
+
+  it("uses stale-deploy copy for chunk load failures", () => {
+    render(
+      <RouteErrorBoundary resetKey="/">
+        <Boom message="Failed to fetch dynamically imported module: /assets/x.js" />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByText(/newer version of the site shipped/i)).toBeInTheDocument();
+  });
+
+  it("recovers when the reset key (route) changes", () => {
+    const { rerender } = render(
+      <RouteErrorBoundary resetKey="/broken">
+        <Boom message="render exploded" />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    rerender(
+      <RouteErrorBoundary resetKey="/healthy">
+        <p>recovered page</p>
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByText("recovered page")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/teamColors.test.ts
+++ b/client/src/__tests__/teamColors.test.ts
@@ -47,8 +47,13 @@ describe("teamColors", () => {
       expect(getTeamColor("")).toBe("#0EA5E9");
     });
 
-    it("is case-sensitive (lowercase returns fallback)", () => {
-      expect(getTeamColor("lal")).toBe("#0EA5E9");
+    it("is case-insensitive (lowercase resolves to the team color)", () => {
+      expect(getTeamColor("lal")).toBe("#552583");
+    });
+
+    it("resolves ESPN abbreviation variants to the right color", () => {
+      expect(getTeamColor("bkn")).toBe(getTeamColor("BRK"));
+      expect(getTeamColor("wsh")).toBe(getTeamColor("WAS"));
     });
   });
 });

--- a/client/src/__tests__/teamLogo.test.tsx
+++ b/client/src/__tests__/teamLogo.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TeamLogo from "../components/TeamLogo";
+import {
+  teamLogoUrl,
+  normalizeTeam,
+  getTeamColor,
+  getTeamName,
+  readableTextOn,
+} from "../lib/teamColors";
+
+describe("team identity helpers", () => {
+  it("normalizes ESPN abbreviation variants to our standard set", () => {
+    expect(normalizeTeam("bkn")).toBe("BRK");
+    expect(normalizeTeam("GS")).toBe("GSW");
+    expect(normalizeTeam("no")).toBe("NOP");
+    expect(normalizeTeam("ny")).toBe("NYK");
+    expect(normalizeTeam("SA")).toBe("SAS");
+    expect(normalizeTeam("utah")).toBe("UTA");
+    expect(normalizeTeam("wsh")).toBe("WAS");
+    expect(normalizeTeam("LAL")).toBe("LAL");
+  });
+
+  it("maps every standard team to an ESPN logo URL", () => {
+    for (const abbr of Object.keys(getColorKeys())) {
+      expect(teamLogoUrl(abbr)).toMatch(/^https:\/\/a\.espncdn\.com\/i\/teamlogos\/nba\/500\/[a-z]+\.png$/);
+    }
+  });
+
+  it("resolves logo + color through alias normalization", () => {
+    expect(teamLogoUrl("BKN")).toBe(teamLogoUrl("BRK"));
+    expect(getTeamColor("WSH")).toBe(getTeamColor("WAS"));
+    expect(getTeamName("ny")).toBe("New York Knicks");
+  });
+
+  it("returns null logo for unknown teams (crest fallback path)", () => {
+    expect(teamLogoUrl("ZZZ")).toBeNull();
+  });
+
+  it("picks dark text on light team colors and white on dark", () => {
+    expect(readableTextOn("#FFFFFF")).toBe("#0A1628");
+    expect(readableTextOn("#C4CED4")).toBe("#0A1628");
+    expect(readableTextOn("#0C2340")).toBe("#FFFFFF");
+  });
+});
+
+describe("TeamLogo", () => {
+  it("renders an accessible image with the full team name", () => {
+    render(<TeamLogo team="LAL" />);
+    expect(screen.getByAltText("Los Angeles Lakers")).toBeInTheDocument();
+  });
+
+  it("falls back to a labeled crest for unknown teams", () => {
+    render(<TeamLogo team="ZZZ" />);
+    const crest = screen.getByRole("img", { name: "ZZZ" });
+    expect(crest).toHaveTextContent("ZZZ");
+  });
+});
+
+function getColorKeys() {
+  return {
+    ATL: 1, BOS: 1, BRK: 1, CHA: 1, CHI: 1, CLE: 1, DAL: 1, DEN: 1, DET: 1,
+    GSW: 1, HOU: 1, IND: 1, LAC: 1, LAL: 1, MEM: 1, MIA: 1, MIL: 1, MIN: 1,
+    NOP: 1, NYK: 1, OKC: 1, ORL: 1, PHI: 1, PHX: 1, POR: 1, SAC: 1, SAS: 1,
+    TOR: 1, UTA: 1, WAS: 1,
+  };
+}

--- a/client/src/components/BoxScoreCard.tsx
+++ b/client/src/components/BoxScoreCard.tsx
@@ -65,6 +65,7 @@ function TeamTable({ players, team, teamStats }: {
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-left" style={{ minWidth: 600 }}>
+          <caption className="sr-only">{team} box score</caption>
           <thead>
             <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>
               <th className="px-2 py-1 text-xs font-medium" style={{ color: "rgba(255,255,255,0.4)" }}>Player</th>
@@ -115,11 +116,14 @@ export default function BoxScoreCard({ espnGameId, homeTeam, awayTeam }: {
   return (
     <div className="mt-3">
       <button
+        type="button"
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 text-xs font-medium transition-colors"
+        className="flex items-center gap-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 rounded"
         style={{ color: "#0EA5E9" }}
+        aria-expanded={expanded}
+        aria-controls={`box-score-${espnGameId}`}
       >
-        <span style={{ transform: expanded ? "rotate(90deg)" : "rotate(0deg)", transition: "transform 0.2s", display: "inline-block" }}>
+        <span aria-hidden style={{ transform: expanded ? "rotate(90deg)" : "rotate(0deg)", transition: "transform 0.2s", display: "inline-block" }}>
           &#9654;
         </span>
         {expanded ? "Hide Box Score" : "View Box Score"}
@@ -127,16 +131,17 @@ export default function BoxScoreCard({ espnGameId, homeTeam, awayTeam }: {
 
       {expanded && (
         <div
+          id={`box-score-${espnGameId}`}
           className="mt-3 rounded-lg p-4"
           style={{ background: "rgba(0,0,0,0.3)", border: "1px solid rgba(255,255,255,0.06)" }}
         >
           {loading && (
-            <div className="text-center py-4 text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
+            <div role="status" aria-live="polite" className="text-center py-4 text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
               Loading box score...
             </div>
           )}
           {error && (
-            <div className="text-center py-4 text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
+            <div role="status" className="text-center py-4 text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
               Box score not available for this game.
             </div>
           )}

--- a/client/src/components/PreferencesSetup.tsx
+++ b/client/src/components/PreferencesSetup.tsx
@@ -112,6 +112,9 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="my-pulse-setup-title"
         className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl shadow-2xl"
         style={{
           background: "#0A1628",
@@ -129,11 +132,13 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
         >
           <div>
             <div className="section-label text-xs mb-0.5">CUSTOMIZE</div>
-            <div className="text-lg font-bold text-white">My Pulse Setup</div>
+            <div id="my-pulse-setup-title" className="text-lg font-bold text-white">My Pulse Setup</div>
           </div>
           <button
+            type="button"
             onClick={onClose}
-            className="w-8 h-8 rounded flex items-center justify-center transition-colors hover:bg-white/10"
+            aria-label="Close My Pulse setup"
+            className="w-8 h-8 rounded flex items-center justify-center transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60"
             style={{ color: "rgba(255,255,255,0.4)" }}
           >
             <svg
@@ -166,8 +171,12 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
               </div>
             </div>
             <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              aria-label="Enable My Pulse personalization"
               onClick={() => setEnabled(!enabled)}
-              className="relative w-11 h-6 rounded-full transition-colors"
+              className="relative w-11 h-6 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60"
               style={{
                 background: enabled
                   ? "#0EA5E9"
@@ -211,8 +220,12 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
                 return (
                   <button
                     key={team}
+                    type="button"
                     onClick={() => !disabled && toggleTeam(team)}
-                    className="py-2.5 rounded text-xs font-bold tracking-wider transition-all"
+                    disabled={disabled}
+                    aria-pressed={selected}
+                    aria-label={`${team}${selected ? ", selected" : ""}`}
+                    className="py-2.5 rounded text-xs font-bold tracking-wider transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60"
                     style={{
                       background: selected
                         ? "rgba(14,165,233,0.2)"
@@ -223,13 +236,13 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
                       color: selected
                         ? "#0EA5E9"
                         : disabled
-                        ? "rgba(255,255,255,0.2)"
+                        ? "rgba(255,255,255,0.4)"
                         : "rgba(255,255,255,0.6)",
                       boxShadow: selected
                         ? "0 0 12px rgba(14,165,233,0.3)"
                         : "none",
                       cursor: disabled ? "not-allowed" : "pointer",
-                      opacity: disabled ? 0.4 : 1,
+                      opacity: disabled ? 0.5 : 1,
                     }}
                   >
                     {team}
@@ -301,8 +314,10 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
                   {suggestions.map((p) => (
                     <button
                       key={p}
+                      type="button"
                       onClick={() => addPlayer(p)}
-                      className="w-full text-left px-3 py-2 text-sm text-white hover:bg-white/10 transition-colors"
+                      aria-label={`Add ${p} to favorites`}
+                      className="w-full text-left px-3 py-2 text-sm text-white hover:bg-white/10 focus-visible:outline-none focus-visible:bg-white/10 transition-colors"
                     >
                       {p}
                     </button>
@@ -326,8 +341,10 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
                   >
                     {player}
                     <button
+                      type="button"
                       onClick={() => removePlayer(player)}
-                      className="w-4 h-4 rounded-full flex items-center justify-center hover:bg-white/20 transition-colors"
+                      aria-label={`Remove ${player} from favorites`}
+                      className="w-4 h-4 rounded-full flex items-center justify-center hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 transition-colors"
                       style={{ color: "#0EA5E9" }}
                     >
                       <svg
@@ -368,15 +385,17 @@ export default function PreferencesSetup({ onClose, onSave }: Props) {
           }}
         >
           <button
+            type="button"
             onClick={onClose}
-            className="px-4 py-2 rounded text-sm font-medium transition-colors hover:bg-white/10"
+            className="px-4 py-2 rounded text-sm font-medium transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60"
             style={{ color: "rgba(255,255,255,0.5)" }}
           >
             Cancel
           </button>
           <button
+            type="button"
             onClick={handleSave}
-            className="px-6 py-2 rounded text-sm font-semibold text-white transition-all hover:opacity-90"
+            className="px-6 py-2 rounded text-sm font-semibold text-white transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60"
             style={{ background: "#0EA5E9" }}
           >
             Save Preferences

--- a/client/src/components/RouteErrorBoundary.tsx
+++ b/client/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  /** Changes (e.g. the current path) reset the boundary so navigating away recovers. */
+  resetKey?: string;
+};
+
+type State = { err: Error | null };
+
+/**
+ * Top-level boundary for the lazy route tree. A failed chunk download (stale
+ * deploy, flaky network) throws inside Suspense and would otherwise blank the
+ * whole page; here it falls back to a recoverable shell instead.
+ */
+export default class RouteErrorBoundary extends Component<Props, State> {
+  state: State = { err: null };
+
+  static getDerivedStateFromError(err: Error): State {
+    return { err };
+  }
+
+  componentDidUpdate(prev: Props) {
+    if (this.state.err && prev.resetKey !== this.props.resetKey) {
+      this.setState({ err: null });
+    }
+  }
+
+  componentDidCatch(err: Error, info: ErrorInfo) {
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn("[hoops-intel/route]", err, info.componentStack);
+    }
+  }
+
+  render() {
+    if (!this.state.err) return this.props.children;
+
+    const isChunkError = /chunk|dynamically imported module|Failed to fetch/i.test(
+      this.state.err.message,
+    );
+
+    return (
+      <main className="container py-20 text-center" role="alert" aria-live="assertive">
+        <p className="section-label mb-3">SOMETHING BROKE</p>
+        <h1 className="display-heading text-2xl font-bold text-white mb-4">
+          This page didn&apos;t load
+        </h1>
+        <p className="text-sm mb-6 max-w-md mx-auto" style={{ color: "rgba(255,255,255,0.55)" }}>
+          {isChunkError
+            ? "A newer version of the site shipped while you were here. Reloading will pull the latest."
+            : "An unexpected error stopped this page from rendering. Reloading usually clears it."}
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="px-5 py-2 rounded text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            style={{ background: "#0EA5E9" }}
+          >
+            Reload page
+          </button>
+          <a
+            href="/"
+            className="px-5 py-2 rounded text-sm font-semibold transition-colors hover:bg-white/10"
+            style={{ color: "rgba(255,255,255,0.7)", border: "1px solid rgba(255,255,255,0.15)" }}
+          >
+            Back to today&apos;s desk
+          </a>
+        </div>
+      </main>
+    );
+  }
+}

--- a/client/src/components/ShareButton.tsx
+++ b/client/src/components/ShareButton.tsx
@@ -26,16 +26,23 @@ export default function ShareButton({
   const { toast } = useToast();
   const ref = useRef<HTMLDivElement>(null);
 
-  // Close dropdown on outside click
+  // Close dropdown on outside click or Escape
   useEffect(() => {
     if (!open) return;
-    const handler = (e: MouseEvent) => {
+    const onPointer = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false);
       }
     };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
   }, [open]);
 
   const shareUrl = url || window.location.href;
@@ -81,8 +88,9 @@ export default function ShareButton({
     <div ref={ref} className={`relative inline-block ${className}`}>
       {/* Trigger button */}
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
-        className={`flex items-center gap-1.5 ${btnPad} rounded ${textSize} font-semibold transition-colors`}
+        className={`flex items-center gap-1.5 ${btnPad} rounded ${textSize} font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60`}
         style={{
           background: open ? "rgba(14,165,233,0.2)" : "rgba(255,255,255,0.06)",
           color: open ? "#0EA5E9" : "rgba(255,255,255,0.55)",
@@ -90,6 +98,8 @@ export default function ShareButton({
           borderColor: open ? "rgba(14,165,233,0.4)" : "rgba(255,255,255,0.1)",
         }}
         aria-label="Share"
+        aria-haspopup="menu"
+        aria-expanded={open}
       >
         <svg
           width={iconSize}
@@ -113,6 +123,8 @@ export default function ShareButton({
       {/* Dropdown */}
       {open && (
         <div
+          role="menu"
+          aria-label="Share options"
           className="absolute right-0 mt-1 rounded-lg overflow-hidden z-10"
           style={{
             background: "#0B1728",
@@ -123,8 +135,10 @@ export default function ShareButton({
         >
           {/* Copy link */}
           <button
+            type="button"
+            role="menuitem"
             onClick={handleCopyLink}
-            className="w-full flex items-center gap-2 px-4 py-3 text-xs text-left transition-colors"
+            className="w-full flex items-center gap-2 px-4 py-3 text-xs text-left transition-colors focus-visible:outline-none focus-visible:bg-white/10"
             style={{ color: "rgba(255,255,255,0.8)" }}
             onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.06)")}
             onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
@@ -147,8 +161,10 @@ export default function ShareButton({
 
           {/* Post on X */}
           <button
+            type="button"
+            role="menuitem"
             onClick={handleTweetShare}
-            className="w-full flex items-center gap-2 px-4 py-3 text-xs text-left transition-colors"
+            className="w-full flex items-center gap-2 px-4 py-3 text-xs text-left transition-colors focus-visible:outline-none focus-visible:bg-white/10"
             style={{ color: "rgba(255,255,255,0.8)" }}
             onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.06)")}
             onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
@@ -162,8 +178,10 @@ export default function ShareButton({
           {/* Native share (mobile) */}
           {hasNativeShare && (
             <button
+              type="button"
+              role="menuitem"
               onClick={handleNativeShare}
-              className="w-full flex items-center gap-2 px-4 py-3 text-xs text-left transition-colors"
+              className="w-full flex items-center gap-2 px-4 py-3 text-xs text-left transition-colors focus-visible:outline-none focus-visible:bg-white/10"
               style={{ color: "rgba(255,255,255,0.8)" }}
               onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.06)")}
               onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}

--- a/client/src/components/TeamLogo.tsx
+++ b/client/src/components/TeamLogo.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import {
+  teamLogoUrl,
+  getTeamColor,
+  getTeamName,
+  normalizeTeam,
+  readableTextOn,
+} from "../lib/teamColors";
+
+interface TeamLogoProps {
+  team: string;
+  /** Rendered px size (square). */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Official ESPN team logo with a self-hosted colored crest fallback. The crest
+ * renders instantly if the CDN 403s, the team is unknown, or the image is still
+ * loading-failed — so a team mark is always present, never a broken image.
+ */
+export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoProps) {
+  const [failed, setFailed] = useState(false);
+  const abbr = normalizeTeam(team);
+  const url = teamLogoUrl(team);
+  const name = getTeamName(team);
+
+  if (!url || failed) {
+    const bg = getTeamColor(team);
+    return (
+      <span
+        className={`inline-flex items-center justify-center rounded-full shrink-0 font-bold leading-none ${className}`}
+        style={{
+          width: size,
+          height: size,
+          background: bg,
+          color: readableTextOn(bg),
+          fontSize: Math.max(8, Math.round(size * 0.4)),
+          letterSpacing: "-0.02em",
+          boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.12)",
+        }}
+        role="img"
+        aria-label={name}
+        title={name}
+      >
+        {abbr.slice(0, 3)}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={url}
+      alt={name}
+      title={name}
+      width={size}
+      height={size}
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+      className={`shrink-0 object-contain ${className}`}
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/client/src/lib/teamColors.ts
+++ b/client/src/lib/teamColors.ts
@@ -1,8 +1,69 @@
-// NBA Team Colors
-// Primary brand colors for all 30 NBA teams
+// NBA Team Colors + identity metadata
+// Primary brand colors, full names, and ESPN logo slugs for all 30 NBA teams.
 
 export const teamColors: Record<string, string> = {ATL:"#E03A3E",BOS:"#007A33",BRK:"#FFFFFF",CHA:"#1D1160",CHI:"#CE1141",CLE:"#860038",DAL:"#00538C",DEN:"#0E2240",DET:"#C8102E",GSW:"#1D428A",HOU:"#CE1141",IND:"#002D62",LAC:"#C8102E",LAL:"#552583",MEM:"#5D76A9",MIA:"#98002E",MIL:"#00471B",MIN:"#0C2340",NOP:"#0C2340",NYK:"#006BB6",OKC:"#007AC1",ORL:"#0077C0",PHI:"#006BB6",PHX:"#1D1160",POR:"#E03A3E",SAC:"#5A2D81",SAS:"#C4CED4",TOR:"#CE1141",UTA:"#002B5C",WAS:"#002B5C"};
 
+// ESPN and other feeds use a few different abbreviations than our NBA-standard set.
+// Normalize them so logo + color lookups never miss.
+const TEAM_ALIASES: Record<string, string> = {
+  BKN: "BRK", BK: "BRK",
+  GS: "GSW",
+  NO: "NOP", NOLA: "NOP",
+  NY: "NYK",
+  SA: "SAS",
+  UTAH: "UTA",
+  WSH: "WAS",
+  PHO: "PHX",
+  CHO: "CHA",
+};
+
+export function normalizeTeam(team: string): string {
+  const up = (team || "").trim().toUpperCase();
+  return TEAM_ALIASES[up] ?? up;
+}
+
 export function getTeamColor(team: string): string {
-  return teamColors[team] || "#0EA5E9";
+  return teamColors[normalizeTeam(team)] || "#0EA5E9";
+}
+
+// ESPN logo CDN slugs (differ from our abbreviations for several teams).
+const ESPN_LOGO_SLUGS: Record<string, string> = {
+  ATL: "atl", BOS: "bos", BRK: "bkn", CHA: "cha", CHI: "chi", CLE: "cle",
+  DAL: "dal", DEN: "den", DET: "det", GSW: "gs", HOU: "hou", IND: "ind",
+  LAC: "lac", LAL: "lal", MEM: "mem", MIA: "mia", MIL: "mil", MIN: "min",
+  NOP: "no", NYK: "ny", OKC: "okc", ORL: "orl", PHI: "phi", PHX: "phx",
+  POR: "por", SAC: "sac", SAS: "sa", TOR: "tor", UTA: "utah", WAS: "wsh",
+};
+
+export function teamLogoUrl(team: string): string | null {
+  const slug = ESPN_LOGO_SLUGS[normalizeTeam(team)];
+  return slug ? `https://a.espncdn.com/i/teamlogos/nba/500/${slug}.png` : null;
+}
+
+const TEAM_NAMES: Record<string, string> = {
+  ATL: "Atlanta Hawks", BOS: "Boston Celtics", BRK: "Brooklyn Nets",
+  CHA: "Charlotte Hornets", CHI: "Chicago Bulls", CLE: "Cleveland Cavaliers",
+  DAL: "Dallas Mavericks", DEN: "Denver Nuggets", DET: "Detroit Pistons",
+  GSW: "Golden State Warriors", HOU: "Houston Rockets", IND: "Indiana Pacers",
+  LAC: "LA Clippers", LAL: "Los Angeles Lakers", MEM: "Memphis Grizzlies",
+  MIA: "Miami Heat", MIL: "Milwaukee Bucks", MIN: "Minnesota Timberwolves",
+  NOP: "New Orleans Pelicans", NYK: "New York Knicks", OKC: "Oklahoma City Thunder",
+  ORL: "Orlando Magic", PHI: "Philadelphia 76ers", PHX: "Phoenix Suns",
+  POR: "Portland Trail Blazers", SAC: "Sacramento Kings", SAS: "San Antonio Spurs",
+  TOR: "Toronto Raptors", UTA: "Utah Jazz", WAS: "Washington Wizards",
+};
+
+export function getTeamName(team: string): string {
+  return TEAM_NAMES[normalizeTeam(team)] ?? team;
+}
+
+// Pick black or white text for legible contrast on a given team color.
+export function readableTextOn(hex: string): string {
+  const c = hex.replace("#", "");
+  if (c.length !== 6) return "#FFFFFF";
+  const r = parseInt(c.slice(0, 2), 16);
+  const g = parseInt(c.slice(2, 4), 16);
+  const b = parseInt(c.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? "#0A1628" : "#FFFFFF";
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import {
 } from "../lib/pulseData";
 import { playoffTickerWireItems } from "../lib/playoffTickerDerived";
 import { getTeamColor } from "../lib/teamColors";
+import TeamLogo from "../components/TeamLogo";
 import { useLiveScores } from "../lib/useLiveScores";
 import { slugify } from "../lib/searchUtils";
 import { useBodyScrollLock } from "../hooks/useBodyScrollLock";
@@ -120,9 +121,10 @@ function LiveScorebar() {
                   style={{ background: "rgba(255,255,255,0.04)" }}
                 >
                   <span
-                    className="section-label text-xs"
+                    className="flex items-center gap-1.5 section-label text-xs"
                     style={{ color: awayAhead ? "#0EA5E9" : "rgba(255,255,255,0.5)" }}
                   >
+                    <TeamLogo team={g.awayTeam} size={18} />
                     {g.awayTeam}{" "}
                     <span className="mono-data font-bold">{fmtLiveScore(as)}</span>
                   </span>
@@ -130,9 +132,10 @@ function LiveScorebar() {
                     @
                   </span>
                   <span
-                    className="section-label text-xs"
+                    className="flex items-center gap-1.5 section-label text-xs"
                     style={{ color: homeAhead ? "#0EA5E9" : "rgba(255,255,255,0.5)" }}
                   >
+                    <TeamLogo team={g.homeTeam} size={18} />
                     {g.homeTeam}{" "}
                     <span className="mono-data font-bold">{fmtLiveScore(hs)}</span>
                   </span>
@@ -499,12 +502,14 @@ function GameCard({ game }: { game: (typeof gameResults)[0] }) {
       >
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-3 flex-1">
-            <a href={`/team/${game.awayTeam.toLowerCase()}`} className="text-center w-12" onClick={(e) => e.stopPropagation()}>
+            <a href={`/team/${game.awayTeam.toLowerCase()}`} className="flex flex-col items-center w-14" onClick={(e) => e.stopPropagation()}>
+              <TeamLogo team={game.awayTeam} size={32} className="mb-1" />
               <div className="section-label mb-0.5" style={{ color: awayWin ? "#0EA5E9" : "rgba(255,255,255,0.4)" }}>{game.awayTeam}</div>
               <div className={`mono-data font-bold text-2xl ${awayWin ? "pulse-glow-blue" : ""}`} style={{ color: awayWin ? "#ffffff" : "rgba(255,255,255,0.5)" }}>{game.awayScore}</div>
             </a>
             <div className="text-xs text-center" style={{ color: "rgba(255,255,255,0.3)" }}>@</div>
-            <a href={`/team/${game.homeTeam.toLowerCase()}`} className="text-center w-12" onClick={(e) => e.stopPropagation()}>
+            <a href={`/team/${game.homeTeam.toLowerCase()}`} className="flex flex-col items-center w-14" onClick={(e) => e.stopPropagation()}>
+              <TeamLogo team={game.homeTeam} size={32} className="mb-1" />
               <div className="section-label mb-0.5" style={{ color: homeWin ? "#0EA5E9" : "rgba(255,255,255,0.4)" }}>{game.homeTeam}</div>
               <div className={`mono-data font-bold text-2xl ${homeWin ? "pulse-glow-blue" : ""}`} style={{ color: homeWin ? "#ffffff" : "rgba(255,255,255,0.5)" }}>{game.homeScore}</div>
             </a>
@@ -621,9 +626,22 @@ function ScoresSection({ favoriteTeams }: { favoriteTeams: string[] }) {
             {gameResults.length} GAMES
           </div>
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {sortedGames.map((game) => (<GameCard key={game.gameId} game={game} />))}
-        </div>
+        {sortedGames.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {sortedGames.map((game) => (<GameCard key={game.gameId} game={game} />))}
+          </div>
+        ) : (
+          <div
+            className="glass-card rounded-lg px-6 py-10 text-center"
+            style={{ border: "1px dashed rgba(255,255,255,0.12)" }}
+          >
+            <p className="section-label mb-2" style={{ color: "rgba(255,255,255,0.4)" }}>NO GAMES</p>
+            <p className="text-sm" style={{ color: "rgba(255,255,255,0.55)" }}>
+              No games on last night&apos;s slate. Check{" "}
+              <a href="/watch-guide" className="text-sky-400 underline">tonight&apos;s schedule</a> for the next tip-off.
+            </p>
+          </div>
+        )}
       </div>
     </section>
   );
@@ -853,6 +871,7 @@ function PulseIndexSection() {
             return (
               <div key={player.rank} className="glass-card rounded-lg p-4 flex items-center gap-4" style={isFavorite ? { borderLeft: "3px solid #0EA5E9" } : {}}>
                 <div className="mono-data text-2xl font-bold w-8 text-center" style={{ color: "#0EA5E9" }}>{player.rank}</div>
+                <TeamLogo team={player.team} size={34} />
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-1">
                     <a href={`/player/${slugify(player.player)}`} className="text-sm font-semibold text-white hover:text-sky-400 transition-colors">{player.player}</a>
@@ -1244,12 +1263,14 @@ function GamePreviewCard({ preview }: { preview: any }) {
       <div className="p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <a href={`/team/${preview.awayTeam.toLowerCase()}`} className="text-center">
+            <a href={`/team/${preview.awayTeam.toLowerCase()}`} className="flex flex-col items-center gap-1">
+              <TeamLogo team={preview.awayTeam} size={28} />
               <div className="section-label">{preview.awayTeam}</div>
               <div className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>{preview.awayRecord}</div>
             </a>
             <div className="text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>@</div>
-            <a href={`/team/${preview.homeTeam.toLowerCase()}`} className="text-center">
+            <a href={`/team/${preview.homeTeam.toLowerCase()}`} className="flex flex-col items-center gap-1">
+              <TeamLogo team={preview.homeTeam} size={28} />
               <div className="section-label">{preview.homeTeam}</div>
               <div className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>{preview.homeRecord}</div>
             </a>
@@ -1512,7 +1533,10 @@ function StandingsSection() {
               >
                 <td className="px-3 py-2 mono-data" style={{ color: "#0EA5E9" }}>{team.rank}</td>
                 <td className="px-3 py-2 font-semibold">
-                  <a href={`/team/${team.team.toLowerCase()}`} className="text-white hover:text-sky-400 transition-colors">{team.team}</a>
+                  <a href={`/team/${team.team.toLowerCase()}`} className="inline-flex items-center gap-2 text-white hover:text-sky-400 transition-colors">
+                    <TeamLogo team={team.team} size={20} />
+                    {team.team}
+                  </a>
                   {team.rank === 6 && sortKey === "rank" && (
                     <span className="ml-2 text-[10px] px-1 py-0.5 rounded" style={{ background: "rgba(14,165,233,0.1)", color: "#0EA5E9" }}>PLAYOFF</span>
                   )}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -172,11 +172,26 @@ html.light .section-label {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(10px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 4px 16px rgba(0, 0, 0, 0.18);
+  transition: background 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease, transform 0.18s ease;
 }
 
 .glass-card:hover {
   background: rgba(255, 255, 255, 0.05);
   border-color: rgba(14, 165, 233, 0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3), 0 12px 32px rgba(0, 0, 0, 0.28);
+  transform: translateY(-2px);
+}
+
+html.light .glass-card {
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glass-card:hover {
+    transform: none;
+  }
 }
 
 /* Pulse Glow Effects */

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,6 @@
         "@anthropic-ai/sdk": "^0.100.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "stripe": "^22.1.0",
-        "@anthropic-ai/sdk": "^0.98.0",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
         "stripe": "^22.2.0",
         "wouter": "^3.10.0"
       },
@@ -66,9 +62,6 @@
       "version": "0.100.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
       "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
-      "version": "0.98.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
-      "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",


### PR DESCRIPTION
Four progressive batches that move the site from a text-dashboard feel toward "ESPN-grade" sports media. Each batch is independently reviewable; all green locally (**208 tests**, assembly, `vite build`).

## Batch 4 — Logo rollout completion
- **Playoff `SeriesCard`** team marks render real logos inside the team-tinted badge (most visible surface during the Finals).
- **Player** profile + **Injury Report** team chips lead with logos.
- Visual identity is now consistent across every primary surface.

## Batch 3 — Persistent scoreboard strip
ESPN's signature element. Replaced the live-only bar with a top-of-page strip showing today's **entire** slate: scheduled (tip time + national TV), live (logos, score, clock, pulse), finals (winner highlighted). Header flips **LIVE ↔ TODAY**; hidden on off-days. Logos also added to Game Center score blocks + Team page header.

## Batch 2 — Team visual identity
- **`TeamLogo`** primitive: official ESPN logo + automatic self-hosted **colored-crest fallback** (never a broken image).
- **`teamColors.ts`** identity layer: ESPN abbreviation aliasing, case-insensitive lookups, logo slugs, full names.
- Logos across homepage (scorebar, game cards, Pulse Index, standings, previews); card depth (layered shadows + motion-safe hover lift); empty state for a bare slate.

## Batch 1 — Resilience + accessibility
- **`RouteErrorBoundary`**: recoverable shell on lazy-chunk load failure instead of a blank page.
- A11y: ShareButton, PreferencesSetup, BoxScoreCard (menu/dialog/switch roles, focus rings, live regions, contrast fix).

## Tests
New suites: `RouteErrorBoundary`, `TeamLogo`, team-identity helpers. Rebased onto main's latest Dependabot batch; re-verified.

> **Verification note:** ESPN's logo CDN 403s through the build sandbox's proxy, so logos render as crest fallbacks *in CI/local* but load normally in real browsers. Please confirm on the Vercel preview.

---

## Recommended next steps (not in this PR)
1. **Player headshots** — requires mapping ESPN player IDs (the static `pulseData` has names only). Highest remaining visual lever; needs an ID source in the generation pipeline.
2. **Hero rewrite** — lead-story layout with imagery instead of the generic text hero.
3. **Real-time scores** — swap 30s polling for SSE/WebSocket so "LIVE" is truly live.
4. **Logo sweep on secondary tools** — Trade Simulator/Value, Compare, Lineup Intel, Draft.
5. **Tighten content polish** — standings GB/seed tooltips, line-movement explanations.

https://claude.ai/code/session_012FTn5TmQ5FEvXHpLGHSjvu