### PR TITLE
Fix Daily Edition seasonal drift failures

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -45,6 +45,7 @@ jobs:
     if: needs.check-season.outputs.active == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       issues: write
 
@@ -188,6 +189,20 @@ jobs:
           script: |
             const today = new Date().toISOString().slice(0, 10);
             const title = `Daily generation failed — ${today}`;
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const failedSteps = jobs.flatMap((job) =>
+              (job.steps || [])
+                .filter((step) => step.conclusion === 'failure')
+                .map((step) => `- \`${job.name}\` → \`${step.name}\``),
+            );
+            const failureSummary = failedSteps.length
+              ? failedSteps.join('\n')
+              : '- Failed step unavailable; inspect the linked run logs.';
             // Check if issue already exists for today
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -202,7 +217,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,
-                body: `## Daily Generation Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nCheck the workflow logs for details. Common causes:\n- ESPN API outage\n- Anthropic API key expired or rate limited\n- Schema validation failure\n\nThis issue was auto-created by the daily-update workflow.`,
+                body: `## Daily Generation Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n### Failed step\n${failureSummary}\n\nThe generator, external APIs, and pre-push validation are separate steps. Use the failed step above to identify the failing stage before rotating credentials or retrying external services.\n\nThis issue was auto-created by the daily-update workflow.`,
                 labels: ['generation-failure', 'automated'],
               });
             }

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci --no-audit --no-fund

--- a/client/src/__tests__/finalsDesk.test.ts
+++ b/client/src/__tests__/finalsDesk.test.ts
@@ -13,9 +13,8 @@ describe("Finals Command Mode readiness", () => {
     expect(phrase).toMatch(/series|Finals|round|conference/i);
   });
 
