### PR TITLE
fix(pipeline): weekly draft truncation + offseason CI (test + typecheck) + auto-close recovered issues

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -148,6 +148,35 @@ jobs:
         if: steps.changes.outputs.changed == 'false'
         run: echo "No game data changes — skipping commit."
 
+      - name: Close resolved daily-failure issues
+        if: success()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'generation-failure',
+              per_page: 100,
+            });
+            for (const issue of open.data.filter((i) => i.title.startsWith('Daily generation failed'))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Daily generation succeeded in ${runUrl}. Auto-closing this stale failure report.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }
+
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@v9

--- a/.github/workflows/midday-refresh.yml
+++ b/.github/workflows/midday-refresh.yml
@@ -91,6 +91,35 @@ jobs:
         if: steps.changes.outputs.changed == 'false'
         run: echo "No data changes — skipping commit."
 
+      - name: Close resolved midday-failure issues
+        if: success()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'generation-failure',
+              per_page: 100,
+            });
+            for (const issue of open.data.filter((i) => i.title.startsWith('Midday refresh failed'))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Midday refresh succeeded in ${runUrl}. Auto-closing this stale failure report.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }
+
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@v9

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -104,6 +104,35 @@ jobs:
         if: steps.changes.outputs.changed == 'false'
         run: echo "No data changes — skipping commit."
 
+      - name: Close resolved weekly-failure issues
+        if: success()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'generation-failure',
+              per_page: 100,
+            });
+            for (const issue of open.data.filter((i) => i.title.startsWith('Weekly generation failed'))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Weekly generation succeeded in ${runUrl}. Auto-closing this stale failure report.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }
+
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@v9

