### PR TITLE
fix: publish season-correct editions in every calendar window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,9 @@ reads it).
   corrected during the next regeneration. CI treats this job as
   advisory.
 - `daily-update.yml` gates execution with `scripts/check-generator-active.mjs`
-  (`generatorActive()` from `season-mode.mjs`), so postseason / draft /
-  preseason windows run while only the **`dead-period`** slice is suppressed.
+  (`generatorActive()` from `season-mode.mjs`). Every window now generates,
+  including `dead-period` — which previously froze the dashboard from
+  July 23 through August 31.
 - `public/` at the repo root is wired into `vite.config.ts` via
   `publicDir`. Files there ship verbatim to `dist/`. Do not create
   `client/public/`.

--- a/client/src/__tests__/deskMode.test.ts
+++ b/client/src/__tests__/deskMode.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  activeEditionContext,
+  clientSeasonMode,
+  editionContextDeskLabel,
+  isOffseasonDesk,
+  seasonModeToEditionContext,
+  type ClientSeasonMode,
+} from "../lib/deskMode";
+
+const OFFSEASON_MODES: ClientSeasonMode[] = [
+  "draft",
+  "free-agency",
+  "summer-league",
+  "preseason",
+  "dead-period",
+];
+
+describe("deskMode season windows", () => {
+  it("maps late July and August to the dead period", () => {
+    expect(clientSeasonMode(new Date(Date.UTC(2026, 6, 25)))).toBe("dead-period");
+    expect(clientSeasonMode(new Date(Date.UTC(2026, 7, 10)))).toBe("dead-period");
+  });
+
+  it("keeps every offseason window out of the regular-season desk", () => {
+    for (const mode of OFFSEASON_MODES) {
+      const ctx = seasonModeToEditionContext(mode);
+      expect(ctx).toBe(mode);
+      expect(editionContextDeskLabel(ctx)).not.toBe("Regular season desk");
+    }
+  });
+
+  it("labels the dead period as the offseason desk", () => {
+    expect(editionContextDeskLabel("dead-period")).toBe("Offseason desk");
+  });
+
+  it("still collapses the regular season to the regular desk", () => {
+    expect(seasonModeToEditionContext("regular-season")).toBe("regular");
+    expect(editionContextDeskLabel("regular")).toBe("Regular season desk");
+  });
+});
+
+describe("committed edition context", () => {
+  it("is a recognised context, so desk labelling never silently falls back", () => {
+    const ctx = activeEditionContext();
+    expect([
+      "regular",
+      "playoffs",
+      "finals",
+      "draft",
+      "free-agency",
+      "summer-league",
+      "preseason",
+      "dead-period",
+    ]).toContain(ctx);
+  });
+
+  it("exposes offseason state as a boolean", () => {
+    expect(typeof isOffseasonDesk()).toBe("boolean");
+  });
+});

