### PR TITLE
fix: route automated failure alerts to a human

### DIFF
--- a/.github/scripts/alert-issues.cjs
+++ b/.github/scripts/alert-issues.cjs
@@ -1,0 +1,88 @@
+// Shared helpers for the automated failure-alert issues that the content and
+// deploy workflows file against themselves.
+//
+// These were previously copy-pasted into each workflow's `github-script` block
+// and drifted: daily/midday/weekly closed their issues once the next run went
+// green, while deployment-smoke, health-check and ops-readiness never closed
+// anything. Failures from June (#154, #159, #165) were still open in August
+// alongside 50+ never-closed site-review reports, which buried the alerts that
+// mattered — nobody reads a label with 60 open issues on it.
+//
+// Consumed from a workflow with:
+//   const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
+
+// GitHub silently drops assignees that lack push access (201, empty assignees)
+// and 422s on an org login, so a failed assignment must never fail the step —
+// filing the issue is the part that matters.
+async function assignAlert(github, context, core, issueNumber) {
+  const assignee = process.env.ALERT_ASSIGNEE;
+  if (!assignee) return;
+  try {
+    await github.rest.issues.addAssignees({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: issueNumber,
+      assignees: [assignee],
+    });
+  } catch (err) {
+    core.info(`Could not assign ${assignee} to #${issueNumber}: ${err.message || err}`);
+  }
+}
+
+// Files one issue per label per day. Returns the issue number, or null when an
+// open issue with the same title already exists.
+async function openFailureIssue(github, context, core, { title, body, label }) {
+  const existing = await github.rest.issues.listForRepo({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    state: 'open',
+    labels: label,
+    per_page: 100,
+  });
+  if (existing.data.some((i) => i.title === title)) {
+    core.notice(`Issue already open: ${title} — skip`);
+    return null;
+  }
+  const created = await github.rest.issues.create({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    title,
+    body,
+    labels: [label, 'automated'],
+  });
+  await assignAlert(github, context, core, created.data.number);
+  return created.data.number;
+}
+
+// Closes every open issue carrying `label` whose title starts with
+// `titlePrefix`. Called from the success path so a recovered workflow clears
+// its own backlog instead of leaving it for a human to notice.
+async function closeResolvedIssues(github, context, core, { label, titlePrefix, note }) {
+  const open = await github.rest.issues.listForRepo({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    state: 'open',
+    labels: label,
+    per_page: 100,
+  });
+  const stale = open.data.filter((i) => i.title.startsWith(titlePrefix));
+  for (const issue of stale) {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: issue.number,
+      body: note,
+    });
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: issue.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+  }
+  if (stale.length) core.notice(`Closed ${stale.length} resolved ${label} issue(s)`);
+  return stale.length;
+}
+
+module.exports = { assignAlert, openFailureIssue, closeResolvedIssues };

--- a/.github/workflows/auto-retry.yml
+++ b/.github/workflows/auto-retry.yml
@@ -101,7 +101,7 @@ jobs:
               repo: context.repo.repo,
               state: 'open',
               labels: 'generation-failure',
-              per_page: 5,
+              per_page: 100,
             });
             const issue = issues.data.find(i => i.title === title);
             if (issue) {

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -158,37 +158,23 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'generation-failure',
-              per_page: 100,
+            await alerts.closeResolvedIssues(github, context, core, {
+              label: 'generation-failure',
+              titlePrefix: 'Daily generation failed',
+              note: `Daily generation succeeded in ${runUrl}. Auto-closing this stale failure report.`,
             });
-            for (const issue of open.data.filter((i) => i.title.startsWith('Daily generation failed'))) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `Daily generation succeeded in ${runUrl}. Auto-closing this stale failure report.`,
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'completed',
-              });
-            }
 
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@v9
+        env:
+          ALERT_ASSIGNEE: ${{ vars.ALERT_ASSIGNEE || github.repository_owner }}
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const today = new Date().toISOString().slice(0, 10);
-            const title = `Daily generation failed — ${today}`;
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -203,21 +189,8 @@ jobs:
             const failureSummary = failedSteps.length
               ? failedSteps.join('\n')
               : '- Failed step unavailable; inspect the linked run logs.';
