### PR TITLE
ci: allow out-of-band weekly regeneration via marker file

### DIFF
--- a/.github/weekly-regen-request
+++ b/.github/weekly-regen-request
@@ -1,0 +1,2 @@
+Bump this file (any content change) on main to trigger an out-of-band weekly regeneration.
+Requested: 2026-08-04 — regenerate offseason weekly content stale since July 20 (#273, #289).

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -5,6 +5,12 @@ on:
     # Monday 6:00 AM PST (UTC-8) = 14:00 UTC
     - cron: "0 14 * * 1"
   workflow_dispatch: # allow manual trigger from GitHub Actions UI
+  # Out-of-band regeneration without Actions UI access: bump the marker file
+  # on main (e.g. via a merged PR) and the workflow fires. The generated
+  # content commits never touch the marker, so runs don't self-trigger.
+  push:
+    branches: [main]
+    paths: [".github/weekly-regen-request"]
 
 concurrency:
   group: weekly-edition


### PR DESCRIPTION
## Summary

Follow-up to #291. The weekly runner retry fix is on `main`, but the weekly content itself is still the July 20 edition — regenerating it requires firing **Weekly Data Update** now rather than waiting for next Monday's cron, and the GitHub MCP integration used by remote sessions gets a 403 on the `workflow_dispatch` API.

This adds a `push` trigger scoped to a single marker file, `.github/weekly-regen-request`: bump the file on `main` (normally via a merged PR) and the weekly generator fires. Generated content commits never touch the marker, so runs can't re-trigger themselves. The season gate still applies to these runs (`check-generator-active.mjs` currently returns `true`).

Merging this PR is itself the first trigger — the squash commit touches the marker, which kicks off the regeneration of all eight offseason sections (trade value, lineups, tactics, projections, draft intel, clutch, trade sim, community pulse). A green run pushes the fresh content to `main` and auto-closes #273 and #289.

## Checklist

- [x] `npm run build` passes locally — workflow + marker file only, no code paths touched
- [x] `npm run test:unit` passes — unchanged; workflow YAML validated with a parser
- [ ] Vercel Preview looks correct for UI changes — N/A
- [x] New secrets documented — none added

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb7xfhaqSHhEkE3cYcgQEC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow out-of-band triggering of the weekly-update workflow via a marker file
> Adds a push trigger to [weekly-update.yml](.github/workflows/weekly-update.yml) that fires when [.github/weekly-regen-request](.github/weekly-regen-request) is modified on `main`. Committing a change to the marker file manually triggers the weekly regeneration without waiting for the scheduled run. Generated commits do not touch the marker file, preventing self-triggering loops.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3da8fed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->