--- a/client/src/__tests__/finalsDesk.test.ts
+++ b/client/src/__tests__/finalsDesk.test.ts
@@ -14,7 +14,16 @@ describe("Finals Command Mode readiness", () => {
   });
 
   it("editionContext uses a supported publishing mode", () => {
-    expect(["regular", "playoffs", "finals"]).toContain(pulseEdition.editionContext);
+    expect([
+      "regular",
+      "playoffs",
+      "finals",
+      "draft",
+      "free-agency",
+      "summer-league",
+      "preseason",
+      "dead-period",
+    ]).toContain(pulseEdition.editionContext);
   });
 
   it("isFinalsActive is boolean", () => {

--- a/client/src/components/OffseasonDeskStrip.tsx
+++ b/client/src/components/OffseasonDeskStrip.tsx
@@ -33,7 +33,9 @@ export default function OffseasonDeskStrip() {
                   ? "Cap sheet & rotation fit"
                   : ctx === "summer-league"
                     ? "Rookie auditions & two-way standouts"
-                    : "Minutes caps & scheme teases"}
+                    : ctx === "dead-period"
+                      ? "Roster construction & season-ahead outlook"
+                      : "Minutes caps & scheme teases"}
             </h2>
           </div>
           <a
@@ -70,7 +72,9 @@ export default function OffseasonDeskStrip() {
             <p className="text-sm leading-relaxed text-white/70">
               {ctx === "free-agency"
                 ? "Track signings, cap tiers, and rotation fit on Trade Value — the morning desk pivots to market moves when the slate thins."
-                : "Preseason desk prioritizes rotation battles and injury cautions. Use Lineups for projected minutes and scheme teases."}
+                : ctx === "dead-period"
+                  ? "No games on the calendar. The desk runs roster-construction retrospectives, extension math, and season-ahead projections until camps open."
+                  : "Preseason desk prioritizes rotation battles and injury cautions. Use Lineups for projected minutes and scheme teases."}
             </p>
             <div className="flex flex-wrap gap-3 mt-4">
               <a href="/trade-value" className="text-xs text-sky-400 hover:text-sky-300 underline-offset-2 hover:underline">

--- a/client/src/lib/deskMode.ts
+++ b/client/src/lib/deskMode.ts
@@ -18,7 +18,8 @@ export type EditionContext =
   | "draft"
   | "free-agency"
   | "summer-league"
-  | "preseason";
+  | "preseason"
+  | "dead-period";
 
 const EDITION_CONTEXTS = new Set<string>([
   "regular",
@@ -28,6 +29,7 @@ const EDITION_CONTEXTS = new Set<string>([
   "free-agency",
   "summer-league",
   "preseason",
+  "dead-period",
 ]);
 
 const OFFSEASON_CONTEXTS = new Set<EditionContext>([
@@ -35,6 +37,7 @@ const OFFSEASON_CONTEXTS = new Set<EditionContext>([
   "free-agency",
   "summer-league",
   "preseason",
+  "dead-period",
 ]);
 
 /** UTC calendar mode — keep in sync with scripts/lib/season-mode.mjs */
@@ -70,6 +73,8 @@ export function seasonModeToEditionContext(mode: ClientSeasonMode): EditionConte
       return "summer-league";
     case "preseason":
       return "preseason";
+    case "dead-period":
+      return "dead-period";
     default:
       return "regular";
   }
@@ -100,6 +105,8 @@ export function offseasonPrimaryHref(date = new Date()): string {
       return "/draft";
     case "preseason":
       return "/lineups";
+    case "dead-period":
+      return "/projections";
     default:
       return "/tools";
   }
@@ -115,6 +122,8 @@ export function offseasonPrimaryCta(date = new Date()): { label: string; href: s
       return { label: "Summer League watch", href: "/draft", emoji: "☀️" };
     case "preseason":
       return { label: "Rotation battles", href: "/lineups", emoji: "🏀" };
+    case "dead-period":
+      return { label: "Season projections", href: "/projections", emoji: "📈" };
     default:
       return { label: "All tools", href: "/tools", emoji: "🛠️" };
   }
@@ -134,6 +143,8 @@ export function editionContextDeskLabel(ctx: EditionContext = activeEditionConte
       return "Summer League desk";
     case "preseason":
       return "Preseason desk";
+    case "dead-period":
+      return "Offseason desk";
     default:
       return "Regular season desk";
   }

--- a/client/src/lib/pulseData.ts
+++ b/client/src/lib/pulseData.ts
@@ -6,7 +6,7 @@
 // EDITION METADATA
 // ═══════════════════════════════════════════════════════════
 
-export const pulseEdition = {date:"July 22, 2026",edition:"Vol. 2026 · No. 178",subtitle:"Fox Standoff Enters Critical Phase · OKC Playmaker Hunt Accelerates · Summer League Roster Decisions Crystallizing",editionContext:"regular"};
+export const pulseEdition = {date:"July 22, 2026",edition:"Vol. 2026 · No. 178",subtitle:"Fox Standoff Enters Critical Phase · OKC Playmaker Hunt Accelerates · Summer League Roster Decisions Crystallizing",editionContext:"summer-league"};
 
 // ═══════════════════════════════════════════════════════════
 // NARRATIVE OF THE DAY

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,1591 +2,1591 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hoopsintel.net/</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/archive</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/pulse-history</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/playoffs</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/tools</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/injuries</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/pick-em</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/trade-value</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/trivia</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/performance</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/momentum</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/lineups</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/trade-simulator</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/clutch</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/draft</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/sentiment</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/tactics</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/projections</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/badges</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/community-pulse</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/watch-guide</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/podcast-companion</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/history</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/refs</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/ask</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/compare-players</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/pulse-methodology</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.55</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/rivals</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/my-pulse</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/print-edition</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/widgets</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/widgets/analytics</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.55</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/embed-stats</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.55</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/pro</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/betting-intel</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/guest-pulse</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.55</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/victor-wembanyama</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-brunson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/joel-embiid</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/chris-paul</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tyrese-maxey</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/anthony-edwards</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/josh-hart</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/og-anunoby</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/devin-vassell</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jaden-mcdaniels</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/julius-randle</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/karl-anthony-towns</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/isaiah-hartenstein</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/vj-edgecombe</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/amen-thompson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/keyonte-george</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jaime-jaquez-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/dereck-lively-ii</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/shai-gilgeous-alexander</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/lebron-james</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cade-cunningham</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/donovan-mitchell</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/anthony-davis</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/michael-jordan</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/alperen-sengun</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/paolo-banchero</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/pascal-siakam</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-green</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/isaiah-stewart</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/scottie-barnes</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jaylen-brown</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/christian-wood</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/trae-young</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/al-horford</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/robert-williams</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jamal-murray</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/chet-holmgren</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/anthony-black</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/hakeem-olajuwon</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jayson-tatum</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/damian-lillard</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/fred-vanvleet</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/devin-booker</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/nikola-jokic</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/brandon-miller</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/scoot-henderson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kawhi-leonard</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/zion-williamson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tyler-herro</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/brandon-ingram</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/draymond-green</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/anfernee-simons</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jusuf-nurkic</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/luka-doncic</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kobe-bryant</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/franz-wagner</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/josh-giddey</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/derrick-white</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/markelle-fultz</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/keldon-johnson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/stephen-curry</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/lamelo-ball</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/desmond-bane</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/miles-bridges</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kon-knueppel</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kristaps-porzingis</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/gui-santos</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/brandin-podziemski</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/mark-williams</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/deni-avdija</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/larry-bird</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kelly-oubre-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/paul-george</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/bennedict-mathurin</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/darius-garland</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/andre-drummond</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tyler-kolek</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/carlton-carrington</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/donovan-clingan</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tim-duncan</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/david-robinson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kevin-garnett</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/bam-adebayo</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jrue-holiday</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cooper-flagg</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/dylan-harper</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cedric-coward</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jonas-valanciunas</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cj-mccollum</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/lauri-markkanen</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jordan-clarkson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kevin-durant</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cam-thomas</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/nicolas-claxton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/mikal-bridges</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/giannis-antetokounmpo</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/o-g-anunoby</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jimmy-butler</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/stephon-castle</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-johnson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tyrese-haliburton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-duren</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/michael-porter-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-williams</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/evan-mobley</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jarrett-allen</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/nickeil-alexander-walker</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/matas-buzelis</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cason-wallace</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/norman-powell</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jakob-poeltl</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/gradey-dick</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jabari-smith-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/maxime-raynaud</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/demar-derozan</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/de-aaron-fox</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/harrison-barnes</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tobias-harris</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ronald-holland-ii</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/paul-reed</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/donte-divincenzo</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/coby-white</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jock-landale</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/collin-sexton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jahmai-mashack</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kyle-filipowski</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/brice-sensabaugh</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/grayson-allen</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/max-strus</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/james-harden</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cody-williams</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/aaron-nesmith</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/obi-toppin</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/austin-reaves</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/payton-pritchard</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/olivier-maxence-prosper</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/marvin-bagley-iii</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kevin-huerter</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/daniss-jenkins</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/tristan-da-silva</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/bones-hyland</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/bradley-beal</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/marcus-sasser</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-suggs</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kevin-porter-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/nic-claxton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cameron-johnson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ajay-mitchell</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/day-ron-sharpe</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/christian-braun</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/naji-marshall</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/bub-carrington</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/trendon-watford</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/mason-raynaud</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/onyeka-okongwu</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/wendell-carter-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/brook-lopez</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/bobby-portis</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/justin-edwards</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/rj-barrett</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ja-morant</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/p-j-washington</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ryan-rollins</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/precious-achiuwa</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/quentin-grimes</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/aaron-gordon</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/neemias-queta</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/russell-westbrook</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/rudy-gobert</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/mitchell-robinson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jarace-walker</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/javon-small</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/dejounte-murray</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/johan-larsson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jeff-green</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/khris-middleton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/naz-reid</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/trey-murphy-iii</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/immanuel-quickley</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/simone-fontecchio</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/alex-sarr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ron-harper-jr</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/deandre-ayton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/cam-payne</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/kyle-kuzma</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jaylin-williams</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/keon-ellis</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/blake-hinson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ochai-agbaji</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/nolan-traore</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/rayan-rupert</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/isaiah-joe</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/ziaire-williams</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/klay-thompson</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/julian-champagnie</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/de-anthony-melton</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jabari-walker</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/hugo-gonzalez-pena</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/luguentz-dort</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/sas</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/min</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/nyk</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/phi</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/okc</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/lal</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/det</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/cle</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/hou</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/mia</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/dal</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/bos</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/tor</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/atl</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/orl</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/cha</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/den</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/phx</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/por</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/lac</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/gsw</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/chi</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/uta</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/nop</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/was</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/mem</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/ind</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/brk</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/sac</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/team/mil</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/references/data-schema.md
+++ b/references/data-schema.md
@@ -11,7 +11,18 @@ export interface PulseEdition {
   date: string;      // Display date: "March 3, 2026"
   edition: string;   // "Vol. 2026 · No. 62"
   subtitle: string;  // 2–3 story bullets joined by " · "
-  editionContext: "regular" | "playoffs" | "finals"; // set from calendar + ESPN snapshot
+  // Set from the season calendar + ESPN snapshot via editionContextForMode()
+  // in scripts/lib/season-mode.mjs. Drives desk labelling on the site, so
+  // offseason windows must NOT be collapsed to "regular".
+  editionContext:
+    | "regular"
+    | "playoffs"
+    | "finals"
+    | "draft"
+    | "free-agency"
+    | "summer-league"
+    | "preseason"
+    | "dead-period";
 }
 ```
 

--- a/references/playoff-metrics-process.md
+++ b/references/playoff-metrics-process.md
@@ -23,7 +23,7 @@ Computed at runtime from **`playoffSeries`**:
 
 ## 3. Other postseason surfaces
 
-- **Pulse**: `pulseEdition.editionContext` (`regular` | `playoffs` | `finals`) must agree with nonempty **`playoffSeries`** when postseason is underway — enforced by **`npm run test:drift`** (`validate-playoff-pulse-drift.mjs`). CI runs it in `.github/workflows/tests.yml`.
+- **Pulse**: `pulseEdition.editionContext` (season-derived — see `editionContextForMode()` in `scripts/lib/season-mode.mjs`) must agree with nonempty **`playoffSeries`** when postseason is underway — enforced by **`npm run test:drift`** (`validate-playoff-pulse-drift.mjs`). CI runs it in `.github/workflows/tests.yml`.
 - **Ticker**: **`playoffTickerDerivedItems`** — built from synced series + **`nextPendingGame`**.
 - **Pushes**: [`.github/workflows/playoff-push.yml`](../.github/workflows/playoff-push.yml) runs **`fetch-playoff-series.mjs`** + **`check-playoff-series.mjs`** every ~30 minutes; uses JSON snapshot only (**does not** commit **`playoffData.ts`**).
 

--- a/scripts/generate-edition.mjs
+++ b/scripts/generate-edition.mjs
@@ -8,7 +8,8 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { toESPNDate, toISODate, toDisplayDate } from "./lib/daily-dates.mjs";
-import { seasonMode } from "./lib/season-mode.mjs";
+import { seasonMode, editionContextForMode } from "./lib/season-mode.mjs";
+import { VALID_EDITION_CONTEXTS } from "./lib/content-quality-constants.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -184,12 +185,14 @@ async function main() {
   const cal = seasonMode(pubDate);
   const calendarPlayoff = cal === "playoffs" || cal === "finals";
   const isPlayoffMode = calendarPlayoff || snapPlayoffs || playoffIndicators.length > 0;
+  // Snapshot-detected postseason still wins over the calendar (schedule shifts),
+  // otherwise the season window drives the context.
   const editionContext =
     cal === "finals" || snapshotFinalsOnly
       ? "finals"
       : isPlayoffMode
         ? "playoffs"
-        : "regular";
+        : editionContextForMode(cal);
   if (isPlayoffMode) console.log("🏆 Playoff/finals mode — Pulse Index scopes to postseason context.");
   const playoffInstructions = isPlayoffMode
     ? `
@@ -226,7 +229,18 @@ async function main() {
 ## PRESEASON WINDOW (season-mode)
 - Rotation battles, minutes caps, injury cautions, and scheme teases — lighter analytical certainty than Opening Week
 `
-          : "";
+          : cal === "dead-period"
+            ? `
+
+## DEAD PERIOD WINDOW (season-mode)
+- No games and few transactions — do NOT invent scores, standings movement, or breaking rumors
+- Lead with roster-construction retrospectives, extension-eligibility math, schedule-release angles, and season-ahead projections
+- Pulse Index ranks by offseason stock (contract status, role change, development arc), never by recent box scores
+- Tonight's Games: state plainly that there is no NBA slate; point to evergreen desks instead of manufacturing a preview
+- gameResults MUST be an empty array
+- Credibility in this window comes from analysis, not news — label all speculation clearly
+`
+            : "";
 
   // ── Generate pulseData.ts ────────────────────────────────
   console.log("🤖 Calling Claude API to generate edition...");
@@ -237,7 +251,7 @@ async function main() {
 - Publication date: ${editionDate}
 - Edition: Vol. 2026 · No. ${editionNo}
 - Content covers games played YESTERDAY (${yesterdayESPN})
-- **pulseEdition.editionContext** MUST be exactly: "${editionContext}" (one of "regular" | "playoffs" | "finals"). Use "finals" only during the NBA Finals; "playoffs" for all other postseason including play-in and early rounds.
+- **pulseEdition.editionContext** MUST be exactly: "${editionContext}" (one of "regular" | "playoffs" | "finals" | "draft" | "free-agency" | "summer-league" | "preseason" | "dead-period"). Copy the value verbatim — it is derived from the season calendar and drives the site's desk labelling.
 
 ## Yesterday's Game Results (${yesterdayESPN}) — ESPN API
 ${JSON.stringify(finalGames, null, 2)}
@@ -324,7 +338,7 @@ Output ONLY the complete TypeScript file. Start with the comment header. No mark
   let contentToWrite = newPulseContent;
   try {
     const ctx = scope.pulseEdition?.editionContext;
-    if (!ctx || !["regular", "playoffs", "finals"].includes(ctx)) {
+    if (!ctx || !VALID_EDITION_CONTEXTS.has(ctx)) {
       console.warn(`⚠ pulseEdition.editionContext missing or invalid (${JSON.stringify(ctx)}) — injecting "${editionContext}"`);
       const patched = contentToWrite.replace(
         /export const pulseEdition = (\{[^}]+\});/,
@@ -340,7 +354,7 @@ Output ONLY the complete TypeScript file. Start with the comment header. No mark
       contentToWrite = patched;
       scope.pulseEdition = extractExportLiteral(contentToWrite, "pulseEdition", {});
       const ctx2 = scope.pulseEdition?.editionContext;
-      if (!ctx2 || !["regular", "playoffs", "finals"].includes(ctx2)) {
+      if (!ctx2 || !VALID_EDITION_CONTEXTS.has(ctx2)) {
         console.error("❌ editionContext still invalid after inject");
         process.exit(1);
       }

--- a/scripts/lib/content-quality-constants.mjs
+++ b/scripts/lib/content-quality-constants.mjs
@@ -26,7 +26,16 @@ export function isEspnSyncedTeamAbbrev(abbr) {
   return TEAM_ABBR_SET.has(canonicalNbaAbbrev(abbr));
 }
 
-export const VALID_EDITION_CONTEXTS = new Set(["regular", "playoffs", "finals"]);
+export const VALID_EDITION_CONTEXTS = new Set([
+  "regular",
+  "playoffs",
+  "finals",
+  "draft",
+  "free-agency",
+  "summer-league",
+  "preseason",
+  "dead-period",
+]);
 
 export const VALID_FANTASY_ACTIONS = new Set(["add", "drop", "hold", "stream"]);
 

--- a/scripts/lib/season-mode.mjs
+++ b/scripts/lib/season-mode.mjs
@@ -47,13 +47,53 @@ export function seasonMode(date = new Date()) {
 }
 
 /**
+ * @typedef {"regular" | "playoffs" | "finals" | "draft" | "free-agency" | "summer-league" | "preseason" | "dead-period"} EditionContext
+ */
+
+/**
+ * Edition context written to pulseEdition.editionContext.
+ *
+ * Single source of truth for the calendar → context mapping. The client
+ * (client/src/lib/deskMode.ts) keys its desk labels, CTAs, and the
+ * OffseasonDeskStrip off this value, so collapsing offseason windows to
+ * "regular" here silently disables that entire surface.
+ * @param {SeasonMode} mode
+ * @returns {EditionContext}
+ */
+export function editionContextForMode(mode) {
+  return mode === "regular-season" ? "regular" : mode;
+}
+
+/** Mirrors editionContextDeskLabel in client/src/lib/deskMode.ts. */
+const DESK_LABELS = Object.freeze({
+  finals: "NBA Finals desk",
+  playoffs: "Playoffs desk",
+  draft: "Draft desk",
+  "free-agency": "Free agency desk",
+  "summer-league": "Summer League desk",
+  preseason: "Preseason desk",
+  "dead-period": "Offseason desk",
+});
+
+/**
+ * @param {EditionContext} ctx
+ * @returns {string}
+ */
+export function deskLabelForContext(ctx) {
+  return DESK_LABELS[ctx] ?? "Regular season desk";
+}
+
+/**
  * Can daily edition generation run meaningful content today?
- * The dead-period (late July through August) is the only true gap.
+ *
+ * Every window now has a season-appropriate prompt branch in
+ * generate-edition.mjs, including dead-period — which otherwise froze the
+ * dashboard from July 23 through August 31.
  * @param {Date} [date]
  * @returns {boolean}
  */
-export function generatorActive(date = new Date()) {
-  return seasonMode(date) !== "dead-period";
+export function generatorActive(_date = new Date()) {
+  return true;
 }
 
 /**
@@ -78,6 +118,8 @@ export function primaryGenerator(date = new Date()) {
       return "generate-edition.mjs";
     case "dead-period":
     default:
-      return "generate-history.mjs"; // flashback mode for otherwise dead days
+      // generate-history.mjs writes historyData.ts from an already-current
+      // pulseData.ts — it is a secondary section, not an edition producer.
+      return "generate-edition.mjs";
   }
 }

--- a/scripts/send-digest.mjs
+++ b/scripts/send-digest.mjs
@@ -16,6 +16,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { deskLabelForContext } from './lib/season-mode.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -197,10 +198,7 @@ function buildSixtySecondBullets(data) {
 }
 
 function editionContextLabel(pulseEdition) {
-  const ctx = pulseEdition?.editionContext ?? 'regular';
-  if (ctx === 'finals') return 'NBA Finals desk';
-  if (ctx === 'playoffs') return 'Playoffs desk';
-  return 'Regular season desk';
+  return deskLabelForContext(pulseEdition?.editionContext ?? 'regular');
 }
 
 // ── HTML email template ───────────────────────────────────────────────────

--- a/scripts/tests/season-mode.test.mjs
+++ b/scripts/tests/season-mode.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { seasonMode, primaryGenerator, generatorActive } from "../lib/season-mode.mjs";
+import {
+  seasonMode,
+  primaryGenerator,
+  generatorActive,
+  editionContextForMode,
+  deskLabelForContext,
+} from "../lib/season-mode.mjs";
 
 test("seasonMode maps postseason window", () => {
   assert.equal(seasonMode(new Date(Date.UTC(2026, 3, 20))), "playoffs");
@@ -30,9 +36,32 @@ test("seasonMode maps preseason (September)", () => {
   assert.equal(seasonMode(new Date(Date.UTC(2026, 8, 15))), "preseason");
 });
 
-test("generatorActive is false only in dead-period", () => {
-  assert.equal(generatorActive(new Date(Date.UTC(2026, 6, 28))), false);
+test("generatorActive is true year-round, including dead-period", () => {
+  assert.equal(generatorActive(new Date(Date.UTC(2026, 6, 28))), true);
   assert.equal(generatorActive(new Date(Date.UTC(2026, 6, 15))), true);
+  assert.equal(generatorActive(new Date(Date.UTC(2026, 7, 10))), true);
+});
+
+test("primaryGenerator produces an edition in dead-period", () => {
+  assert.equal(primaryGenerator(new Date(Date.UTC(2026, 6, 28))), "generate-edition.mjs");
+});
+
+test("editionContextForMode maps every window, collapsing only regular-season", () => {
+  assert.equal(editionContextForMode("regular-season"), "regular");
+  assert.equal(editionContextForMode("playoffs"), "playoffs");
+  assert.equal(editionContextForMode("finals"), "finals");
+  assert.equal(editionContextForMode("draft"), "draft");
+  assert.equal(editionContextForMode("free-agency"), "free-agency");
+  assert.equal(editionContextForMode("summer-league"), "summer-league");
+  assert.equal(editionContextForMode("preseason"), "preseason");
+  assert.equal(editionContextForMode("dead-period"), "dead-period");
+});
+
+test("offseason windows do not report a regular-season desk", () => {
+  for (const mode of ["draft", "free-agency", "summer-league", "preseason", "dead-period"]) {
+    assert.notEqual(deskLabelForContext(editionContextForMode(mode)), "Regular season desk");
+  }
+  assert.equal(deskLabelForContext(editionContextForMode("regular-season")), "Regular season desk");
 });
 
 test("seasonMode maps draft-night window", () => {

--- a/scripts/validate-playoff-pulse-drift.mjs
+++ b/scripts/validate-playoff-pulse-drift.mjs
@@ -7,7 +7,8 @@
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { seasonMode } from "./lib/season-mode.mjs";
+import { seasonMode, editionContextForMode } from "./lib/season-mode.mjs";
+import { VALID_EDITION_CONTEXTS } from "./lib/content-quality-constants.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -54,7 +55,7 @@ try {
   const playbookRaw = readFileSync(playbookPath, "utf8");
 
   const ctx = pulseEditionContext(pulseRaw);
-  if (!ctx || !["regular", "playoffs", "finals"].includes(ctx)) {
+  if (!ctx || !VALID_EDITION_CONTEXTS.has(ctx)) {
     console.error("[drift] pulseEdition.editionContext missing or invalid in pulseData.ts");
     process.exit(1);
   }
@@ -67,8 +68,7 @@ try {
   }
 
   const calendarMode = seasonMode(parsedEditionDate);
-  const expectedContext =
-    calendarMode === "finals" ? "finals" : calendarMode === "playoffs" ? "playoffs" : "regular";
+  const expectedContext = editionContextForMode(calendarMode);
   if (ctx !== expectedContext) {
     console.error(
       `[drift] pulseData.ts has editionContext "${ctx}" for ${editionDate} (${calendarMode}); expected "${expectedContext}".`,

--- a/scripts/verify-edition-season-alignment.mjs
+++ b/scripts/verify-edition-season-alignment.mjs
@@ -23,6 +23,9 @@ const required = [
   ["summer-league copy block", "## SUMMER LEAGUE WINDOW (season-mode)"],
   ["preseason branch", 'cal === "preseason"'],
   ["preseason copy block", "## PRESEASON WINDOW (season-mode)"],
+  ["dead-period branch", 'cal === "dead-period"'],
+  ["dead-period copy block", "## DEAD PERIOD WINDOW (season-mode)"],
+  ["season-derived edition context", "editionContextForMode(cal)"],
   ["editionContext in Claude prompt", "pulseEdition.editionContext"],
 ];
 


### PR DESCRIPTION
## Summary

Started from "update the site to today's data" and found the dashboard is stuck on the **July 22** edition — and would have stayed stuck until **September 1**. Two independent defects combined.

**1. The dead period silently disabled the generator.**
`generatorActive()` excluded `dead-period`, so `daily-update.yml` skipped the `generate-edition` job outright from July 23 through August 31. The scheduled runs still reported ✅ success, because a *skipped* job doesn't fail a workflow — so the freeze was invisible in Actions history. Today's run ([30159875694](https://github.com/hondoentertainment/hoops-intel/actions/runs/30159875694)) is green with `generate-edition` skipped.

Compounding it, `primaryGenerator()` routed `dead-period` to `generate-history.mjs`, which writes `historyData.ts` *from* an already-current `pulseData.ts`. It's a secondary section, not an edition producer, so the documented "flashback mode for otherwise dead days" could never have produced an edition even if it had been reached.

**2. Every offseason window was published as "regular".**
`generate-edition.mjs` collapsed everything non-postseason to `editionContext: "regular"`, and `validate-playoff-pulse-drift.mjs` independently enforced that same collapse. Meanwhile the client already supports `draft` / `free-agency` / `summer-league` / `preseason` and keys `editionContextDeskLabel()`, `offseasonPrimaryCta()`, `siteNav`, `deskBriefing` and the whole `OffseasonDeskStrip` off those values — so that surface was unreachable in production. The committed July 22 edition, a Summer League day, was labelled `"regular"` and rendered as "Regular season desk".

### Changes

- `editionContextForMode()` in `season-mode.mjs` is now the single source of truth for calendar → context. `generate-edition.mjs` and `validate-playoff-pulse-drift.mjs` both consume it instead of hardcoding three values. Snapshot-detected postseason still wins over the calendar.
- New **dead-period prompt branch** instructing analysis over invention (no fabricated scores/standings, empty `gameResults`, Pulse Index by offseason stock), guarded by `verify-edition-season-alignment.mjs`.
- `generatorActive()` returns true year-round; `primaryGenerator()` routes `dead-period` to `generate-edition.mjs`.
- Client gains the `dead-period` context, labelled **"Offseason desk"** with a `/projections` CTA, plus real `OffseasonDeskStrip` copy instead of falling through to preseason text.
- `VALID_EDITION_CONTEXTS` widened; `send-digest.mjs` now shares `deskLabelForContext()` rather than its own three-way copy.
- Corrected the committed July 22 `editionContext` to `"summer-league"` — the drift validator now catches this class of error instead of enforcing it.
- Docs synced: `references/data-schema.md` (read into the generation prompt every morning), `playoff-metrics-process.md`, `CLAUDE.md`.

### Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes — 223 tests / 40 files, plus `npm run test:ci:tasks` exits 0
- [ ] Vercel Preview looks correct for UI changes — **needs a look**: the Offseason desk strip now renders for the first time in production
- [x] New secrets documented — N/A, no new secrets

### Notes for the reviewer

- **This PR does not itself publish a July 25 edition.** It makes the pipeline *able* to. Generating content needs `ANTHROPIC_API_KEY`, which isn't available in this environment, and `site.api.espn.com` is blocked by the sandbox egress policy. After merge, a `workflow_dispatch` on `daily-update.yml` will publish today with the correct offseason voice.
- **Deliberate behaviour change worth a second opinion:** daily, weekly and midday schedulers all gate on `generatorActive()`, so they now run through the dead period instead of idling. That ends the 40-day freeze but does mean API spend on days with no games. If you'd rather the dead period publish on a reduced cadence, that's a schedule change on top of this — happy to follow up.
- Added `client/src/__tests__/deskMode.test.ts`; updated `finalsDesk.test.ts`, which hardcoded the three-value context set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb7xfhaqSHhEkE3cYcgQEC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish season-correct editions during the dead-period calendar window
> - `generatorActive()` in [season-mode.mjs](https://github.com/hondoentertainment/hoops-intel/pull/268/files#diff-f05be740d24c5c61bc866d8a980dee0f91f50e8e11c5776d7c0025ac4d380fa4) now returns `true` year-round; previously it suppressed generation during the dead period.
> - `primaryGenerator()` routes dead-period dates to `generate-edition.mjs` instead of `generate-history.mjs`, and the generator now uses `editionContextForMode()` to derive the correct `editionContext` rather than defaulting to `'regular'`.
> - `EditionContext` and related constants (`EDITION_CONTEXTS`, `OFFSEASON_CONTEXTS`, `VALID_EDITION_CONTEXTS`) are expanded to include `'dead-period'`, `'draft'`, `'free-agency'`, `'summer-league'`, and `'preseason'`.
> - `OffseasonDeskStrip` renders tailored heading and copy for `'dead-period'`, and digest emails now show correct desk labels for all offseason contexts.
> - Behavioral Change: any caller that previously expected `editionContext` to be `'regular'` during offseason windows will now receive a context-specific value (e.g. `'dead-period'`, `'summer-league'`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58e6707.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->