-  it("editionContext is playoffs or finals during postseason", () => {
-    if (playoffSeries.length === 0) return;
-    expect(["playoffs", "finals"]).toContain(pulseEdition.editionContext);
+  it("editionContext uses a supported publishing mode", () => {
+    expect(["regular", "playoffs", "finals"]).toContain(pulseEdition.editionContext);
   });
 
   it("isFinalsActive is boolean", () => {

--- a/client/src/lib/pulseData.ts
+++ b/client/src/lib/pulseData.ts
@@ -6,7 +6,7 @@
 // EDITION METADATA
 // ═══════════════════════════════════════════════════════════
 
-export const pulseEdition = {date:"July 4, 2026",edition:"Vol. 2026 · No. 175",subtitle:"Wemby Supermax Watch · Fox Offer Sheet Clock Ticking · Independence Day, No Games",editionContext:"finals"};
+export const pulseEdition = {date:"July 4, 2026",edition:"Vol. 2026 · No. 175",subtitle:"Wemby Supermax Watch · Fox Offer Sheet Clock Ticking · Independence Day, No Games",editionContext:"regular"};
 
 // ═══════════════════════════════════════════════════════════
 // NARRATIVE OF THE DAY

--- a/scripts/tests/validate-content.mjs
+++ b/scripts/tests/validate-content.mjs
@@ -456,6 +456,8 @@ function main() {
     test("advisory", "game previews include exactly one featured game", () => {
       const previews = exports.gamePreviews;
       assert(Array.isArray(previews), "gamePreviews should be an array");
+      // Off-days and offseason editions legitimately have no game previews.
+      if (previews.length === 0) return;
       const featured = previews.filter((p) => p.featured === true);
       assertEqual(featured.length, 1, "Number of featured games");
     });

--- a/scripts/validate-playoff-pulse-drift.mjs
+++ b/scripts/validate-playoff-pulse-drift.mjs
@@ -7,6 +7,7 @@
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { seasonMode } from "./lib/season-mode.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,6 +18,11 @@ const pulsePath = join(ROOT, "client/src/lib/pulseData.ts");
 
 function pulseEditionContext(raw) {
   const m = raw.match(/editionContext\s*:\s*"([^"]+)"/);
+  return m?.[1] ?? null;
+}
+
+function pulseEditionDate(raw) {
+  const m = raw.match(/export const pulseEdition\s*=\s*\{[^;]*\bdate\s*:\s*"([^"]+)"/s);
   return m?.[1] ?? null;
 }
 
@@ -53,6 +59,23 @@ try {
     process.exit(1);
   }
 
+  const editionDate = pulseEditionDate(pulseRaw);
+  const parsedEditionDate = editionDate ? new Date(`${editionDate} 00:00:00 UTC`) : null;
+  if (!parsedEditionDate || Number.isNaN(parsedEditionDate.getTime())) {
+    console.error("[drift] pulseEdition.date missing or invalid in pulseData.ts");
+    process.exit(1);
+  }
+
+  const calendarMode = seasonMode(parsedEditionDate);
+  const expectedContext =
+    calendarMode === "finals" ? "finals" : calendarMode === "playoffs" ? "playoffs" : "regular";
+  if (ctx !== expectedContext) {
+    console.error(
+      `[drift] pulseData.ts has editionContext "${ctx}" for ${editionDate} (${calendarMode}); expected "${expectedContext}".`,
+    );
+    process.exit(1);
+  }
+
   const inner = playoffSyncInner(playbookRaw);
   const boardOn = playbookBoardHasRows(inner);
   const hasRealSeries = boardOn ? hasNonTbdSeries(inner) : false;
@@ -60,11 +83,9 @@ try {
   const expectPlayoffEdition = ctx === "playoffs" || ctx === "finals";
 
   if (boardOn && hasRealSeries && ctx === "regular") {
-    console.error(
-      `[drift] pulseData.ts has editionContext "regular" but playoffData.ts has active matchups.`,
+    console.warn(
+      `[drift advisory] Archived playoffData.ts matchups remain during ${calendarMode}; edition context is correctly "${ctx}".`,
     );
-    console.error('      Set pulseEdition.editionContext to "playoffs" or "finals" during the postseason.');
-    process.exit(1);
   }
 
   if (expectPlayoffEdition && boardOn && !hasRealSeries) {
@@ -80,7 +101,7 @@ try {
   }
 
   console.log(
-    `[drift] OK — editionContext=${ctx}, playoff board nonempty=${boardOn}, real matchups=${hasRealSeries}`,
+    `[drift] OK — date=${editionDate}, mode=${calendarMode}, editionContext=${ctx}, playoff board nonempty=${boardOn}, real matchups=${hasRealSeries}`,
   );
 } catch (e) {
   console.error("[drift]", e.message || e);


### PR DESCRIPTION
## Summary
- validate edition context against the edition date and season mode, treating archived playoff matchups as advisory outside postseason
- align E2E smoke with the repository's supported Node 24 runtime
- include exact failed job steps in automated generation-failure issues

Root cause: Daily generation, ESPN fetches, and Anthropic generation all succeeded. The pre-push drift validator incorrectly treated archived playoff matchups as active during Summer League.

Fixes #257

## Test plan
- [x] `npm run test:pre-push`
- [x] `node --test scripts/tests/season-mode.test.mjs`
- [x] `npm run test:e2e`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Daily Edition seasonal drift by validating `editionContext` against calendar-derived season mode
> - [`validate-playoff-pulse-drift.mjs`](https://github.com/hondoentertainment/hoops-intel/pull/259/files#diff-b94b55d8adcd74eaa72022828bf2143f9a3dce0fcc9d2a942b9f47baec073537) now computes the expected season mode from `pulseEdition.date` and exits with an error if `editionContext` does not match; previously mismatched contexts went undetected.
> - [`pulseData.ts`](https://github.com/hondoentertainment/hoops-intel/pull/259/files#diff-7673238a4750413989b6fcc0aa9414bf40680dee5972af2b04e5de65f166a014) sets `editionContext` to `'regular'` to reflect the current off-season calendar state.
> - The validation script now warns (rather than errors) when archived playoff matchups exist during a regular-mode edition.
> - [`validate-content.mjs`](https://github.com/hondoentertainment/hoops-intel/pull/259/files#diff-8656cc8aa030d4276fd8b68381cb006a2d06d93a3bd95f370fa6328bb89895c9) skips the "exactly one featured game" check on off-days and offseason editions with no game previews.
> - The `generate-edition` CI job gains `actions: read` permission so failure issues can include a per-run summary of failed steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b99cae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->