-            // Check if issue already exists for today
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'generation-failure',
-              per_page: 5,
+            await alerts.openFailureIssue(github, context, core, {
+              label: 'generation-failure',
+              title: `Daily generation failed — ${today}`,
+              body: `## Daily Generation Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n### Failed step\n${failureSummary}\n\nThe generator, external APIs, and pre-push validation are separate steps. Use the failed step above to identify the failing stage before rotating credentials or retrying external services.\n\nThis issue was auto-created by the daily-update workflow.`,
             });
-            const alreadyExists = existing.data.some(i => i.title === title);
-            if (!alreadyExists) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `## Daily Generation Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n### Failed step\n${failureSummary}\n\nThe generator, external APIs, and pre-push validation are separate steps. Use the failed step above to identify the failing stage before rotating credentials or retrying external services.\n\nThis issue was auto-created by the daily-update workflow.`,
-                labels: ['generation-failure', 'automated'],
-              });
-            }

--- a/.github/workflows/deployment-smoke.yml
+++ b/.github/workflows/deployment-smoke.yml
@@ -88,33 +88,36 @@ jobs:
         env:
           SMOKE_BASE_URL: ${{ inputs.base_url || 'https://hoopsintel.net' }}
 
-      - name: Create issue on smoke failure
-        if: failure()
+      - name: Close resolved deployment-failure issues
+        if: success()
         uses: actions/github-script@v9
         with:
           script: |
-            const today = new Date().toISOString().slice(0, 10);
-            const title = `Production smoke failed — ${today}`;
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'deployment-failure',
-              per_page: 5,
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await alerts.closeResolvedIssues(github, context, core, {
+              label: 'deployment-failure',
+              titlePrefix: 'Production smoke failed',
+              note: `Production smoke passed in ${runUrl}. Auto-closing this stale failure report.`,
             });
-            const alreadyExists = existing.data.some(i => i.title === title);
-            if (!alreadyExists) {
-              const upstream = context.payload.workflow_run
-                ? `\n**Upstream workflow:** ${context.payload.workflow_run.name} (${context.payload.workflow_run.html_url})`
-                : '';
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `## Production Smoke Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}${upstream}\n\nDeployment smoke checks failed after a content push or scheduled verification. Review logs for HTTP errors, missing routes, or API handler failures.\n\nThis issue was auto-created by the deployment-smoke workflow.`,
-                labels: ['deployment-failure', 'automated'],
-              });
-            }
+
+      - name: Create issue on smoke failure
+        if: failure()
+        uses: actions/github-script@v9
+        env:
+          ALERT_ASSIGNEE: ${{ vars.ALERT_ASSIGNEE || github.repository_owner }}
+        with:
+          script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
+            const today = new Date().toISOString().slice(0, 10);
+            const upstream = context.payload.workflow_run
+              ? `\n**Upstream workflow:** ${context.payload.workflow_run.name} (${context.payload.workflow_run.html_url})`
+              : '';
+            await alerts.openFailureIssue(github, context, core, {
+              label: 'deployment-failure',
+              title: `Production smoke failed — ${today}`,
+              body: `## Production Smoke Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}${upstream}\n\nDeployment smoke checks failed after a content push or scheduled verification. Review logs for HTTP errors, missing routes, or API handler failures.\n\nThis issue was auto-created by the deployment-smoke workflow.`,
+            });
 
       - name: Notify Slack webhook (optional)
         if: failure()

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -31,35 +31,39 @@ jobs:
         run: |
           set +e
           node scripts/health-check.mjs 2>&1 | tee health-report.json
-          exit_code=$?
+          # PIPESTATUS[0], not $? — after a pipeline $? is tee's status, which
+          # is always 0, so the stale-content alert could never fire.
+          exit_code=${PIPESTATUS[0]}
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
           exit 0
+
+      - name: Close resolved content-stale issues
+        if: steps.health.outputs.exit_code == '0'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await alerts.closeResolvedIssues(github, context, core, {
+              label: 'content-stale',
+              titlePrefix: 'Content stale',
+              note: `Health check passed in ${runUrl}. Content is fresh again — auto-closing this stale report.`,
+            });
 
       - name: Create issue if content is stale
         if: steps.health.outputs.exit_code == '1'
         uses: actions/github-script@v9
