### PR TITLE
fix: stream large generations past the SDK 10-minute guard

### DIFF
--- a/.github/weekly-regen-request
+++ b/.github/weekly-regen-request
@@ -1,2 +1,2 @@
 Bump this file (any content change) on main to trigger an out-of-band weekly regeneration.
-Requested: 2026-08-04 — regenerate offseason weekly content stale since July 20 (#273, #289).
+Requested: 2026-08-04 (second attempt) — regenerate offseason weekly content stale since July 20 (#273, #289, #293).

--- a/scripts/generate-projections.mjs
+++ b/scripts/generate-projections.mjs
@@ -198,18 +198,22 @@ async function main() {
 
   let responseText;
   try {
-    const message = await client.messages.create({
-      model: "claude-sonnet-4-6",
-      // 16000 truncated mid-file on 2026-08-03 (#289) and sank the whole
-      // weekly run. Same headroom the trade-sim retry uses.
-      max_tokens: 24576,
-      messages: [
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
-    });
+    // 16000 truncated mid-file on 2026-08-03 (#289) and sank the whole
+    // weekly run. max_tokens above ~16K trips the SDK's 10-minute
+    // non-streaming guard and rejects before sending (#293), so stream
+    // and take the final message.
+    const message = await client.messages
+      .stream({
+        model: "claude-sonnet-4-6",
+        max_tokens: 24576,
+        messages: [
+          {
+            role: "user",
+            content: prompt,
+          },
+        ],
+      })
+      .finalMessage();
 
     const block = message.content.find((b) => b.type === "text");
     if (!block) throw new Error("No text block in Claude response");

--- a/scripts/generate-trade-sim.mjs
+++ b/scripts/generate-trade-sim.mjs
@@ -177,16 +177,20 @@ function stripFences(text) {
 async function generateOnce(client, prompt, attempt) {
   const maxTokens = TOKEN_LADDER[attempt - 1] ?? TOKEN_LADDER[TOKEN_LADDER.length - 1];
   console.log(`🤖 Calling Claude (claude-sonnet-4-6, max_tokens=${maxTokens}, attempt ${attempt}/${MAX_ATTEMPTS})...`);
-  const message = await client.messages.create({
-    model: "claude-sonnet-4-6",
-    max_tokens: maxTokens,
-    messages: [
-      {
-        role: "user",
-        content: prompt,
-      },
-    ],
-  });
+  // The 24576 retry rung trips the SDK's 10-minute non-streaming guard
+  // (#293), so stream and take the final message.
+  const message = await client.messages
+    .stream({
+      model: "claude-sonnet-4-6",
+      max_tokens: maxTokens,
+      messages: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+    })
+    .finalMessage();
 
   const block = message.content.find((b) => b.type === "text");
   if (!block) throw new Error("No text block in Claude response");


### PR DESCRIPTION
## Summary

The #292 marker-triggered regeneration failed (#293) — and the cause was #291's own token bump. `max_tokens: 24576` trips the Anthropic SDK's non-streaming duration guard, so `messages.create()` rejects instantly with *"Streaming is required for operations that may take longer than 10 minutes"*. Projections failed in 0.1s on both attempts; the new runner retry worked exactly as designed but a deterministic rejection isn't a re-roll candidate. Trade-sim's 24576 retry rung had the same landmine, unexercised.

The run was otherwise the closest yet: 7/8 sections passed, including Trade Simulator.

Changes:

- **`generate-projections.mjs`**, **`generate-trade-sim.mjs`**: switch to `client.messages.stream(...).finalMessage()`, which permits large `max_tokens` and returns the same message shape (content blocks, `stop_reason`) — no other logic touched.
- **`.github/weekly-regen-request`**: bumped, so merging this PR immediately re-fires the weekly generator with the fix.

A green run pushes fresh offseason content (stale since July 20) to `main` and auto-closes #273, #289 and #293.

## Checklist

- [x] `npm run build` passes locally — pipeline scripts only, no client code
- [x] `npm run test:unit` passes — unchanged; both scripts `node --check` clean and `messages.stream` verified present on the pinned SDK (0.112.5)
- [ ] Vercel Preview looks correct for UI changes — N/A
- [x] New secrets documented — none added

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb7xfhaqSHhEkE3cYcgQEC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix large generation timeouts by switching to streaming in projection and trade-sim scripts
> The Anthropic SDK enforces a 10-minute timeout on non-streaming requests, which causes failures for large generations. Both [generate-projections.mjs](https://github.com/hondoentertainment/hoops-intel/pull/294/files#diff-727f9276d92784ca0ed485fb85a8c0ad2ea793fd6fce1b53d2920cf9066613ed) and [generate-trade-sim.mjs](https://github.com/hondoentertainment/hoops-intel/pull/294/files#diff-07997595a0eabc7448b0a7dcf1efd14c72fb4c956f2303030274c9311834e603) now call `client.messages.stream({...}).finalMessage()` instead of `client.messages.create(...)` to bypass this guard. Response parsing logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de135de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->