### PR TITLE
Update daily edition to July 27, 2026

### DIFF
--- a/client/src/lib/pulseData.ts
+++ b/client/src/lib/pulseData.ts
@@ -1,12 +1,12 @@
 // NBA Pulse — Daily Edition Data
-// Last updated: July 22, 2026 (Vol. 2026 · No. 178)
+// Last updated: July 27, 2026 (Vol. 2026 · No. 179)
 // Live at: https://hoopsintel.net
 
 // ═══════════════════════════════════════════════════════════
 // EDITION METADATA
 // ═══════════════════════════════════════════════════════════
 
-export const pulseEdition = {date:"July 22, 2026",edition:"Vol. 2026 · No. 178",subtitle:"Fox Standoff Enters Critical Phase · OKC Playmaker Hunt Accelerates · Summer League Roster Decisions Crystallizing",editionContext:"summer-league"};
+export const pulseEdition = {date:"July 27, 2026",edition:"Vol. 2026 · No. 179",subtitle:"Fox Standoff Enters Critical Phase · OKC Playmaker Hunt Accelerates · Summer League Roster Decisions Crystallizing",editionContext:"dead-period"};
 
 // ═══════════════════════════════════════════════════════════
 // NARRATIVE OF THE DAY
@@ -30,7 +30,7 @@ export const tickerItems = [
   {text:"TONIGHT: No NBA games scheduled — offseason/Summer League window; Las Vegas SL games on ESPN2 and NBA TV",type:"score"}
 ];
 
-// GAME RESULTS — No Games (July 22, 2026)
+// GAME RESULTS — No Games (July 27, 2026)
 export const gameResults = [];
 
 // ═══════════════════════════════════════════════════════════
@@ -88,7 +88,7 @@ export const injuryUpdates = [
 ];
 
 // ═══════════════════════════════════════════════════════════
-// GAME PREVIEWS — No Games Tonight (July 22, 2026)
+// GAME PREVIEWS — No Games Tonight (July 27, 2026)
 // ═══════════════════════════════════════════════════════════
 
 export const gamePreviews = [];
@@ -157,16 +157,16 @@ export const westStandings = [
 export const standings = [...eastStandings, ...westStandings];
 
 // ═══════════════════════════════════════════════════════════
-// THIS DAY IN NBA HISTORY — July 22
+// THIS DAY IN NBA HISTORY — July 27
 // ═══════════════════════════════════════════════════════════
 
-export const historyFact = {year:1998,fact:"On July 22, 1998, the NBA and the NBA Players Association failed to reach a new collective bargaining agreement, triggering an owner lockout that would ultimately shorten the 1998-99 season to just 50 games. The work stoppage lasted 191 days and became one of the most disruptive labor disputes in league history.",players:["David Stern","Patrick Ewing"]};
+export const historyFact = {year:1993,fact:"On July 27, 1993, Boston Celtics captain and two-time All-Star Reggie Lewis died after collapsing during an offseason practice. The Celtics later retired his No. 35 jersey.",players:["Reggie Lewis"]};
 
 // ═══════════════════════════════════════════════════════════
 // HOOPS IQ TRIVIA (Daily)
 // ═══════════════════════════════════════════════════════════
 
-export const triviaQuestion = {id:"2026-07-22",question:"The 1998-99 NBA season was shortened to how many games per team due to the owner lockout?",options:["42 games","50 games","58 games","66 games"],correctIndex:1,explanation:"The 1998 NBA lockout, which began on July 1, 1998, reduced the 1998-99 regular season to 50 games per team after a deal was reached in January 1999.",difficulty:"medium"};
+export const triviaQuestion = {id:"2026-07-27",question:"Which NBA team retired Reggie Lewis's No. 35 jersey?",options:["Boston Celtics","Charlotte Hornets","Detroit Pistons","Philadelphia 76ers"],correctIndex:0,explanation:"The Boston Celtics retired Reggie Lewis's No. 35 in 1995, honoring their former captain and two-time All-Star.",difficulty:"medium"};
 
 // ═══════════════════════════════════════════════════════════
 // HOOPS IQ QUIZ


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- update the daily edition metadata and no-game labels to July 27, 2026
- switch the edition context to the current dead-period window
- refresh the daily history fact and trivia for July 27

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (covered by the stricter `npm run test:pre-push` validation path)
- [ ] Vercel Preview looks correct for UI changes
- [x] New secrets documented in `.env.example` / `README.md` if applicable (N/A)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77127c37-0a6b-4f81-bd0f-2359be20f736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77127c37-0a6b-4f81-bd0f-2359be20f736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update daily edition content in `pulseData.ts` to July 27, 2026
> Updates the static daily edition data in [pulseData.ts](https://github.com/hondoentertainment/hoops-intel/pull/270/files#diff-7673238a4750413989b6fcc0aa9414bf40680dee5972af2b04e5de65f166a014) to reflect the July 27, 2026 issue.
>
> - Sets edition metadata to Vol. 2026 · No. 179 with a `dead-period` context (previously `summer-league`)
> - Replaces the 'This Day in NBA History' fact with the July 27, 1993 death of Reggie Lewis
> - Updates the daily trivia question to ask which team retired Reggie Lewis's No. 35, with Boston Celtics as the correct answer
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fe380f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->