### PR TITLE
Align August 10 game-results date

### DIFF
--- a/client/src/lib/pulseData.ts
+++ b/client/src/lib/pulseData.ts
@@ -33,7 +33,7 @@ export const tickerItems = [
   {text:"NEWS: 82-0 Challenge live at hoopsintel.net/82-0 — spin eras, draft a five, chase the perfect season",type:"news"}
 ];
 
-// GAME RESULTS — No Games (August 9, 2026)
+// GAME RESULTS — No Games (August 10, 2026)
 export const gameResults = [];
 
 // ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- align the no-games results label with the August 10, 2026 edition metadata
- remove the final stale August 9 reference from the primary daily edition

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (269 tests)
- [ ] Vercel Preview looks correct for UI changes
- [x] New secrets documented in `.env.example` / `README.md` if applicable (N/A)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77127c37-0a6b-4f81-bd0f-2359be20f736?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77127c37-0a6b-4f81-bd0f-2359be20f736&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inline comment date label in `pulseData.ts` from August 9 to August 10
> Corrects a mislabeled inline comment in [pulseData.ts](https://github.com/hondoentertainment/hoops-intel/pull/310/files#diff-7673238a4750413989b6fcc0aa9414bf40680dee5972af2b04e5de65f166a014) that referred to 'No Games (August 9, 2026)' instead of 'No Games (August 10, 2026)'. No executable code or data is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ba09d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->