--- a/client/src/__tests__/lineMovement.test.ts
+++ b/client/src/__tests__/lineMovement.test.ts
@@ -5,12 +5,17 @@ import { lineMovementRows } from "../lib/lineMovementData";
 describe("lineMovement", () => {
   it("finds movement row for matchup regardless of home/away order", () => {
     const seed = lineMovementRows[0];
-    expect(seed).toBeDefined();
-    const row = lineMovementForMatchup(seed!.awayTeam, seed!.homeTeam);
-    expect(row?.openingSpread).toBe(seed!.openingSpread);
-    expect(row?.closingSpread).toBe(seed!.closingSpread);
-    const reversed = lineMovementForMatchup(seed!.homeTeam, seed!.awayTeam);
-    expect(reversed?.openingSpread).toBe(seed!.openingSpread);
+    if (!seed) {
+      // Offseason / no games: sync-line-movement.mjs emits an empty rows array.
+      // The lookup contract still holds — any matchup resolves to undefined.
+      expect(lineMovementForMatchup("LAL", "BOS")).toBeUndefined();
+      return;
+    }
+    const row = lineMovementForMatchup(seed.awayTeam, seed.homeTeam);
+    expect(row?.openingSpread).toBe(seed.openingSpread);
+    expect(row?.closingSpread).toBe(seed.closingSpread);
+    const reversed = lineMovementForMatchup(seed.homeTeam, seed.awayTeam);
+    expect(reversed?.openingSpread).toBe(seed.openingSpread);
   });
 
   it("spreadMoved detects opener vs closer drift", () => {

--- a/client/src/lib/teamIntel.ts
+++ b/client/src/lib/teamIntel.ts
@@ -18,7 +18,7 @@ export interface TeamIntelResponse {
   fullName: string;
   standing?: (typeof eastStandings)[0];
   recentGames: GameTeamMatchup[];
-  previews: typeof gamePreviews;
+  previews: GameTeamMatchup[];
   injuries: typeof injuryUpdates;
   pulsePlayers: typeof pulseIndex;
   editions: typeof archiveEditions;
@@ -48,7 +48,7 @@ export function getTeamIntelByAbbr(rawAbbr: string): TeamIntelResponse | null {
     fullName,
     standing,
     recentGames: (gameResults as GameTeamMatchup[]).filter((g) => g.homeTeam === abbr || g.awayTeam === abbr),
-    previews: gamePreviews.filter((g) => g.homeTeam === abbr || g.awayTeam === abbr),
+    previews: (gamePreviews as GameTeamMatchup[]).filter((g) => g.homeTeam === abbr || g.awayTeam === abbr),
     injuries: injuryUpdates.filter((inj) => inj.team === abbr),
     pulsePlayers: pulseIndex.filter((p) => p.team === abbr),
     editions: archiveEditions.filter((ed: any) => (ed.teams || []).includes(abbr)),

--- a/scripts/generate-draft.mjs
+++ b/scripts/generate-draft.mjs
@@ -155,7 +155,7 @@ async function main() {
   try {
     const message = await client.messages.create({
       model: "claude-sonnet-4-6",
-      max_tokens: 12288,
+      max_tokens: 16384,
       messages: [{ role: "user", content: prompt }],
     });
 


### PR DESCRIPTION
## Four pipeline/CI fixes surfaced while auditing the failure issues

### 1. Draft Intel truncation — root cause of every Monday weekly failure

`Weekly Data Update` has failed **every Monday since June 15** (#185, #197, #214; last success June 8). Always the same section:

```
[x] Draft Intel — 216.0s (invalid output (truncated: unexpected file ending (lotteryOdds: "1.)))
  Passed: 7/8   Failed: 1/8
Partial failure — refusing to commit
```

`generate-draft.mjs` capped Claude output at `max_tokens: 12288`; the committed `draftData.ts` is ~39 KB (~12K tokens). It's draft/free-agency season, so the model reliably overruns the cap and truncates mid-string. `generate-all-weekly.mjs` treats any section failure as partial (exit 2) and the weekly workflow **refuses to commit on partial**, so this one section has blocked the entire weekly edition. **Fix:** raise `max_tokens` to `16384` (same budget as history / community-pulse, bumped for the identical class in #151).

### 2. Failure issues never auto-close (the manual-sweep treadmill)

`daily-update`, `weekly-update`, `midday-refresh` open a `generation-failure` issue on failure but never close it on recovery — 14+ piled up across June. Add an `if: success()` step to each that closes *its own* open failure issues, scoped by title prefix (`Daily generation failed` / `Weekly generation failed` / `Midday refresh failed`) so a daily success never closes a genuine weekly-failure issue. Each close leaves an audit comment linking the successful run.

### 3. `lineMovement` test red on `main` (offseason data)

`main`'s MUST-pass "Unit tests + build" gate was **already red**: `lineMovement.test.ts` hard-asserted `lineMovementRows[0]` is defined, but `sync-line-movement.mjs` emits an empty array in the offseason. Guarded the data-dependent branch to assert the empty-state lookup contract when there are no rows.

### 4. `typecheck:api` red on `main` (offseason data) — revealed after fixing #3

With vitest fixed, the next step in the same job surfaced its own offseason failure:
```
client/src/lib/teamIntel.ts(51): error TS2339: Property 'homeTeam' does not exist on type 'never'.
```
Generated `pulseData.ts` exports `export const gamePreviews = [];` (no annotation → `never[]` when empty), and `teamIntel.previews` filtered it without the `as GameTeamMatchup[]` cast that the sibling `gameResults` line already uses. Applied the same cast and typed the response field explicitly.

## Verification

Ran the **entire** "Unit tests + build" step sequence locally — all 16 steps green: `vitest` 208/208, `typecheck:api`, drift guard, seriesIntel keys, line-sync, verify-generators, season alignment, archive-dups, schema, route manifest, generated structure, content hard-only, deploy config, embed, plus both `node:test` suites. CI on `5488f3a`: **Unit tests + build ✓, Pipeline assembly ✓, Macroscope ✓, Vercel ✓ (×3)**. Only "Content validation (advisory)" fails — that job is `continue-on-error: true` (offseason team-abbrev/injury drift from the daily AI generator; self-corrects on regeneration, per CLAUDE.md).

## Effect after merge

- **`main` CI goes green again** (fixes #3 + #4 — it's been red).
- Next Monday's weekly run completes all 8 sections and commits (#1).
- Recovered failure issues auto-close on the next successful run (#2). I've hand-closed the 7 stale **daily**-failure issues (#199/#201/#203/#205/#207/#209/#213); the weekly ones (#185/#197/#214) auto-close after the next successful Monday run.

## Not addressed here

- `site-review` issues (#183–#219) still accumulate daily — informational all-200 route diffs, not failures. Follow-up could make that workflow close its prior report when filing a new one.

https://claude.ai/code/session_01X7q5m7186NSUrHtqtLYEtw

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix weekly draft truncation and auto-close recovered generation-failure issues
> - Increases `max_tokens` from 12288 to 16384 in [generate-draft.mjs](https://github.com/hondoentertainment/hoops-intel/pull/220/files#diff-e029246f7e306df60fcf0f8818b5bcdfd61daad7bf6cf7af7d159fd1545b48ff) to prevent weekly draft responses from being truncated.
> - Adds a post-success step to each of the three CI workflows ([daily-update.yml](https://github.com/hondoentertainment/hoops-intel/pull/220/files#diff-e655172173b6634d8bcbd7e86cef19ab4ee66938261951eccf691700e4d232d7), [midday-refresh.yml](https://github.com/hondoentertainment/hoops-intel/pull/220/files#diff-3fd73abb4796f439fae7ada6c370005680f729e7db50ea25f36a06503a5c4f05), [weekly-update.yml](https://github.com/hondoentertainment/hoops-intel/pull/220/files#diff-6af92b47160954f5624a62ed99f87a002e7b6a5c12a73df6b22092d3a2888408)) that finds open `generation-failure` issues matching the workflow name, comments with the successful run URL, and closes them.
> - Fixes the `lineMovement` test to handle offseason periods where no line movement rows exist, asserting `undefined` lookups instead of dereferencing absent data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5488f3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->