### PR TITLE
Enhance the 82-0 Challenge experience

### DIFF
--- a/client/src/__tests__/eightyTwoZeroSim.test.ts
+++ b/client/src/__tests__/eightyTwoZeroSim.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect } from "vitest";
 import { ERA_LABELS, TEAM_ERA_POOLS, type EraPlayer } from "../lib/eightyTwoZeroData";
 import {
   availablePlayers,
+  createRng,
+  dailyWheelSeed,
+  draftCoverage,
+  gameStrip,
+  monthlySplits,
   playerScore,
   respinEra,
   respinTeam,
+  SEASON_MONTHS,
   simulateSeason,
   strengthRating,
   verdictFor,
@@ -136,6 +142,72 @@ describe("spin helpers", () => {
     const names = availablePlayers(pool, taken).map((p) => p.name);
     expect(names).not.toContain(pool.players[0].name);
     expect(names.length).toBe(pool.players.length - 1);
+  });
+});
+
+describe("season presentation helpers", () => {
+  it("month buckets cover exactly 82 games", () => {
+    expect(SEASON_MONTHS.reduce((s, m) => s + m.games, 0)).toBe(82);
+  });
+
+  it("monthlySplits partitions wins and losses to the right months", () => {
+    const splits = monthlySplits([
+      { gameNumber: 1, opponent: "'96 Bulls" },
+      { gameNumber: 9, opponent: "'17 Warriors" },
+      { gameNumber: 82, opponent: "'86 Celtics" },
+    ]);
+    expect(splits.map((s) => s.label)).toEqual(["OCT", "NOV", "DEC", "JAN", "FEB", "MAR", "APR"]);
+    expect(splits[0]).toMatchObject({ losses: 1, wins: 7 });
+    expect(splits[1]).toMatchObject({ losses: 1, wins: 14 });
+    expect(splits[6]).toMatchObject({ losses: 1, wins: 3 });
+    expect(splits.reduce((s, m) => s + m.wins + m.losses, 0)).toBe(82);
+  });
+
+  it("gameStrip mirrors the season record game by game", () => {
+    const result = simulateSeason(roleSquad);
+    const strip = gameStrip(result);
+    expect(strip.length).toBe(82);
+    expect(strip.filter(Boolean).length).toBe(result.wins);
+    for (const loss of result.lossGames) {
+      expect(strip[loss.gameNumber - 1]).toBe(false);
+    }
+  });
+});
+
+describe("draftCoverage", () => {
+  it("tracks positional coverage of a partial lineup", () => {
+    const partial = [godSquad[0], godSquad[2]];
+    const cov = draftCoverage(partial);
+    expect(cov.hasGuard).toBe(true);
+    expect(cov.hasCenter).toBe(false);
+    expect(cov.rawStrength).toBeCloseTo(playerScore(partial[0]) + playerScore(partial[1]));
+  });
+
+  it("scales assist and rebound pace to filled slots", () => {
+    const onePasser = [pl("John Stockton", "G", 13.5, 2.8, 11.5)];
+    expect(draftCoverage(onePasser).onPaceAssists).toBe(true);
+    const oneNonPasser = [pl("Reggie Miller", "G", 19.5, 3, 1)];
+    expect(draftCoverage(oneNonPasser).onPaceAssists).toBe(false);
+  });
+});
+
+describe("Daily Wheel seeding", () => {
+  it("the same seed yields the same spin sequence", () => {
+    const a = createRng("82-0-daily-2026-08-09");
+    const b = createRng("82-0-daily-2026-08-09");
+    const seqA = Array.from({ length: 10 }, () => a());
+    const seqB = Array.from({ length: 10 }, () => b());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it("different days yield different sequences", () => {
+    const a = createRng(dailyWheelSeed(new Date(2026, 7, 9)));
+    const b = createRng(dailyWheelSeed(new Date(2026, 7, 10)));
+    expect(a()).not.toBe(b());
+  });
+
+  it("seed string is date-stamped", () => {
+    expect(dailyWheelSeed(new Date(2026, 7, 9))).toBe("82-0-daily-2026-08-09");
   });
 });
 

--- a/client/src/lib/eightyTwoZeroSim.ts
+++ b/client/src/lib/eightyTwoZeroSim.ts
@@ -63,6 +63,44 @@ export function strengthRating(lineup: EraPlayer[]): RatingBreakdown {
   return { base, rimProtectionPenalty, playmakingPenalty, reboundPenalty, usageTax, total };
 }
 
+/** Regular-season month buckets; game counts sum to 82. */
+export const SEASON_MONTHS: { label: string; games: number }[] = [
+  { label: "OCT", games: 8 },
+  { label: "NOV", games: 15 },
+  { label: "DEC", games: 14 },
+  { label: "JAN", games: 15 },
+  { label: "FEB", games: 11 },
+  { label: "MAR", games: 15 },
+  { label: "APR", games: 4 },
+];
+
+export interface MonthSplit {
+  label: string;
+  wins: number;
+  losses: number;
+}
+
+export function monthlySplits(lossGames: SeasonLoss[]): MonthSplit[] {
+  const lossNumbers = new Set(lossGames.map((l) => l.gameNumber));
+  const splits: MonthSplit[] = [];
+  let game = 0;
+  for (const month of SEASON_MONTHS) {
+    let losses = 0;
+    for (let i = 0; i < month.games; i++) {
+      game++;
+      if (lossNumbers.has(game)) losses++;
+    }
+    splits.push({ label: month.label, wins: month.games - losses, losses });
+  }
+  return splits;
+}
+
+/** Win/loss for each of the 82 games in order — drives the season-reveal strip. */
+export function gameStrip(result: SeasonResult): boolean[] {
+  const lossNumbers = new Set(result.lossGames.map((l) => l.gameNumber));
+  return Array.from({ length: GAMES }, (_, i) => !lossNumbers.has(i + 1));
+}
+
 function fnv1a(str: string): number {
   let h = 0x811c9dc5;
   for (let i = 0; i < str.length; i++) {
@@ -117,6 +155,48 @@ export function verdictFor(wins: number): string {
   if (wins >= 50) return "A solid playoff team. You were asked for a perfect one.";
   if (wins >= 35) return "Play-in territory. Someone drafted for vibes.";
   return "The lottery balls thank you for your service.";
+}
+
+// ── Draft-time coverage hints ───────────────────────────────
+
+export interface DraftCoverage {
+  rawStrength: number;
+  hasCenter: boolean;
+  hasGuard: boolean;
+  onPaceAssists: boolean;
+  onPaceRebounds: boolean;
+}
+
+/** Coverage checks scale to how many slots are filled so hints stay honest mid-draft. */
+export function draftCoverage(picked: EraPlayer[]): DraftCoverage {
+  const filled = Math.max(1, picked.length);
+  const totalAst = picked.reduce((s, pl) => s + pl.ast, 0);
+  const totalReb = picked.reduce((s, pl) => s + pl.reb, 0);
+  return {
+    rawStrength: picked.reduce((s, pl) => s + playerScore(pl), 0),
+    hasCenter: picked.some((pl) => pl.pos === "C"),
+    hasGuard: picked.some((pl) => pl.pos === "G"),
+    onPaceAssists: totalAst >= (15 * filled) / 5,
+    onPaceRebounds: totalReb >= (35 * filled) / 5,
+  };
+}
+
+// ── Seeded spinning (Daily Wheel) ───────────────────────────
+
+/** Deterministic RNG stream; the Daily Wheel gives every visitor the same spins. */
+export function createRng(seedString: string): () => number {
+  return mulberry32(fnv1a(seedString));
+}
+
+export function dailyWheelSeed(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `82-0-daily-${y}-${m}-${d}`;
+}
+
+export function dailyWheelLabel(date: Date = new Date()): string {
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 // ── Spin helpers ────────────────────────────────────────────

--- a/client/src/pages/EightyTwoZero.tsx
+++ b/client/src/pages/EightyTwoZero.tsx
@@ -1,12 +1,19 @@
 // 82-0 Challenge — spin an era, draft a five, chase the perfect season
-// Best record persisted at localStorage key "hoops-82-0-best"
+// localStorage: "hoops-82-0-best" (best record), "hoops-82-0-history" (recent
+// runs), "hoops-82-0-daily" (today's best on the Daily Wheel)
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ToolPageLayout from "../components/ToolPageLayout";
 import ShareButton from "../components/ShareButton";
 import { ERA_LABELS, type EraPlayer, type TeamEraPool } from "../lib/eightyTwoZeroData";
 import {
   availablePlayers,
+  createRng,
+  dailyWheelLabel,
+  dailyWheelSeed,
+  draftCoverage,
+  gameStrip,
+  monthlySplits,
   randomPool,
   respinEra,
   respinTeam,
@@ -17,29 +24,50 @@ import {
 import { getTeamColor, getTeamName, readableTextOn } from "../lib/teamColors";
 
 const BEST_KEY = "hoops-82-0-best";
+const HISTORY_KEY = "hoops-82-0-history";
+const DAILY_KEY = "hoops-82-0-daily";
 const SLOT_COUNT = 5;
+const HISTORY_LIMIT = 5;
+const SPIN_MS = 650;
+const SPIN_TICK_MS = 70;
+const REVEAL_TICK_MS = 24;
 
-interface BestRecord {
+type Mode = "free" | "daily";
+
+interface RunRecord {
   wins: number;
   losses: number;
   lineup: string[];
+  mode: Mode;
 }
 
-function loadBest(): BestRecord | null {
+interface DailyRecord extends RunRecord {
+  seed: string;
+}
+
+function loadJson<T>(key: string): T | null {
   try {
-    const raw = localStorage.getItem(BEST_KEY);
-    if (raw) return JSON.parse(raw) as BestRecord;
+    const raw = localStorage.getItem(key);
+    if (raw) return JSON.parse(raw) as T;
   } catch {
     // ignore
   }
   return null;
 }
 
-function saveBest(record: BestRecord) {
+function saveJson(key: string, value: unknown) {
   try {
-    localStorage.setItem(BEST_KEY, JSON.stringify(record));
+    localStorage.setItem(key, JSON.stringify(value));
   } catch {
     // ignore
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
   }
 }
 
@@ -50,67 +78,189 @@ function statLine(pl: EraPlayer): string {
   return parts.join(" · ");
 }
 
+function CoverageChip({ ok, okLabel, needLabel }: { ok: boolean; okLabel: string; needLabel: string }) {
+  return (
+    <span
+      className="mono-data text-[10px] px-2 py-0.5 rounded-full border"
+      style={{
+        borderColor: ok ? "rgba(16,185,129,0.5)" : "rgba(245,158,11,0.5)",
+        color: ok ? "#10B981" : "#F59E0B",
+        background: ok ? "rgba(16,185,129,0.08)" : "rgba(245,158,11,0.08)",
+      }}
+    >
+      {ok ? `✓ ${okLabel}` : `△ ${needLabel}`}
+    </span>
+  );
+}
+
 export default function EightyTwoZero() {
+  const [mode, setMode] = useState<Mode>("free");
   const [slots, setSlots] = useState<LineupSlot[]>([]);
   const [pool, setPool] = useState<TeamEraPool>(() => randomPool());
+  const [displayPool, setDisplayPool] = useState<TeamEraPool | null>(null);
+  const [spinning, setSpinning] = useState(false);
   const [teamRespinUsed, setTeamRespinUsed] = useState(false);
   const [eraRespinUsed, setEraRespinUsed] = useState(false);
   const [result, setResult] = useState<SeasonResult | null>(null);
-  const [best, setBest] = useState<BestRecord | null>(() => loadBest());
+  const [revealed, setRevealed] = useState(0);
+  const [best, setBest] = useState<RunRecord | null>(() => loadJson<RunRecord>(BEST_KEY));
+  const [history, setHistory] = useState<RunRecord[]>(() => loadJson<RunRecord[]>(HISTORY_KEY) ?? []);
+  const [daily, setDaily] = useState<DailyRecord | null>(() => {
+    const stored = loadJson<DailyRecord>(DAILY_KEY);
+    return stored && stored.seed === dailyWheelSeed() ? stored : null;
+  });
 
-  const choices = availablePlayers(pool, slots);
+  const rngRef = useRef<() => number>(Math.random);
+  const spinTimers = useRef<number[]>([]);
+  const revealTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      spinTimers.current.forEach((t) => window.clearInterval(t));
+      if (revealTimer.current !== null) window.clearInterval(revealTimer.current);
+    };
+  }, []);
+
+  function clearSpinTimers() {
+    spinTimers.current.forEach((t) => window.clearInterval(t));
+    spinTimers.current = [];
+  }
+
+  function spinTo(next: TeamEraPool) {
+    clearSpinTimers();
+    if (prefersReducedMotion()) {
+      setPool(next);
+      return;
+    }
+    setSpinning(true);
+    // Cycle cosmetic pools fast, then settle on the real one.
+    const cycle = window.setInterval(() => setDisplayPool(randomPool()), SPIN_TICK_MS);
+    const settle = window.setTimeout(() => {
+      window.clearInterval(cycle);
+      spinTimers.current = spinTimers.current.filter((t) => t !== cycle);
+      setDisplayPool(null);
+      setPool(next);
+      setSpinning(false);
+    }, SPIN_MS);
+    spinTimers.current.push(cycle, settle as unknown as number);
+  }
+
+  function drawPool(taken: LineupSlot[]): TeamEraPool {
+    let next = randomPool(rngRef.current);
+    for (let i = 0; i < 20 && availablePlayers(next, taken).length === 0; i++) {
+      next = randomPool(rngRef.current);
+    }
+    return next;
+  }
 
   function nextSpin(taken: LineupSlot[]) {
-    let next = randomPool();
-    // A spin with zero pickable players (all already drafted) is a dead end — reroll.
-    for (let i = 0; i < 20 && availablePlayers(next, taken).length === 0; i++) {
-      next = randomPool();
-    }
-    setPool(next);
     setTeamRespinUsed(false);
     setEraRespinUsed(false);
+    spinTo(drawPool(taken));
+  }
+
+  function startRun(nextMode: Mode) {
+    setMode(nextMode);
+    rngRef.current = nextMode === "daily" ? createRng(dailyWheelSeed()) : Math.random;
+    setSlots([]);
+    setResult(null);
+    setRevealed(0);
+    if (revealTimer.current !== null) {
+      window.clearInterval(revealTimer.current);
+      revealTimer.current = null;
+    }
+    nextSpin([]);
+  }
+
+  function beginReveal() {
+    if (prefersReducedMotion()) {
+      setRevealed(82);
+      return;
+    }
+    setRevealed(0);
+    const timer = window.setInterval(() => {
+      setRevealed((n) => {
+        if (n + 1 >= 82) {
+          window.clearInterval(timer);
+          revealTimer.current = null;
+          return 82;
+        }
+        return n + 1;
+      });
+    }, REVEAL_TICK_MS);
+    revealTimer.current = timer;
+  }
+
+  function skipReveal() {
+    if (revealTimer.current !== null) {
+      window.clearInterval(revealTimer.current);
+      revealTimer.current = null;
+    }
+    setRevealed(82);
+  }
+
+  function recordRun(season: SeasonResult, taken: LineupSlot[]) {
+    const run: RunRecord = { wins: season.wins, losses: season.losses, lineup: taken.map((s) => s.player.name), mode };
+    if (!best || season.wins > best.wins) {
+      saveJson(BEST_KEY, run);
+      setBest(run);
+    }
+    const nextHistory = [run, ...history].slice(0, HISTORY_LIMIT);
+    saveJson(HISTORY_KEY, nextHistory);
+    setHistory(nextHistory);
+    if (mode === "daily" && (!daily || season.wins > daily.wins)) {
+      const dailyRun: DailyRecord = { ...run, seed: dailyWheelSeed() };
+      saveJson(DAILY_KEY, dailyRun);
+      setDaily(dailyRun);
+    }
   }
 
   function pickPlayer(player: EraPlayer) {
+    if (spinning || result) return;
     const taken = [...slots, { player, team: pool.team, era: pool.era }];
     setSlots(taken);
     if (taken.length === SLOT_COUNT) {
       const season = simulateSeason(taken.map((s) => s.player));
       setResult(season);
-      if (!best || season.wins > best.wins) {
-        const record = { wins: season.wins, losses: season.losses, lineup: taken.map((s) => s.player.name) };
-        saveBest(record);
-        setBest(record);
-      }
+      recordRun(season, taken);
+      beginReveal();
     } else {
       nextSpin(taken);
     }
   }
 
   function handleRespinTeam() {
-    if (teamRespinUsed) return;
+    if (teamRespinUsed || spinning) return;
     setTeamRespinUsed(true);
-    let next = respinTeam(pool);
+    let next = respinTeam(pool, rngRef.current);
     for (let i = 0; i < 20 && availablePlayers(next, slots).length === 0; i++) {
-      next = respinTeam(pool);
+      next = respinTeam(pool, rngRef.current);
     }
-    setPool(next);
+    spinTo(next);
   }
 
   function handleRespinEra() {
-    if (eraRespinUsed) return;
+    if (eraRespinUsed || spinning) return;
     setEraRespinUsed(true);
-    const next = respinEra(pool);
-    if (availablePlayers(next, slots).length > 0) setPool(next);
+    const next = respinEra(pool, rngRef.current);
+    if (availablePlayers(next, slots).length > 0) spinTo(next);
   }
 
-  function reset() {
-    setSlots([]);
-    setResult(null);
-    nextSpin([]);
-  }
+  const shownPool = spinning && displayPool ? displayPool : pool;
+  const teamColor = getTeamColor(shownPool.team);
+  const choices = availablePlayers(pool, slots);
+  const coverage = draftCoverage(slots.map((s) => s.player));
+  const strip = result ? gameStrip(result) : [];
+  const revealedWins = strip.slice(0, revealed).filter(Boolean).length;
+  const revealDone = result !== null && revealed >= 82;
+  const splits = result ? monthlySplits(result.lossGames) : [];
+  const perfect = result?.wins === 82;
 
-  const teamColor = getTeamColor(pool.team);
+  const shareText = result
+    ? mode === "daily"
+      ? `The 82-0 Daily Wheel (${dailyWheelLabel()}) gave me ${slots.map((s) => s.player.name).join(", ")} — they went ${result.wins}–${result.losses}. Spin the same wheel → hoopsintel.net/82-0`
+      : `My five went ${result.wins}–${result.losses} in the 82-0 Challenge: ${slots.map((s) => s.player.name).join(", ")}. Beat that → hoopsintel.net/82-0`
+    : "";
 
   return (
     <ToolPageLayout
@@ -123,23 +273,54 @@ export default function EightyTwoZero() {
       <h1 className="display-heading text-2xl sm:text-3xl mb-3" style={{ color: "var(--hi-heading,#fff)" }}>
         Can your five go 82-0?
       </h1>
-      <p className="text-sm mb-6 max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted,rgba(255,255,255,0.6))" }}>
-        Spin a franchise and an era, draft one player, repeat until you have a starting five. Then we simulate a full
+      <p className="text-sm mb-4 max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted,rgba(255,255,255,0.6))" }}>
+        Spin a franchise and an era, draft one player, repeat until you have a starting five. Then we play out a full
         82-game season against history&apos;s buzzsaws. One team re-spin and one era re-spin per slot — spend them
         wisely. Same five, same record, every time: no take-backs, no lucky reruns.
       </p>
 
+      {/* Mode toggle */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
+        <button
+          type="button"
+          onClick={() => startRun("free")}
+          className="desk-section-pill"
+          data-active={mode === "free" ? "true" : undefined}
+        >
+          Free spin
+        </button>
+        <button
+          type="button"
+          onClick={() => startRun("daily")}
+          className="desk-section-pill"
+          data-active={mode === "daily" ? "true" : undefined}
+        >
+          Daily Wheel · {dailyWheelLabel()}
+        </button>
+        {mode === "daily" && (
+          <span className="text-[11px]" style={{ color: "rgba(255,255,255,0.45)" }}>
+            Everyone gets the same spins today — the draft is on you.
+          </span>
+        )}
+        {daily && (
+          <span className="mono-data text-[11px] ml-auto" style={{ color: "rgba(255,255,255,0.45)" }}>
+            TODAY&apos;S WHEEL BEST: {daily.wins}–{daily.losses}
+          </span>
+        )}
+      </div>
+
       {/* Lineup rail */}
-      <div className="grid grid-cols-5 gap-2 mb-8" aria-label="Your starting five">
+      <div className="grid grid-cols-5 gap-2 mb-3" aria-label="Your starting five">
         {Array.from({ length: SLOT_COUNT }, (_, i) => {
           const slot = slots[i];
           const color = slot ? getTeamColor(slot.team) : "rgba(255,255,255,0.08)";
+          const isNext = !slot && i === slots.length && !result;
           return (
             <div
               key={i}
               className="rounded-lg border p-2 min-h-[84px] flex flex-col justify-between"
               style={{
-                borderColor: slot ? color : "rgba(255,255,255,0.12)",
+                borderColor: slot ? color : isNext ? "rgba(14,165,233,0.5)" : "rgba(255,255,255,0.12)",
                 background: slot ? `${color}22` : "rgba(255,255,255,0.03)",
               }}
             >
@@ -156,8 +337,8 @@ export default function EightyTwoZero() {
                   </div>
                 </div>
               ) : (
-                <div className="text-[11px]" style={{ color: "rgba(255,255,255,0.3)" }}>
-                  Empty
+                <div className="text-[11px]" style={{ color: isNext ? "#0EA5E9" : "rgba(255,255,255,0.3)" }}>
+                  {isNext ? "On the clock" : "Empty"}
                 </div>
               )}
             </div>
@@ -165,76 +346,164 @@ export default function EightyTwoZero() {
         })}
       </div>
 
-      {result ? (
-        /* ── Season results ── */
-        <div className="rounded-2xl border border-white/10 p-6 sm:p-8 text-center" style={{ background: "rgba(255,255,255,0.03)" }}>
-          <p className="section-label mb-2">FINAL RECORD</p>
-          <div
-            className="mono-data font-bold text-6xl sm:text-7xl mb-3"
-            style={{ color: result.wins === 82 ? "#F59E0B" : result.wins >= 73 ? "#10B981" : result.wins >= 50 ? "#0EA5E9" : "#F43F5E" }}
-          >
-            {result.wins}–{result.losses}
-          </div>
-          <p className="text-sm mb-6 max-w-md mx-auto" style={{ color: "rgba(255,255,255,0.7)" }}>
-            {result.verdict}
-          </p>
-
-          <div className="mono-data text-xs mb-6" style={{ color: "rgba(255,255,255,0.45)" }}>
-            STRENGTH RATING {Math.round(result.rating.total)}
-            {result.rating.total < result.rating.base && (
-              <span> (base {Math.round(result.rating.base)} − {Math.round(result.rating.base - result.rating.total)} balance penalties)</span>
-            )}
-          </div>
-
-          {result.lossGames.length > 0 && (
-            <div className="max-w-sm mx-auto mb-6 text-left">
-              <p className="section-label mb-2 text-center">THE NIGHTS IT DIED</p>
-              <ul className="space-y-1">
-                {result.lossGames.slice(0, 8).map((loss) => (
-                  <li key={loss.gameNumber} className="mono-data text-xs flex justify-between" style={{ color: "rgba(255,255,255,0.55)" }}>
-                    <span style={{ color: "#F43F5E" }}>L — Game {loss.gameNumber}</span>
-                    <span>vs the {loss.opponent}</span>
-                  </li>
-                ))}
-                {result.lossGames.length > 8 && (
-                  <li className="mono-data text-xs text-center" style={{ color: "rgba(255,255,255,0.35)" }}>
-                    …and {result.lossGames.length - 8} more
-                  </li>
-                )}
-              </ul>
+      {/* Draft strength meter */}
+      {!result && slots.length > 0 && (
+        <div className="mb-8 flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2 min-w-[180px] flex-1 max-w-xs">
+            <span className="mono-data text-[10px]" style={{ color: "rgba(255,255,255,0.4)" }}>
+              RAW STRENGTH
+            </span>
+            <div className="flex-1 h-1.5 rounded-full bg-white/10 overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all duration-500"
+                style={{ width: `${Math.min(100, (coverage.rawStrength / 240) * 100)}%`, background: "#0EA5E9" }}
+              />
             </div>
-          )}
+            <span className="mono-data text-xs font-bold" style={{ color: "#0EA5E9" }}>
+              {Math.round(coverage.rawStrength)}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            <CoverageChip ok={coverage.hasCenter} okLabel="Rim protected" needLabel="No center" />
+            <CoverageChip ok={coverage.hasGuard} okLabel="Backcourt set" needLabel="No guard" />
+            <CoverageChip ok={coverage.onPaceAssists} okLabel="Ball moves" needLabel="Light playmaking" />
+            <CoverageChip ok={coverage.onPaceRebounds} okLabel="Owns the glass" needLabel="Thin on boards" />
+          </div>
+        </div>
+      )}
+      {!result && slots.length === 0 && <div className="mb-5" />}
 
-          <div className="flex flex-wrap items-center justify-center gap-3">
+      {result ? (
+        /* ── Season reveal + results ── */
+        <div
+          className="rounded-2xl border p-6 sm:p-8 text-center"
+          style={{
+            background: "rgba(255,255,255,0.03)",
+            borderColor: perfect && revealDone ? "rgba(245,158,11,0.6)" : "rgba(255,255,255,0.1)",
+          }}
+        >
+          <p className="section-label mb-2">{revealDone ? "FINAL RECORD" : "SEASON IN PROGRESS"}</p>
+          <div
+            className={`mono-data font-bold text-6xl sm:text-7xl mb-4 ${perfect && revealDone ? "animate-pulse" : ""}`}
+            role="status"
+            style={{
+              color: revealDone
+                ? perfect
+                  ? "#F59E0B"
+                  : result.wins >= 73
+                    ? "#10B981"
+                    : result.wins >= 50
+                      ? "#0EA5E9"
+                      : "#F43F5E"
+                : "rgba(255,255,255,0.85)",
+            }}
+          >
+            {revealedWins}–{revealed - revealedWins}
+          </div>
+
+          {/* 82-game strip */}
+          <div className="flex flex-wrap justify-center gap-1 max-w-lg mx-auto mb-4" aria-hidden>
+            {strip.map((won, i) => {
+              const shown = i < revealed;
+              const loss = result.lossGames.find((l) => l.gameNumber === i + 1);
+              return (
+                <span
+                  key={i}
+                  title={shown && loss ? `Game ${loss.gameNumber}: L vs the ${loss.opponent}` : undefined}
+                  className="rounded-sm"
+                  style={{
+                    width: 10,
+                    height: 14,
+                    background: !shown ? "rgba(255,255,255,0.08)" : won ? "#10B981" : "#F43F5E",
+                    transition: "background 120ms",
+                  }}
+                />
+              );
+            })}
+          </div>
+
+          {!revealDone ? (
             <button
               type="button"
-              onClick={reset}
-              className="min-h-[44px] px-6 rounded-xl font-bold text-sm"
-              style={{ background: "#0EA5E9", color: "#050D1A" }}
+              onClick={skipReveal}
+              className="mono-data text-xs underline"
+              style={{ color: "rgba(255,255,255,0.5)" }}
             >
-              Run it back
+              Skip to the final record
             </button>
-            <ShareButton
-              tweetText={`My five went ${result.wins}–${result.losses} in the 82-0 Challenge: ${slots
-                .map((s) => s.player.name)
-                .join(", ")}. Beat that → hoopsintel.net/82-0`}
-              size="md"
-            />
-          </div>
+          ) : (
+            <>
+              {/* Monthly splits */}
+              <div className="mono-data text-[11px] mb-4 flex flex-wrap justify-center gap-x-3 gap-y-1" style={{ color: "rgba(255,255,255,0.5)" }}>
+                {splits.map((s) => (
+                  <span key={s.label}>
+                    {s.label}{" "}
+                    <span style={{ color: s.losses === 0 ? "#10B981" : "#F43F5E" }}>
+                      {s.wins}-{s.losses}
+                    </span>
+                  </span>
+                ))}
+              </div>
+
+              <p className="text-sm mb-5 max-w-md mx-auto" style={{ color: "rgba(255,255,255,0.7)" }}>
+                {result.verdict}
+              </p>
+
+              <div className="mono-data text-xs mb-6" style={{ color: "rgba(255,255,255,0.45)" }}>
+                STRENGTH RATING {Math.round(result.rating.total)}
+                {result.rating.total < result.rating.base && (
+                  <span> (base {Math.round(result.rating.base)} − {Math.round(result.rating.base - result.rating.total)} balance penalties)</span>
+                )}
+              </div>
+
+              {result.lossGames.length > 0 && (
+                <div className="max-w-sm mx-auto mb-6 text-left">
+                  <p className="section-label mb-2 text-center">THE NIGHTS IT DIED</p>
+                  <ul className="space-y-1">
+                    {result.lossGames.slice(0, 8).map((loss) => (
+                      <li key={loss.gameNumber} className="mono-data text-xs flex justify-between" style={{ color: "rgba(255,255,255,0.55)" }}>
+                        <span style={{ color: "#F43F5E" }}>L — Game {loss.gameNumber}</span>
+                        <span>vs the {loss.opponent}</span>
+                      </li>
+                    ))}
+                    {result.lossGames.length > 8 && (
+                      <li className="mono-data text-xs text-center" style={{ color: "rgba(255,255,255,0.35)" }}>
+                        …and {result.lossGames.length - 8} more
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              )}
+
+              <div className="flex flex-wrap items-center justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => startRun(mode)}
+                  className="min-h-[44px] px-6 rounded-xl font-bold text-sm"
+                  style={{ background: "#0EA5E9", color: "#050D1A" }}
+                >
+                  Run it back
+                </button>
+                <ShareButton tweetText={shareText} size="md" />
+              </div>
+            </>
+          )}
         </div>
       ) : (
         /* ── Spin + pick ── */
         <div className="rounded-2xl border border-white/10 overflow-hidden" style={{ background: "rgba(255,255,255,0.03)" }}>
           <div
             className="px-5 py-4 flex flex-wrap items-center justify-between gap-3"
-            style={{ background: `${teamColor}33`, borderBottom: `2px solid ${teamColor}` }}
+            style={{ background: `${teamColor}33`, borderBottom: `2px solid ${teamColor}`, transition: "background 120ms, border-color 120ms" }}
           >
             <div>
-              <p className="section-label mb-1">SLOT {slots.length + 1} OF {SLOT_COUNT} — THE WHEEL SAYS</p>
-              <div className="display-heading text-xl sm:text-2xl" style={{ color: "var(--hi-heading,#fff)" }}>
-                {getTeamName(pool.team)}{" "}
+              <p className="section-label mb-1">
+                SLOT {slots.length + 1} OF {SLOT_COUNT} — {spinning ? "SPINNING…" : "THE WHEEL SAYS"}
+              </p>
+              <div className="display-heading text-xl sm:text-2xl" style={{ color: "var(--hi-heading,#fff)" }} aria-live="polite">
+                {getTeamName(shownPool.team)}{" "}
                 <span className="mono-data text-sm align-middle px-2 py-0.5 rounded" style={{ background: teamColor, color: readableTextOn(teamColor) }}>
-                  {ERA_LABELS[pool.era]}
+                  {ERA_LABELS[shownPool.era]}
                 </span>
               </div>
             </div>
@@ -242,7 +511,7 @@ export default function EightyTwoZero() {
               <button
                 type="button"
                 onClick={handleRespinTeam}
-                disabled={teamRespinUsed}
+                disabled={teamRespinUsed || spinning}
                 className="min-h-[40px] px-3 rounded-lg text-xs font-bold border border-white/20 disabled:opacity-30"
                 style={{ color: "rgba(255,255,255,0.85)" }}
               >
@@ -251,7 +520,7 @@ export default function EightyTwoZero() {
               <button
                 type="button"
                 onClick={handleRespinEra}
-                disabled={eraRespinUsed}
+                disabled={eraRespinUsed || spinning}
                 className="min-h-[40px] px-3 rounded-lg text-xs font-bold border border-white/20 disabled:opacity-30"
                 style={{ color: "rgba(255,255,255,0.85)" }}
               >
@@ -260,13 +529,14 @@ export default function EightyTwoZero() {
             </div>
           </div>
 
-          <div className="p-5 grid gap-3 sm:grid-cols-3">
-            {choices.map((pl) => (
+          <div className="p-5 grid gap-3 sm:grid-cols-3" style={{ opacity: spinning ? 0.35 : 1, transition: "opacity 150ms" }}>
+            {(spinning ? shownPool.players : choices).map((pl) => (
               <button
                 key={pl.name}
                 type="button"
                 onClick={() => pickPlayer(pl)}
-                className="text-left rounded-xl border border-white/10 p-4 transition-colors hover:border-sky-500/60 focus-visible:ring-2 focus-visible:ring-sky-500/50 outline-none"
+                disabled={spinning}
+                className="text-left rounded-xl border border-white/10 p-4 transition-colors hover:border-sky-500/60 focus-visible:ring-2 focus-visible:ring-sky-500/50 outline-none disabled:cursor-default"
                 style={{ background: "rgba(255,255,255,0.04)" }}
               >
                 <div className="flex items-center justify-between mb-1">
@@ -286,10 +556,31 @@ export default function EightyTwoZero() {
         </div>
       )}
 
-      {best && (
-        <p className="mono-data text-xs mt-6" style={{ color: "rgba(255,255,255,0.4)" }}>
-          YOUR BEST: {best.wins}–{best.losses} ({best.lineup.join(", ")})
-        </p>
+      {/* Best + recent runs */}
+      {(best || history.length > 0) && (
+        <div className="mt-8">
+          {best && (
+            <p className="mono-data text-xs mb-2" style={{ color: "rgba(255,255,255,0.4)" }}>
+              YOUR BEST: {best.wins}–{best.losses} ({best.lineup.join(", ")})
+            </p>
+          )}
+          {history.length > 0 && (
+            <div>
+              <p className="section-label mb-2">RECENT RUNS</p>
+              <ul className="space-y-1">
+                {history.map((run, i) => (
+                  <li key={i} className="mono-data text-xs flex flex-wrap gap-x-2" style={{ color: "rgba(255,255,255,0.5)" }}>
+                    <span style={{ color: run.wins === 82 ? "#F59E0B" : run.wins >= 73 ? "#10B981" : "rgba(255,255,255,0.75)" }}>
+                      {run.wins}–{run.losses}
+                    </span>
+                    {run.mode === "daily" && <span style={{ color: "#0EA5E9" }}>[daily]</span>}
+                    <span>{run.lineup.join(", ")}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
       )}
     </ToolPageLayout>
   );


### PR DESCRIPTION
## Summary

Follow-up to #306 — makes the 82-0 Challenge feel like the viral game instead of a form:

- **Spin animation** — the wheel visibly cycles franchises/eras for ~650ms before settling; player cards dim and lock while it spins.
- **Season reveal** — instead of an instant record, the 82-game season plays out as an animated strip (win/loss cells) with a live record ticker and a "skip to the final record" control. Loss cells carry opponent tooltips.
- **Draft strength meter** — a live raw-strength bar plus coverage chips (rim protection, backcourt, playmaking pace, rebounding pace) that warn about the sim's balance penalties while you still have picks left.
- **Daily Wheel mode** — a date-seeded spin sequence (`createRng`/`dailyWheelSeed`) so every visitor gets the same spins each day; today's best persists locally. Free-spin mode unchanged.
- **Monthly splits** (`monthlySplits`/`SEASON_MONTHS`, Oct–Apr buckets summing to 82) shown under the final record.
- **Recent-run history** (last 5, with daily tags) and mode-aware share text.
- Both animations honor `prefers-reduced-motion`.

Verified in the built app with Playwright: spin → draft → reveal flow, and Daily Wheel determinism (two identical drafts produced identical 72–10 seasons).

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (269/269, 8 new sim-helper tests)
- [ ] Vercel Preview looks correct for UI changes (verified locally via `vite preview` + Playwright)
- [x] New secrets documented in `.env.example` / `README.md` if applicable — none added

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeFt9Zbn4pwKhxWZwxCKdN)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enhance the 82-0 Challenge with daily mode, animated spins, draft coverage, and season reveal
> - Adds a **daily mode** to [EightyTwoZero.tsx](https://github.com/hondoentertainment/hoops-intel/pull/308/files#diff-89e02075b83166ef3882c7d20d45c9b4ea781469df734985ed9e23f7b48a7d6d) that uses a deterministic RNG seeded per calendar day via `dailyWheelSeed()`, so all users see the same spin sequence each day.
> - Adds animated spin transitions with reduced-motion support; interactions are disabled while spinning and timers are cleaned up via `useEffect`.
> - Introduces a mid-draft **coverage meter** powered by `draftCoverage()`, showing raw strength, role presence (center/guard), and pace thresholds for assists and rebounds.
> - Adds an 82-game **reveal strip** after season simulation using `gameStrip()`, followed by a `monthlySplits()` summary, verdict, and loss list.
> - Persists best run, recent history, and per-day daily best to separate `localStorage` keys; daily share text includes the date label from `dailyWheelLabel()`.
> - Adds supporting utilities (`createRng`, `monthlySplits`, `gameStrip`, `draftCoverage`, `dailyWheelSeed`, `SEASON_MONTHS`) to [eightyTwoZeroSim.ts](https://github.com/hondoentertainment/hoops-intel/pull/308/files#diff-2580abac937109940fe0126cabb82015e4cc04273baa430b203eb489c04d541e) with full test coverage in [eightyTwoZeroSim.test.ts](https://github.com/hondoentertainment/hoops-intel/pull/308/files#diff-570095c9490cd81dd1a2ced8261c5f5eae3390b21f66f2672d7f1b5182ef7f72).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f4302e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->