### PR TITLE
fix: retry failed weekly sections instead of discarding the run

### DIFF
--- a/scripts/generate-all-weekly.mjs
+++ b/scripts/generate-all-weekly.mjs
@@ -117,7 +117,25 @@ async function main() {
   console.log(`   Total scripts: ${WEEKLY_SCRIPTS.length}`);
   console.log(`   Running all scripts in parallel...\n`);
 
-  const results = await Promise.all(WEEKLY_SCRIPTS.map(runScript));
+  let results = await Promise.all(WEEKLY_SCRIPTS.map(runScript));
+
+  // One failed section discards the whole run (exit 2 refuses to commit), so
+  // a single stochastic truncation costs a full week of content — that is
+  // what sank 7 passing sections on 2026-07-27 (#273, Trade Simulator) and
+  // again on 2026-08-03 (#289, Projections). Generation is a re-roll:
+  // re-run just the failed scripts once before giving up on the week.
+  const firstWaveFailures = results.filter((r) => r.status === "failed");
+  if (firstWaveFailures.length > 0 && firstWaveFailures.length < results.length) {
+    const names = firstWaveFailures.map((r) => r.name).join(", ");
+    console.log(`\nRetrying ${firstWaveFailures.length} failed script(s): ${names}\n`);
+    const retryScripts = WEEKLY_SCRIPTS.filter((s) =>
+      firstWaveFailures.some((f) => f.name === s.name)
+    );
+    const retried = await Promise.all(retryScripts.map(runScript));
+    results = results.map((r) =>
+      r.status === "failed" ? (retried.find((n) => n.name === r.name) ?? r) : r
+    );
+  }
 
   const passed = results.filter((r) => r.status === "success").length;
   const failed = results.filter((r) => r.status === "failed").length;

--- a/scripts/generate-projections.mjs
+++ b/scripts/generate-projections.mjs
@@ -200,7 +200,9 @@ async function main() {
   try {
     const message = await client.messages.create({
       model: "claude-sonnet-4-6",
-      max_tokens: 16000,
+      // 16000 truncated mid-file on 2026-08-03 (#289) and sank the whole
+      // weekly run. Same headroom the trade-sim retry uses.
+      max_tokens: 24576,
       messages: [
         {
           role: "user",


### PR DESCRIPTION
## Summary

The weekly offseason content (trade sim, draft intel, projections, trade value, lineups, tactics, clutch, community pulse) has been stale since **July 20** — two consecutive Monday runs failed, each because *one* section's Claude output truncated and the runner's all-or-nothing exit discarded the seven sections that succeeded:

- **2026-07-27** (#273): Trade Simulator truncated at 8K tokens
- **2026-08-03** (#289): Projections truncated at 16K tokens — *after* trade-sim was hardened, proving per-generator hardening is whack-a-mole

Two changes:

- **`generate-all-weekly.mjs`**: after the parallel first wave, re-run just the failed scripts once before giving up on the week. Truncation is stochastic — a re-roll usually lands. If *every* script failed, the retry is skipped: that's systemic (API outage, bad key), not a re-roll candidate. Worst-case runtime stays inside the workflow's 15-minute bound.
- **`generate-projections.mjs`**: raise `max_tokens` 16000 → 24576, the demonstrated truncation point, matching the trade-sim retry ceiling.

Once merged, dispatching **Weekly Data Update** regenerates all eight sections and pushes fresh offseason content to `main`; a green run also auto-closes #273 and #289.

Side note: #289 is itself proof the alerting fix works — filed same-hour and assigned to `hondoentertainment`, versus #273 which sat unread for a week.

## Checklist

- [x] `npm run build` passes locally — unchanged client code; build verified on this branch previously
- [x] `npm run test:unit` passes — plus `npm test` (content validator + assembly) and `node --check` on both scripts; the retry path itself needs a live API key, so its first real exercise is the dispatched run
- [ ] Vercel Preview looks correct for UI changes — N/A, pipeline scripts only
- [x] New secrets documented — none added

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb7xfhaqSHhEkE3cYcgQEC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry failed weekly sections instead of discarding the run
> - Adds retry logic to [generate-all-weekly.mjs](https://github.com/hondoentertainment/hoops-intel/pull/291/files#diff-c1fb26b3004f32fd9702229792dd0b8533829eb8f3c7c7df19a6571ee7af8861): after the initial parallel run, any failed scripts are re-executed once (only when some, but not all, scripts fail), and their results replace the original failures before final aggregation.
> - Increases `max_tokens` in [generate-projections.mjs](https://github.com/hondoentertainment/hoops-intel/pull/291/files#diff-727f9276d92784ca0ed485fb85a8c0ad2ea793fd6fce1b53d2920cf9066613ed) from 16000 to 24576 to avoid response truncation.
> - Behavioral Change: previously, a partial failure would discard the entire run; now the runner recovers from partial failures automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63350c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->