### PR TITLE
Refresh NEXT-STEPS to August 10 state

### DIFF
--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,6 +1,6 @@
 # Hoops Intel — Next steps (living doc)
 
-_Last revised: August 1, 2026 — see refreshed [`ROADMAP.md`](./ROADMAP.md)_
+_Last revised: August 10, 2026 — see refreshed [`ROADMAP.md`](./ROADMAP.md)_
 
 ### Deploy & reliability
 
@@ -35,23 +35,30 @@ buried five real deploy failures dating back to June.
 | Auto-close on recovery | `deployment-smoke`, `health-check`, `ops-readiness` now clear their own backlog | **Done** |
 | Site-review noise | Each day's report supersedes and closes the previous one | **Done** |
 | Health-check alert | `exit_code=$?` after a pipe read `tee`'s status, so the stale-content alert could never fire | **Fixed** (`PIPESTATUS[0]`) |
-| Assignee | Set repo variable **`ALERT_ASSIGNEE`** to a collaborator login | **Manual** — defaults to `github.repository_owner`, which is silently ignored if that's an org |
+| Assignee | Set repo variable **`ALERT_ASSIGNEE`** to a collaborator login | **Done** — resolves to `hondoentertainment` (confirmed in the Aug 10 ops-readiness run env) |
 | Slack | Set `SLACK_DATA_QUALITY_WEBHOOK` for out-of-band alerts | **Manual** — smoke failures post there today only if set |
 
 ### Dependencies
 
-The npm bump was deferred pending a green Vercel preview — now satisfied.
-
 | Step | Action | Status |
 |------|--------|--------|
-| Dependabot npm group | PR **#279** (9 updates) | **Verified, awaiting merge** — keeps `typescript@~6.0.3`; full suite, `vite build`, `dist/embed.js` and `typecheck:api` all pass against it |
-| jsdom 29 → 30 | Major bump of the vitest environment, bundled in #279 | **Verified** — 223/223 pass |
+| Dependabot npm group | PRs **#287** and **#311** | **Merged** (Aug 10) — keeps `typescript@~6.0.3`; #311 verified locally: 269/269 vitest, `vite build`, `dist/embed.js`, `typecheck:api` all pass |
+| jsdom 29 → 30 | Major bump of the vitest environment (landed via the group PRs) | **Merged** |
 
-Verified locally on Node 22; CI and Vercel run Node 24.
+Verified locally on Node 22; CI and Vercel run Node 24. The TS-majors
+Dependabot ignore rule remains in force (see standing constraint above).
 
 ### P0 — Ops (manual — still blocking live Pro/push)
 
 `/api/ops-readiness` must flip to ready. Until secrets land, code paths soft-skip.
+
+**Status Aug 10:** all six env groups still missing per the scheduled
+ops-readiness check — `stripe checkout, stripe webhook, push notify,
+supabase server, resend, anthropic` (tracker issue #129). Every row below
+is blocked on entering credentials; there is no code work left in P0.
+Note: the GitHub App used by remote agent sessions cannot dispatch
+workflows (403), so Actions → Supabase migrations / dry-run must be
+clicked by a maintainer.
 
 | Step | Action | Status |
 |------|--------|--------|
@@ -71,6 +78,7 @@ Verified locally on Node 22; CI and Vercel run Node 24.
 | Favorite-team **game-start** | Defaults + Account “Team tip alerts” + team refresh on Save topics |
 | Digest quiet hours | Wired in `email-digest.yml` (6–11 PT) + List-Unsubscribe header |
 | Multi-book consensus UI | `oddsBooksData` + Betting Intel; fills when Odds API fetch returns `books[]` |
+| **82-0 Challenge** (`/82-0`) | Era-spin lineup game with seeded season sim, animated reveal, Daily Wheel mode (#306, #308) |
 
 ### Deferred
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ Near-term sequencing lives in **`NEXT-STEPS.md`**. This document tracks **shippe
 
 ### Pages & Navigation
 - Player / team detail, Pulse History, Playoff Bracket, global search (Cmd+K)
-- Ask Hoops Intel (`/ask`), Pick'em, Trivia, Trade Value / Simulator
+- Ask Hoops Intel (`/ask`), Pick'em, Trivia, Trade Value / Simulator, 82-0 Challenge (`/82-0`)
 - Momentum, Clutch Factor, Lineup Intel, Sentiment Pulse
 - Draft Tracker, Ref Reports, Coach Corner, Community Pulse, Projections
 - Watch Guide, History Engine, Season Performance, Podcast Companion


### PR DESCRIPTION
## Summary

Docs-only refresh of the living punch list to match today's reality:

- **Dependencies** — replaces the stale #279 row: npm group PRs #287 and #311 are merged (Aug 10), TS stays pinned at `~6.0.3`, and #311 was verified locally before merge (269/269 vitest, `vite build`, `dist/embed.js`, `typecheck:api`).
- **Alerting** — `ALERT_ASSIGNEE` marked Done; it resolves to `hondoentertainment` (confirmed in the Aug 10 ops-readiness run env).
- **P0 Ops** — adds today's gap snapshot from the scheduled ops-readiness check: all six env groups (`stripe checkout, stripe webhook, push notify, supabase server, resend, anthropic`) still missing (tracker #129), with a note that remote agent sessions get 403 on workflow dispatch, so the Supabase migrations workflow must be run by a maintainer.
- **Shipped tables** — 82-0 Challenge added to NEXT-STEPS "Shipped product (this cycle)" and the ROADMAP pages list.

## Checklist

- [x] `npm run build` passes locally — N/A (docs only, no code changes)
- [x] `npm run test:unit` passes (or note why N/A) — N/A (docs only)
- [x] Vercel Preview looks correct for UI changes — N/A (docs only)
- [x] New secrets documented in `.env.example` / `README.md` if applicable — none added

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeFt9Zbn4pwKhxWZwxCKdN)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update NEXT-STEPS and ROADMAP to August 10 state
> - Updates [NEXT-STEPS.md](https://github.com/hondoentertainment/hoops-intel/pull/313/files#diff-d41777c935a0c563bdff6bce5aa79684b9b084d3357fa10f1640c668be3ceb58) revision date and marks several items as done or merged, including two Dependabot dependency PRs (#287, #311) and the jsdom 29→30 upgrade.
> - Adds a status note in P0 — Ops listing six missing environment groups and flagging that maintainers must manually trigger Supabase-related Actions workflows.
> - Adds the '82-0 Challenge' (`/82-0`) as a shipped product item referencing PRs #306 and #308.
> - Updates [ROADMAP.md](https://github.com/hondoentertainment/hoops-intel/pull/313/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51) to include '82-0 Challenge (`/82-0`)' in the Shipped pages list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2c62d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->