+        env:
+          ALERT_ASSIGNEE: ${{ vars.ALERT_ASSIGNEE || github.repository_owner }}
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const today = new Date().toISOString().slice(0, 10);
-            const title = `Content stale — health check failed — ${today}`;
-            // Check if issue already exists for today
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'content-stale',
-              per_page: 5,
+            await alerts.openFailureIssue(github, context, core, {
+              label: 'content-stale',
+              title: `Content stale — health check failed — ${today}`,
+              body: `## Health Check Failed\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nOne or more critical checks failed. The daily content may be stale (>36 hours old) or missing required data.\n\nCheck the workflow logs for the full health report.\n\nThis issue was auto-created by the health-check workflow.`,
             });
-            const alreadyExists = existing.data.some(i => i.title === title);
-            if (!alreadyExists) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `## Health Check Failed\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nOne or more critical checks failed. The daily content may be stale (>36 hours old) or missing required data.\n\nCheck the workflow logs for the full health report.\n\nThis issue was auto-created by the health-check workflow.`,
-                labels: ['content-stale', 'automated'],
-              });
-            }
 
       - name: Fail workflow if critical issues found
         if: steps.health.outputs.exit_code == '1'

--- a/.github/workflows/midday-refresh.yml
+++ b/.github/workflows/midday-refresh.yml
@@ -96,50 +96,25 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'generation-failure',
-              per_page: 100,
+            await alerts.closeResolvedIssues(github, context, core, {
+              label: 'generation-failure',
+              titlePrefix: 'Midday refresh failed',
+              note: `Midday refresh succeeded in ${runUrl}. Auto-closing this stale failure report.`,
             });
-            for (const issue of open.data.filter((i) => i.title.startsWith('Midday refresh failed'))) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `Midday refresh succeeded in ${runUrl}. Auto-closing this stale failure report.`,
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'completed',
-              });
-            }
 
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@v9
+        env:
+          ALERT_ASSIGNEE: ${{ vars.ALERT_ASSIGNEE || github.repository_owner }}
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const today = new Date().toISOString().slice(0, 10);
-            const title = `Midday refresh failed — ${today}`;
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'generation-failure',
-              per_page: 5,
+            await alerts.openFailureIssue(github, context, core, {
+              label: 'generation-failure',
+              title: `Midday refresh failed — ${today}`,
+              body: `## Midday Refresh Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
-            if (!existing.data.some(i => i.title === title)) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `## Midday Refresh Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-                labels: ['generation-failure', 'automated'],
-              });
-            }

--- a/.github/workflows/ops-readiness-check.yml
+++ b/.github/workflows/ops-readiness-check.yml
@@ -16,9 +16,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Fetch production ops-readiness
         id: readiness
         env:
@@ -44,28 +48,43 @@ jobs:
             echo "Production ops-readiness OK"
           fi
 
-      - name: Open issue when production env gaps remain
-        if: steps.readiness.outputs.has_gaps == 'true'
+      - name: Close ops-readiness issues once gaps clear
+        if: steps.readiness.outputs.has_gaps == 'false'
         uses: actions/github-script@v9
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await alerts.closeResolvedIssues(github, context, core, {
+              label: 'ops-readiness',
+              titlePrefix: 'Ops readiness gaps',
+              note: `Production ops-readiness reports no gaps in ${runUrl}. Auto-closing.`,
+            });
+
+      - name: Open issue when production env gaps remain
+        if: steps.readiness.outputs.has_gaps == 'true'
+        uses: actions/github-script@v9
+        env:
+          ALERT_ASSIGNEE: ${{ vars.ALERT_ASSIGNEE || github.repository_owner }}
+        with:
+          script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const today = new Date().toISOString().slice(0, 10);
-            const title = `Ops readiness gaps — ${today}`;
-            const existing = await github.rest.issues.listForRepo({
+            const open = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'ops-readiness',
-              per_page: 10,
+              per_page: 100,
             });
