### PR TITLE
chore(deps): batch all Dependabot npm bumps into one weekly PR (prevent #155 recurrence)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 # Dependabot — keep npm + Actions dependencies current (weekly batches).
+#
+# All npm bumps land in a single weekly PR (the `npm-all` group). This
+# eliminates the merge-cascade race where multiple Dependabot PRs auto-
+# merged in parallel produced duplicate JSON keys in package.json /
+# package-lock.json (see #155 post-mortem). With one grouped PR per
+# week, the lockfile resolves once, linearly.
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -6,17 +12,22 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
-      vite-react:
+      # All npm dependency bumps (prod + dev) land in one weekly PR.
+      # A single PR means one `npm install` resolves the whole lockfile
+      # atomically; no inter-PR collisions on package.json or
+      # package-lock.json.
+      npm-all:
         patterns:
-          - "vite"
-          - "@vitejs/*"
-          - "react*"
-          - "@types/react*"
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Background

Post-mortem on #155: four Dependabot PRs (#141 vite-react group, #142 vitest, #143 @anthropic-ai/sdk, #144 stripe) auto-merged within ~5 minutes of each other. Each PR was based on a different baseline, so the auto-merges concatenated `package.json` and `package-lock.json` entries instead of resolving them — producing duplicate JSON keys and breaking `npm ci` across `main` until #155 cleaned it up (and filed issue #154 along the way).

## Change

Replace the narrow `vite-react` group with a catch-all `npm-all` group, plus an equivalent `actions-all` group for the github-actions ecosystem. Dependabot now opens at most **one npm PR per week** containing every bump, so the lockfile resolves once, linearly — no inter-PR collisions possible.

Also lowered `open-pull-requests-limit: 10 → 5` as a defense-in-depth ceiling.

## Why not also disable auto-merge entirely?

Auto-merge itself is enabled at the **repository level** (Settings → General → Pull Requests), not in any file in the repo. That part is out of scope for a code change. If you want the stronger guarantee, the GitHub UI route is:

- **Settings → General → Pull Requests** → uncheck *Allow auto-merge*; **or**
- **Settings → Branches → main branch protection** → enable *Require branches to be up to date before merging* (this forces each PR to rebase against latest `main` before its merge can land, which fixes the underlying race regardless of group size).

## What this PR does *not* prevent

- **Out-of-cycle Dependabot security PRs.** These can still appear individually between weekly batches. They'll merge cleanly one at a time, but if two security alerts fire near-simultaneously the race could recur. Branch protection (above) is the durable fix.

## Verification

YAML lints clean (34 lines, no tabs). No code changes — this is config-only. Nothing for unit/build CI to fail on, but `dependabot.yml` schema is enforced server-side, so if I got the structure wrong, the next scheduled run will surface that.

https://claude.ai/code/session_01X7q5m7186NSUrHtqtLYEtw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7q5m7186NSUrHtqtLYEtw)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch all npm and GitHub Actions Dependabot updates into single weekly PRs
> Updates [dependabot.yml](.github/dependabot.yml) to prevent excessive concurrent dependency PRs (recurrence of #155).
>
> - Replaces the `vite-react` npm group with an `npm-all` group matching all npm packages via `*`, so all npm updates are batched into one weekly PR
> - Adds an `actions-all` group for the `github-actions` ecosystem with the same `*` pattern
> - Reduces `open-pull-requests-limit` for npm from 10 to 5
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e3ef25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->