-            if (existing.data.some((i) => i.title.startsWith('Ops readiness gaps'))) {
+            // Gaps persist until secrets land, so one open tracker is enough —
+            // match on the prefix rather than today's exact title.
+            if (open.data.some((i) => i.title.startsWith('Ops readiness gaps'))) {
               core.notice('Ops readiness issue already open — skip');
               return;
             }
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
+            await alerts.openFailureIssue(github, context, core, {
+              label: 'ops-readiness',
+              title: `Ops readiness gaps — ${today}`,
               body: `## Production env gaps\n\n**Date:** ${today}\n**Check:** https://hoopsintel.net/api/ops-readiness\n**Workflow:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nRun \`vercel env pull\` and \`npm run ops:preflight:strict\` locally. See \`PRODUCTION-OPS.md\` for the full checklist.`,
-              labels: ['ops-readiness', 'automated'],
             });

--- a/.github/workflows/site-review-agent.yml
+++ b/.github/workflows/site-review-agent.yml
@@ -103,14 +103,14 @@ jobs:
               repo: context.repo.repo,
               labels: 'site-review',
               state: 'open',
-              per_page: 30,
+              per_page: 100,
             });
             const dup = openIssues.data.find((i) => i.title.includes(today));
             if (dup) {
               core.notice('Issue already exists for ' + today + ' — skip');
               return;
             }
-            await github.rest.issues.create({
+            const created = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title,
@@ -118,3 +118,29 @@ jobs:
                 `\n\n---\n**Workflow:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               labels: ['site-review', 'automated'],
             });
+            // A site review is a daily snapshot, not a tracked defect. Leaving
+            // each one open accumulated 50+ issues that buried the
+            // deployment-failure and generation-failure alerts sharing the
+            // list. Supersede yesterday's once today's is filed; anything
+            // worth keeping gets relabelled by a human, which exempts it.
+            const superseded = openIssues.data.filter(
+              (i) => i.number !== created.data.number &&
+                i.title.startsWith('Site review —') &&
+                i.labels.some((l) => (l.name || l) === 'automated'),
+            );
+            for (const issue of superseded) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Superseded by #${created.data.number} (${today}).`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }
+            if (superseded.length) core.notice(`Closed ${superseded.length} superseded site review(s)`);

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -109,51 +109,25 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'generation-failure',
-              per_page: 100,
+            await alerts.closeResolvedIssues(github, context, core, {
+              label: 'generation-failure',
+              titlePrefix: 'Weekly generation failed',
+              note: `Weekly generation succeeded in ${runUrl}. Auto-closing this stale failure report.`,
             });
-            for (const issue of open.data.filter((i) => i.title.startsWith('Weekly generation failed'))) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: `Weekly generation succeeded in ${runUrl}. Auto-closing this stale failure report.`,
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'completed',
-              });
-            }
 
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@v9
+        env:
+          ALERT_ASSIGNEE: ${{ vars.ALERT_ASSIGNEE || github.repository_owner }}
         with:
           script: |
+            const alerts = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/alert-issues.cjs`);
             const today = new Date().toISOString().slice(0, 10);
-            const title = `Weekly generation failed — ${today}`;
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'generation-failure',
-              per_page: 5,
+            await alerts.openFailureIssue(github, context, core, {
+              label: 'generation-failure',
+              title: `Weekly generation failed — ${today}`,
+              body: `## Weekly Generation Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nCheck the workflow logs for details.\n\nThis issue was auto-created by the weekly-update workflow.`,
             });
-            const alreadyExists = existing.data.some(i => i.title === title);
-            if (!alreadyExists) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `## Weekly Generation Failure\n\n**Date:** ${today}\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nCheck the workflow logs for details.\n\nThis issue was auto-created by the weekly-update workflow.`,
-                labels: ['generation-failure', 'automated'],
-              });
-            }

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,6 +1,6 @@
 # Hoops Intel — Next steps (living doc)
 
-_Last revised: July 22, 2026 — see refreshed [`ROADMAP.md`](./ROADMAP.md)_
+_Last revised: August 1, 2026 — see refreshed [`ROADMAP.md`](./ROADMAP.md)_
 
 ### Deploy & reliability
 
@@ -8,6 +8,35 @@ _Last revised: July 22, 2026 — see refreshed [`ROADMAP.md`](./ROADMAP.md)_
 |-------|--------|--------|
 | P0–P5 product/CI | CI, smoke, print, social dry-run, Guest Pulse feed, rival_pairs, opener archive, multi-fav push, creator edit | **Done** |
 | Post-deploy | `npm run smoke:deploy` after each prod push | **Ongoing ritual** |
+
+### July 2026 outage post-mortem (both resolved)
+
+Two independent defects overlapped and froze the dashboard for ~6 days.
+
+| Defect | Cause | Fix |
+|--------|-------|-----|
+| Generator freeze (#268) | `dead-period` window skipped generation July 23 – Aug 31 | `generatorActive()` now returns true in every window |
+| Deploy break (#272, #275) | TypeScript 7 is Go-native and drops the JS Compiler API (`ts.sys` / `createProgram`) that Vercel's serverless compilation needs — `Cannot read properties of undefined (reading 'readFile')` | Pinned `typescript@~6.0.3` + Dependabot `ignore` on TS majors (#278) |
+
+**Standing constraint:** do not unpin TypeScript to 7.x until Vercel's Node
+builder supports the Go-native compiler. The Dependabot ignore rule enforces
+this; removing it re-breaks production deploys, not just the build.
+
+### Alerting
+
+Failure issues were auto-filed but never reached a human — `deployment-smoke`,
+`health-check` and `ops-readiness` opened issues and never closed them, while
+`site-review` filed a fresh report every day and closed none. 65 open issues
+buried five real deploy failures dating back to June.
+
+| Step | Action | Status |
+|------|--------|--------|
+| Shared helper | `.github/scripts/alert-issues.cjs` — one open/close/assign path for all workflows | **Done** |
+| Auto-close on recovery | `deployment-smoke`, `health-check`, `ops-readiness` now clear their own backlog | **Done** |
+| Site-review noise | Each day's report supersedes and closes the previous one | **Done** |
+| Health-check alert | `exit_code=$?` after a pipe read `tee`'s status, so the stale-content alert could never fire | **Fixed** (`PIPESTATUS[0]`) |
+| Assignee | Set repo variable **`ALERT_ASSIGNEE`** to a collaborator login | **Manual** — defaults to `github.repository_owner`, which is silently ignored if that's an org |
+| Slack | Set `SLACK_DATA_QUALITY_WEBHOOK` for out-of-band alerts | **Manual** — smoke failures post there today only if set |
 
 ### P0 — Ops (manual — still blocking live Pro/push)
 
@@ -36,7 +65,12 @@ _Last revised: July 22, 2026 — see refreshed [`ROADMAP.md`](./ROADMAP.md)_
 
 - SSR/SEO unless Lighthouse regresses
 - Public API / native / WNBA (Q4+)
-- Dependabot npm #242 (after green Vercel preview)
+- Weekly generation is all-or-nothing: one failed section (exit code 2) discards
+  the seven that succeeded. Deliberate today — revisit only if partial-commit
+  semantics are worth the risk of shipping half an edition.
+- Six workflows still inline their own `github-script` blocks. The shared helper
+  covers issue open/close; the surrounding boilerplate could become a composite
+  action if it drifts again.
 
 ---
 

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -38,6 +38,17 @@ buried five real deploy failures dating back to June.
 | Assignee | Set repo variable **`ALERT_ASSIGNEE`** to a collaborator login | **Manual** — defaults to `github.repository_owner`, which is silently ignored if that's an org |
 | Slack | Set `SLACK_DATA_QUALITY_WEBHOOK` for out-of-band alerts | **Manual** — smoke failures post there today only if set |
 
+### Dependencies
+
+The npm bump was deferred pending a green Vercel preview — now satisfied.
+
+| Step | Action | Status |
+|------|--------|--------|
+| Dependabot npm group | PR **#279** (9 updates) | **Verified, awaiting merge** — keeps `typescript@~6.0.3`; full suite, `vite build`, `dist/embed.js` and `typecheck:api` all pass against it |
+| jsdom 29 → 30 | Major bump of the vitest environment, bundled in #279 | **Verified** — 223/223 pass |
+
+Verified locally on Node 22; CI and Vercel run Node 24.
+
 ### P0 — Ops (manual — still blocking live Pro/push)
 
 `/api/ops-readiness` must flip to ready. Until secrets land, code paths soft-skip.

--- a/scripts/generate-all-weekly.mjs
+++ b/scripts/generate-all-weekly.mjs
@@ -49,7 +49,8 @@ const WEEKLY_SCRIPTS = [
   { name: "Projections",     script: "generate-projections.mjs",   output: "client/src/lib/projectionsData.ts" },
   { name: "Draft Intel",     script: "generate-draft.mjs",         output: "client/src/lib/draftData.ts" },
   { name: "Clutch Ratings",  script: "generate-clutch.mjs",        output: "client/src/lib/clutchData.ts" },
-  // Extra headroom: generator retries once at 16K tokens when output truncates.
+  // Extra headroom: on truncation the generator retries at a raised token
+  // ceiling (16K then 24K), so it needs room for two full-length calls.
   { name: "Trade Simulator", script: "generate-trade-sim.mjs",     output: "client/src/lib/tradeSimData.ts", timeoutMs: 480_000 },
   { name: "Community Pulse", script: "generate-community-pulse.mjs", output: "client/src/lib/communityPulseData.ts" },
 ];

--- a/scripts/generate-trade-sim.mjs
+++ b/scripts/generate-trade-sim.mjs
@@ -18,9 +18,11 @@ const ROOT = join(__dirname, "..");
 const OUT_PATH = join(ROOT, "client", "src", "lib", "tradeSimData.ts");
 
 // Trade sim payloads are large (30+ players + 6 proposals). 8K max_tokens
-// truncates mid-string under weekly load; 16K + one retry covers that.
-const MAX_TOKENS = 16384;
-const MAX_ATTEMPTS = 2;
+// truncated mid-string under weekly load (#273). A retry at the same ceiling
+// is just a re-roll of the same constraint, so the second attempt gets more
+// room rather than the same budget twice.
+const TOKEN_LADDER = [16384, 24576];
+const MAX_ATTEMPTS = TOKEN_LADDER.length;
 
 // ── CLI args ────────────────────────────────────────────────
 
@@ -173,10 +175,11 @@ function stripFences(text) {
 }
 
 async function generateOnce(client, prompt, attempt) {
-  console.log(`🤖 Calling Claude (claude-sonnet-4-6, max_tokens=${MAX_TOKENS}, attempt ${attempt}/${MAX_ATTEMPTS})...`);
+  const maxTokens = TOKEN_LADDER[attempt - 1] ?? TOKEN_LADDER[TOKEN_LADDER.length - 1];
+  console.log(`🤖 Calling Claude (claude-sonnet-4-6, max_tokens=${maxTokens}, attempt ${attempt}/${MAX_ATTEMPTS})...`);
   const message = await client.messages.create({
     model: "claude-sonnet-4-6",
-    max_tokens: MAX_TOKENS,
+    max_tokens: maxTokens,
     messages: [
       {
         role: "user",

--- a/scripts/tests/alert-issues.vitest.mjs
+++ b/scripts/tests/alert-issues.vitest.mjs
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const require = createRequire(import.meta.url);
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const alerts = require(join(ROOT, ".github", "scripts", "alert-issues.cjs"));
+
+const context = { repo: { owner: "hondoentertainment", repo: "hoops-intel" } };
+
+function fakeGitHub(openIssues = []) {
+  const calls = { created: [], comments: [], updates: [], assignees: [], listArgs: [] };
+  return {
+    calls,
+    rest: {
+      issues: {
+        listForRepo: async (args) => {
+          calls.listArgs.push(args);
+          return { data: openIssues };
+        },
+        create: async (args) => {
+          calls.created.push(args);
+          return { data: { number: 900 + calls.created.length } };
+        },
+        createComment: async (args) => calls.comments.push(args),
+        update: async (args) => calls.updates.push(args),
+        addAssignees: async (args) => calls.assignees.push(args),
+      },
+    },
+  };
+}
+
+const core = { info: () => {}, notice: () => {}, warning: () => {} };
+
+describe("alert-issues helper", () => {
+  beforeEach(() => {
+    delete process.env.ALERT_ASSIGNEE;
+  });
+
+  it("files an issue and assigns it when ALERT_ASSIGNEE is set", async () => {
+    process.env.ALERT_ASSIGNEE = "hondoentertainment";
+    const gh = fakeGitHub([]);
+    const num = await alerts.openFailureIssue(gh, context, core, {
+      label: "deployment-failure",
+      title: "Production smoke failed — 2026-08-01",
+      body: "boom",
+    });
+
+    expect(num).toBe(901);
+    expect(gh.calls.created).toHaveLength(1);
+    expect(gh.calls.created[0].labels).toEqual(["deployment-failure", "automated"]);
+    expect(gh.calls.assignees[0].assignees).toEqual(["hondoentertainment"]);
+  });
+
+  it("does not file a duplicate when the same title is already open", async () => {
+    const gh = fakeGitHub([{ number: 272, title: "Production smoke failed — 2026-08-01" }]);
+    const num = await alerts.openFailureIssue(gh, context, core, {
+      label: "deployment-failure",
+      title: "Production smoke failed — 2026-08-01",
+      body: "boom",
+    });
+
+    expect(num).toBeNull();
+    expect(gh.calls.created).toHaveLength(0);
+  });
+
+  // The dedupe window was per_page: 5, so with five stale issues already open
+  // the sixth failure could slip past the duplicate check.
+  it("scans a full page of open issues when deduping", async () => {
+    const gh = fakeGitHub([]);
+    await alerts.openFailureIssue(gh, context, core, { label: "x", title: "t", body: "b" });
+    expect(gh.calls.listArgs[0].per_page).toBe(100);
+  });
+
+  it("never fails the step when assignment is rejected", async () => {
+    process.env.ALERT_ASSIGNEE = "not-a-collaborator";
+    const gh = fakeGitHub([]);
+    gh.rest.issues.addAssignees = async () => {
+      throw new Error("Validation Failed: assignee");
+    };
+
+    await expect(
+      alerts.openFailureIssue(gh, context, core, { label: "x", title: "t", body: "b" }),
+    ).resolves.toBe(901);
+    expect(gh.calls.created).toHaveLength(1);
+  });
+
+  it("skips assignment entirely when ALERT_ASSIGNEE is unset", async () => {
+    const gh = fakeGitHub([]);
+    await alerts.openFailureIssue(gh, context, core, { label: "x", title: "t", body: "b" });
+    expect(gh.calls.assignees).toHaveLength(0);
+  });
+
+  it("closes only matching open issues and leaves others alone", async () => {
+    const gh = fakeGitHub([
+      { number: 154, title: "Production smoke failed — 2026-06-04" },
+      { number: 272, title: "Production smoke failed — 2026-07-27" },
+      { number: 273, title: "Weekly generation failed — 2026-07-27" },
+    ]);
+
+    const closed = await alerts.closeResolvedIssues(gh, context, core, {
+      label: "deployment-failure",
+      titlePrefix: "Production smoke failed",
+      note: "green again",
+    });
+
+    expect(closed).toBe(2);
+    expect(gh.calls.updates.map((u) => u.issue_number)).toEqual([154, 272]);
+    expect(gh.calls.updates.every((u) => u.state === "closed")).toBe(true);
+    expect(gh.calls.updates.every((u) => u.state_reason === "completed")).toBe(true);
+    expect(gh.calls.comments.map((c) => c.issue_number)).toEqual([154, 272]);
+  });
+
+  it("is a no-op when there is nothing stale to close", async () => {
+    const gh = fakeGitHub([{ number: 273, title: "Weekly generation failed — 2026-07-27" }]);
+    const closed = await alerts.closeResolvedIssues(gh, context, core, {
+      label: "deployment-failure",
+      titlePrefix: "Production smoke failed",
+      note: "green again",
+    });
+
+    expect(closed).toBe(0);
+    expect(gh.calls.updates).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

The July outage was found by hand, not by an alert — even though the workflows had been filing issues about it since July 22. This fixes why nobody saw them.

Five real deploy failures (#154, #159, #165 from June; #272, #275 from July) were sitting open among 65 issues. Two causes:

1. **Nothing closed them.** `daily-update`, `midday-refresh` and `weekly-update` close their failure issues once the next run goes green. `deployment-smoke`, `health-check` and `ops-readiness` never did — the copy-pasted `github-script` blocks had drifted apart.
2. **Nothing was assigned.** Every alert was authored by `github-actions[bot]` with no assignee, so GitHub notified no one.

Meanwhile `site-review` filed a fresh report every single day and closed none — roughly 55 of the 65 open issues — which buried the alerts that mattered.

### Changes

- **`.github/scripts/alert-issues.cjs`** — one open/close/assign path, replacing six diverging inline copies. This is the fix for the class of bug, not just the instances.
- **Auto-close on recovery** for `deployment-failure`, `content-stale` and `ops-readiness`, matching the behaviour the generation workflows already had.
- **Assignment** to `ALERT_ASSIGNEE` (repo variable, falling back to `github.repository_owner`). Assignment failures are logged, never fatal — GitHub silently drops assignees without push access and 422s on an org login, and neither should cost us the issue itself.
- **Dedupe scan widened** from `per_page: 5` to `100`. With five stale issues already open on a label, the duplicate check could miss.
- **`site-review` reports supersede** the previous day's instead of accumulating.

### Two defects found along the way

- **`health-check.yml` read `exit_code=$?` after a pipeline**, which captures `tee`'s status, not node's. It was always `0`, so the stale-content alert could never fire — that alert has never worked. Now uses `${PIPESTATUS[0]}`, as `weekly-update` already did.
- **#273 (Trade Simulator truncation)**: the root cause was already fixed on `main` by 67cf97c, which raised 8K → 16K and added a retry. But the retry reused the same ceiling, so if the ceiling was what bound, attempt 2 re-rolled the same constraint. Now escalates 16K → 24K.

### Not addressed

Weekly generation stays all-or-nothing — one failed section (exit code 2) still discards the seven that succeeded. That's deliberate today; changing it means shipping partial editions. Noted in `NEXT-STEPS.md` rather than changed here.

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes — 41 files / 230 tests, including 7 new cases in `scripts/tests/alert-issues.vitest.mjs`
- [ ] Vercel Preview looks correct for UI changes — N/A, no UI or client code touched
- [x] New secrets documented — no secrets added; the optional `ALERT_ASSIGNEE` repo variable is documented in `NEXT-STEPS.md`

Also validated all 18 workflow YAML files parse and all 14 embedded `github-script` blocks are syntactically valid.

### Follow-up, separate from this PR

Dependabot **#279** is verified and ready: it keeps `typescript@~6.0.3` (your ignore rule held), and the full suite, `vite build`, `dist/embed.js` and `typecheck:api` all pass against it — including the jsdom 29 → 30 major. It needs your merge decision, not mine, given a dependency bump is what broke production last time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb7xfhaqSHhEkE3cYcgQEC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route automated failure alerts to a human assignee via shared alert helpers
> - Adds [alert-issues.cjs](.github/scripts/alert-issues.cjs) with three shared helpers: `openFailureIssue` (deduplicates against up to 100 open issues before creating), `closeResolvedIssues` (auto-closes matching issues with a comment on recovery), and `assignAlert` (assigns issues to `ALERT_ASSIGNEE` env var without failing the workflow on error).
> - Refactors all alert-producing workflows (`daily-update`, `midday-refresh`, `weekly-update`, `deployment-smoke`, `health-check`, `ops-readiness-check`, `site-review-agent`) to use these helpers instead of inline GitHub Script logic.
> - Fixes exit code capture in `health-check.yml` after a piped command by using `PIPESTATUS[0]` instead of `$?`.
> - Increases deduplication scan windows from 5–30 to 100 issues across all workflows.
> - Behavioral Change: successful workflow runs now automatically comment on and close any open stale failure issues for their respective labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ac13c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->