### PR TITLE
Site-wide SPA navigation with prefetching and scroll management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import PwaInstallPrompt from "./components/PwaInstallPrompt";
 import KeyboardShortcutsHelp from "./components/KeyboardShortcutsHelp";
 import RouteSeo from "./components/RouteSeo";
 import RouteErrorBoundary from "./components/RouteErrorBoundary";
+import SpaNavigator from "./components/SpaNavigator";
 import { incrementVisitCount } from "./lib/visitCount";
 import { syncEngagementBadges } from "./lib/badgeChecks";
 
@@ -124,6 +125,7 @@ export default function App() {
     <ThemeProvider switchable={true}>
       <ToastProvider>
       <RouteSeo />
+      <SpaNavigator />
       <SkipToContent />
       <VercelAnalyticsScript />
       <div

--- a/client/src/__tests__/spaNavigation.test.ts
+++ b/client/src/__tests__/spaNavigation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { NON_SPA_PATH_RE, recallScroll, rememberScroll, scrollKeyFor, shouldIntercept } from "../lib/spaNavigation";
+import { HOT_ROUTES, importerForPath } from "../lib/routePreload";
+
+const ORIGIN = "https://hoopsintel.net";
+
+const click = (overrides: Partial<Parameters<typeof shouldIntercept>[0]> = {}) => ({
+  button: 0,
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  defaultPrevented: false,
+  ...overrides,
+});
+
+const anchor = (overrides: Partial<Parameters<typeof shouldIntercept>[1]> = {}) => ({
+  origin: ORIGIN,
+  pathname: "/tools",
+  target: "",
+  hasDownload: false,
+  ...overrides,
+});
+
+describe("shouldIntercept", () => {
+  it("intercepts a plain same-origin route click", () => {
+    expect(shouldIntercept(click(), anchor(), ORIGIN)).toBe(true);
+  });
+
+  it("leaves modified clicks to the browser (new tab, etc.)", () => {
+    expect(shouldIntercept(click({ metaKey: true }), anchor(), ORIGIN)).toBe(false);
+    expect(shouldIntercept(click({ ctrlKey: true }), anchor(), ORIGIN)).toBe(false);
+    expect(shouldIntercept(click({ shiftKey: true }), anchor(), ORIGIN)).toBe(false);
+    expect(shouldIntercept(click({ button: 1 }), anchor(), ORIGIN)).toBe(false);
+  });
+
+  it("skips prevented, targeted, download, and cross-origin links", () => {
+    expect(shouldIntercept(click({ defaultPrevented: true }), anchor(), ORIGIN)).toBe(false);
+    expect(shouldIntercept(click(), anchor({ target: "_blank" }), ORIGIN)).toBe(false);
+    expect(shouldIntercept(click(), anchor({ hasDownload: true }), ORIGIN)).toBe(false);
+    expect(shouldIntercept(click(), anchor({ origin: "https://espn.com" }), ORIGIN)).toBe(false);
+  });
+
+  it("skips static files and API routes", () => {
+    for (const path of ["/feed.xml", "/sitemap.xml", "/robots.txt", "/embed.js", "/manifest.webmanifest", "/api/ask", "/og-image.svg"]) {
+      expect(shouldIntercept(click(), anchor({ pathname: path }), ORIGIN), path).toBe(false);
+    }
+  });
+
+  it("still intercepts routes whose names merely contain dots or api", () => {
+    expect(shouldIntercept(click(), anchor({ pathname: "/82-0" }), ORIGIN)).toBe(true);
+    expect(NON_SPA_PATH_RE.test("/rapid-city")).toBe(false);
+  });
+});
+
+describe("scroll memory", () => {
+  it("round-trips positions per path+search key", () => {
+    const key = scrollKeyFor("/archive", "?page=2");
+    rememberScroll(key, 640.6);
+    expect(recallScroll(key)).toBe(641);
+    expect(recallScroll(scrollKeyFor("/archive", ""))).toBeNull();
+  });
+});
+
+describe("route preload registry", () => {
+  it("resolves importers for hot routes and dynamic prefixes", () => {
+    for (const path of HOT_ROUTES) {
+      expect(importerForPath(path), path).toBeTypeOf("function");
+    }
+    expect(importerForPath("/player/jalen-brunson")).toBeTypeOf("function");
+    expect(importerForPath("/team/SAS")).toBeTypeOf("function");
+    expect(importerForPath("/game/LAL-HOU-20260418")).toBeTypeOf("function");
+  });
+
+  it("returns null for unknown and non-SPA paths", () => {
+    expect(importerForPath("/feed.xml")).toBeNull();
+    expect(importerForPath("/nonexistent")).toBeNull();
+  });
+});

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -478,6 +478,14 @@ export default function SiteHeader({
     void getUser().then(setSessionUser);
   }, []);
 
+  // Client-side navs don't reload the document, so overlays must close themselves.
+  useEffect(() => {
+    setMobileOpen(false);
+    document.querySelectorAll<HTMLDetailsElement>("header details[open]").forEach((d) => {
+      d.open = false;
+    });
+  }, [locationPath]);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement)?.tagName;

--- a/client/src/components/SpaNavigator.tsx
+++ b/client/src/components/SpaNavigator.tsx
@@ -1,0 +1,142 @@
+// SpaNavigator — turns the app's plain <a href> links into client-side
+// navigations with native-feeling scroll behavior and chunk prefetching.
+// Mounted once in App; renders nothing.
+
+import { useEffect, useRef } from "react";
+import { useLocation } from "wouter";
+import {
+  findAnchor,
+  recallScroll,
+  rememberScroll,
+  restoreScroll,
+  scrollKeyFor,
+  scrollToHash,
+  shouldIntercept,
+} from "../lib/spaNavigation";
+import { preloadHotRoutes, preloadRoute } from "../lib/routePreload";
+
+export default function SpaNavigator() {
+  const [location, navigate] = useLocation();
+  const pendingHash = useRef<string>("");
+  const lastPopTime = useRef(0);
+  const skipNextScrollEffect = useRef(true);
+
+  // Intercept qualifying link clicks and route them client-side.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      const anchor = findAnchor(e.target);
+      if (!anchor) return;
+      const ok = shouldIntercept(
+        e,
+        { origin: anchor.origin, pathname: anchor.pathname, target: anchor.target, hasDownload: anchor.hasAttribute("download") },
+        window.location.origin,
+      );
+      if (!ok) return;
+
+      e.preventDefault();
+      rememberScroll(scrollKeyFor(window.location.pathname, window.location.search), window.scrollY);
+
+      const samePage = anchor.pathname === window.location.pathname && anchor.search === window.location.search;
+      if (samePage) {
+        if (anchor.hash) {
+          history.replaceState(history.state, "", anchor.pathname + anchor.search + anchor.hash);
+          scrollToHash(anchor.hash);
+        }
+        return;
+      }
+
+      pendingHash.current = anchor.hash;
+      navigate(anchor.pathname + anchor.search + anchor.hash);
+    };
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, [navigate]);
+
+  // Own scroll restoration entirely — the browser's native popstate restore
+  // would race the custom one and win with stale positions.
+  useEffect(() => {
+    const prior = history.scrollRestoration;
+    history.scrollRestoration = "manual";
+    return () => {
+      history.scrollRestoration = prior;
+    };
+  }, []);
+
+  // Back/forward: restore the remembered position for the entry being
+  // re-entered. Restoration is driven from here (not the location effect)
+  // because wouter's own popstate handler can flush React synchronously,
+  // making listener/effect ordering unreliable. Double-rAF lands the restore
+  // after the re-entered page has painted.
+  useEffect(() => {
+    const onPop = () => {
+      lastPopTime.current = performance.now();
+      pendingHash.current = "";
+      const y = recallScroll(scrollKeyFor(window.location.pathname, window.location.search)) ?? 0;
+      requestAnimationFrame(() => requestAnimationFrame(() => restoreScroll(y)));
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  // Continuously remember where the reader is on the current entry.
+  useEffect(() => {
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      window.setTimeout(() => {
+        ticking = false;
+        rememberScroll(scrollKeyFor(window.location.pathname, window.location.search), window.scrollY);
+      }, 250);
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // After each push-style route change: jump to hash or start at top.
+  // Pop navigations are handled by the popstate listener above; the recency
+  // guard covers whichever order React flushes the two in.
+  useEffect(() => {
+    if (skipNextScrollEffect.current) {
+      // First mount — the browser already put us where we belong.
+      skipNextScrollEffect.current = false;
+      return;
+    }
+    if (performance.now() - lastPopTime.current < 500) return;
+    if (pendingHash.current) {
+      const hash = pendingHash.current;
+      pendingHash.current = "";
+      scrollToHash(hash);
+      return;
+    }
+    window.scrollTo(0, 0);
+  }, [location]);
+
+  // Warm the chunk for whatever link the pointer is considering.
+  useEffect(() => {
+    const onIntent = (e: Event) => {
+      const anchor = findAnchor(e.target);
+      if (!anchor || anchor.origin !== window.location.origin) return;
+      preloadRoute(anchor.pathname);
+    };
+    document.addEventListener("pointerover", onIntent, { passive: true });
+    document.addEventListener("touchstart", onIntent, { passive: true });
+    return () => {
+      document.removeEventListener("pointerover", onIntent);
+      document.removeEventListener("touchstart", onIntent);
+    };
+  }, []);
+
+  // Warm the most-travelled routes once the main thread is idle.
+  useEffect(() => {
+    const idle = (cb: () => void) =>
+      "requestIdleCallback" in window ? (window as Window & { requestIdleCallback: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback(cb, { timeout: 4000 }) : window.setTimeout(cb, 2500);
+    const handle = idle(preloadHotRoutes);
+    return () => {
+      if ("cancelIdleCallback" in window) (window as Window & { cancelIdleCallback: (h: number) => void }).cancelIdleCallback(handle as number);
+      else window.clearTimeout(handle as number);
+    };
+  }, []);
+
+  return null;
+}

--- a/client/src/lib/routePreload.ts
+++ b/client/src/lib/routePreload.ts
@@ -1,0 +1,84 @@
+// Route chunk preloading — Vite dedupes these dynamic imports against the
+// lazy() calls in App.tsx, so warming a chunk here makes the eventual
+// navigation render instantly instead of showing the page loader.
+
+type Importer = () => Promise<unknown>;
+
+const STATIC_IMPORTERS: Record<string, Importer> = {
+  "/archive": () => import("../pages/Archive"),
+  "/pulse-history": () => import("../pages/PulseHistory"),
+  "/playoffs": () => import("../pages/PlayoffBracket"),
+  "/pick-em": () => import("../pages/PickEm"),
+  "/trade-value": () => import("../pages/TradeValue"),
+  "/injuries": () => import("../pages/InjuryReport"),
+  "/trivia": () => import("../pages/Trivia"),
+  "/82-0": () => import("../pages/EightyTwoZero"),
+  "/performance": () => import("../pages/SeasonPerformance"),
+  "/momentum": () => import("../pages/Momentum"),
+  "/lineups": () => import("../pages/LineupIntel"),
+  "/trade-simulator": () => import("../pages/TradeSimulator"),
+  "/clutch": () => import("../pages/ClutchFactor"),
+  "/draft": () => import("../pages/DraftTracker"),
+  "/sentiment": () => import("../pages/SentimentPulse"),
+  "/tactics": () => import("../pages/CoachCorner"),
+  "/projections": () => import("../pages/Projections"),
+  "/badges": () => import("../pages/Badges"),
+  "/community-pulse": () => import("../pages/CommunityPulse"),
+  "/watch-guide": () => import("../pages/WatchGuide"),
+  "/widgets": () => import("../pages/Widgets"),
+  "/widgets/analytics": () => import("../pages/WidgetAnalytics"),
+  "/embed-stats": () => import("../pages/EmbedPublisherStats"),
+  "/podcast-companion": () => import("../pages/PodcastCompanion"),
+  "/history": () => import("../pages/HistoryEngine"),
+  "/refs": () => import("../pages/RefReports"),
+  "/ask": () => import("../pages/AskAI"),
+  "/my-pulse": () => import("../pages/MyPulse"),
+  "/pro": () => import("../pages/Pro"),
+  "/account": () => import("../pages/Account"),
+  "/tools": () => import("../pages/Tools"),
+  "/unsubscribe": () => import("../pages/Unsubscribe"),
+  "/compare-players": () => import("../pages/PlayerCompare"),
+  "/betting-intel": () => import("../pages/BettingIntel"),
+  "/print-edition": () => import("../pages/PrintEdition"),
+  "/guest-pulse": () => import("../pages/GuestPulse"),
+  "/rivals": () => import("../pages/Rivals"),
+  "/pulse-methodology": () => import("../pages/PulseMethodology"),
+  "/creator-queue": () => import("../pages/CreatorQueue"),
+};
+
+const PREFIX_IMPORTERS: [string, Importer][] = [
+  ["/player/", () => import("../pages/Player")],
+  ["/team/", () => import("../pages/Team")],
+  ["/game/", () => import("../pages/GameCenter")],
+  ["/card/", () => import("../pages/PlayerCard")],
+  ["/playoffs/series/", () => import("../pages/PlayoffSeriesRedirect")],
+];
+
+/** Most-travelled destinations, warmed during idle time after first paint. */
+export const HOT_ROUTES = ["/tools", "/archive", "/injuries", "/playoffs", "/82-0", "/trivia", "/pick-em", "/my-pulse", "/ask"];
+
+export function importerForPath(pathname: string): Importer | null {
+  const direct = STATIC_IMPORTERS[pathname];
+  if (direct) return direct;
+  for (const [prefix, importer] of PREFIX_IMPORTERS) {
+    if (pathname.startsWith(prefix)) return importer;
+  }
+  return null;
+}
+
+const warmed = new Set<string>();
+
+/** Fire-and-forget chunk warm-up; failures are irrelevant (nav still works). */
+export function preloadRoute(pathname: string): void {
+  if (warmed.has(pathname)) return;
+  const importer = importerForPath(pathname);
+  if (!importer) return;
+  warmed.add(pathname);
+  importer().catch(() => {
+    warmed.delete(pathname);
+  });
+}
+
+export function preloadHotRoutes(): void {
+  for (const path of HOT_ROUTES) preloadRoute(path);
+}

--- a/client/src/lib/spaNavigation.ts
+++ b/client/src/lib/spaNavigation.ts
@@ -1,0 +1,114 @@
+// SPA navigation helpers — every nav link in the app is a plain <a href>, so a
+// document-level interceptor (components/SpaNavigator) turns qualifying clicks
+// into client-side route changes. These pure helpers decide what qualifies and
+// manage scroll memory so back/forward feels native.
+
+/** Paths that must stay full-document navigations (static files, APIs, embeds). */
+export const NON_SPA_PATH_RE = /^\/(api\/|embed\.js$)|\.(xml|txt|json|js|css|svg|png|jpg|jpeg|webp|ico|pdf|webmanifest)$/i;
+
+export interface ClickLike {
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  defaultPrevented: boolean;
+}
+
+export interface AnchorLike {
+  origin: string;
+  pathname: string;
+  target: string;
+  hasDownload: boolean;
+}
+
+export function findAnchor(target: EventTarget | null): HTMLAnchorElement | null {
+  if (!(target instanceof Element)) return null;
+  return target.closest("a[href]");
+}
+
+export function shouldIntercept(event: ClickLike, anchor: AnchorLike, currentOrigin: string): boolean {
+  if (event.defaultPrevented) return false;
+  if (event.button !== 0) return false;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
+  if (anchor.target && anchor.target !== "_self") return false;
+  if (anchor.hasDownload) return false;
+  if (anchor.origin !== currentOrigin) return false;
+  if (NON_SPA_PATH_RE.test(anchor.pathname)) return false;
+  return true;
+}
+
+// ── Scroll memory (back/forward restoration across SPA navs) ──
+
+const SCROLL_STORE_KEY = "hi-scroll-memory";
+const SCROLL_STORE_LIMIT = 50;
+
+type ScrollStore = Record<string, number>;
+
+function readStore(): ScrollStore {
+  try {
+    const raw = sessionStorage.getItem(SCROLL_STORE_KEY);
+    if (raw) return JSON.parse(raw) as ScrollStore;
+  } catch {
+    // ignore
+  }
+  return {};
+}
+
+export function scrollKeyFor(pathname: string, search: string): string {
+  return `${pathname}${search}`;
+}
+
+export function rememberScroll(key: string, y: number): void {
+  try {
+    const store = readStore();
+    store[key] = Math.round(y);
+    const keys = Object.keys(store);
+    if (keys.length > SCROLL_STORE_LIMIT) {
+      for (const stale of keys.slice(0, keys.length - SCROLL_STORE_LIMIT)) delete store[stale];
+    }
+    sessionStorage.setItem(SCROLL_STORE_KEY, JSON.stringify(store));
+  } catch {
+    // ignore
+  }
+}
+
+export function recallScroll(key: string): number | null {
+  const store = readStore();
+  return typeof store[key] === "number" ? store[key] : null;
+}
+
+/**
+ * Scroll to an in-page anchor once it exists — lazy routes render after a
+ * Suspense tick, so the element may not be in the DOM on the first frame.
+ */
+export function scrollToHash(hash: string, maxFrames = 60): void {
+  const id = decodeURIComponent(hash.replace(/^#/, ""));
+  if (!id) return;
+  const behavior: ScrollBehavior = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+  let frames = 0;
+  const attempt = () => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior, block: "start" });
+      return;
+    }
+    if (frames++ < maxFrames) requestAnimationFrame(attempt);
+  };
+  attempt();
+}
+
+/** Restore a remembered scroll position once the page is tall enough to hold it. */
+export function restoreScroll(y: number, maxFrames = 60): void {
+  let frames = 0;
+  const attempt = () => {
+    const maxY = document.documentElement.scrollHeight - window.innerHeight;
+    if (maxY >= y || frames >= maxFrames) {
+      window.scrollTo(0, Math.min(y, Math.max(0, maxY)));
+      return;
+    }
+    frames++;
+    requestAnimationFrame(attempt);
+  };
+  attempt();
+}

--- a/client/src/pages/EightyTwoZero.tsx
+++ b/client/src/pages/EightyTwoZero.tsx
@@ -121,6 +121,40 @@ export default function EightyTwoZero() {
     };
   }, []);
 
+  // Keyboard flow: 1-3 drafts, T/E re-spin, Enter runs it back. The handler
+  // lives in a ref so one listener always sees current state.
+  const keyHandler = useRef<(e: KeyboardEvent) => void>(() => {});
+  keyHandler.current = (e: KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const tag = (e.target as HTMLElement)?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || (e.target as HTMLElement)?.isContentEditable) return;
+    if (result) {
+      if (e.key === "Enter" && revealed >= 82) {
+        e.preventDefault();
+        startRun(mode);
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        skipReveal();
+      }
+      return;
+    }
+    if (spinning) return;
+    const num = Number.parseInt(e.key, 10);
+    if (num >= 1 && num <= choices.length) {
+      e.preventDefault();
+      pickPlayer(choices[num - 1]);
+    } else if (e.key.toLowerCase() === "t") {
+      handleRespinTeam();
+    } else if (e.key.toLowerCase() === "e") {
+      handleRespinEra();
+    }
+  };
+  useEffect(() => {
+    const listener = (e: KeyboardEvent) => keyHandler.current(e);
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, []);
+
   function clearSpinTimers() {
     spinTimers.current.forEach((t) => window.clearInterval(t));
     spinTimers.current = [];
@@ -276,7 +310,10 @@ export default function EightyTwoZero() {
       <p className="text-sm mb-4 max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted,rgba(255,255,255,0.6))" }}>
         Spin a franchise and an era, draft one player, repeat until you have a starting five. Then we play out a full
         82-game season against history&apos;s buzzsaws. One team re-spin and one era re-spin per slot — spend them
-        wisely. Same five, same record, every time: no take-backs, no lucky reruns.
+        wisely. Same five, same record, every time: no take-backs, no lucky reruns.{" "}
+        <span className="hidden sm:inline mono-data text-[11px]" style={{ color: "rgba(255,255,255,0.35)" }}>
+          Keys: 1–3 draft · T/E re-spin · Enter runs it back.
+        </span>
       </p>
 
       {/* Mode toggle */}
@@ -530,7 +567,7 @@ export default function EightyTwoZero() {
           </div>
 
           <div className="p-5 grid gap-3 sm:grid-cols-3" style={{ opacity: spinning ? 0.35 : 1, transition: "opacity 150ms" }}>
-            {(spinning ? shownPool.players : choices).map((pl) => (
+            {(spinning ? shownPool.players : choices).map((pl, idx) => (
               <button
                 key={pl.name}
                 type="button"
@@ -543,8 +580,13 @@ export default function EightyTwoZero() {
                   <span className="font-bold text-sm" style={{ color: "var(--hi-heading,#fff)" }}>
                     {pl.name}
                   </span>
-                  <span className="mono-data text-[10px] px-1.5 py-0.5 rounded bg-white/10" style={{ color: "rgba(255,255,255,0.6)" }}>
-                    {pl.pos}
+                  <span className="flex items-center gap-1">
+                    <kbd className="mono-data text-[10px] px-1.5 py-0.5 rounded bg-white/10 hidden sm:inline" style={{ color: "rgba(255,255,255,0.4)" }} aria-hidden>
+                      {idx + 1}
+                    </kbd>
+                    <span className="mono-data text-[10px] px-1.5 py-0.5 rounded bg-white/10" style={{ color: "rgba(255,255,255,0.6)" }}>
+                      {pl.pos}
+                    </span>
                   </span>
                 </div>
                 <div className="mono-data text-[11px]" style={{ color: "rgba(255,255,255,0.55)" }}>


### PR DESCRIPTION
## Summary

Audit finding: the app had **zero** wouter `<Link>`s — every nav link is a plain `<a href>`, so every click was a full document reload (re-download HTML, re-boot React, white flash, lost widget state). The lazy-route SPA architecture wasn't being used for navigation at all.

- **`SpaNavigator`** (new, mounted once in App) — a document-level click interceptor that routes qualifying anchor clicks through wouter client-side. Skips cross-origin links, modified clicks (cmd/ctrl/shift/middle), `target`/`download` anchors, `/api/*`, and static files (`feed.xml`, `embed.js`, etc.). Every existing link upgrades without touching 40+ pages.
- **Prefetching** (`routePreload.ts`) — route chunks warm on pointer-over/touch-start and the nine hottest routes warm during first idle. Verified in the built app: 12 chunks prefetched at idle, and navigating to `/tools` makes **zero** network requests.
- **Scroll management** (`spaNavigation.ts`) — push navs start at top; hash links (`/#pulse-index`) scroll to their section once the lazy route renders; back/forward restores the reader's position via sessionStorage memory. `history.scrollRestoration` is taken manual, and restoration runs from the popstate handler (double-rAF) because wouter's own popstate handler can flush React synchronously, making effect ordering unreliable.
- **Overlay hygiene** — the mobile drawer and the header "More" dropdown now close on route change (the full reload used to do this for free).
- **82-0 keyboard flow** — 1–3 drafts the shown players, T/E spends re-spins, Enter skips the reveal / runs it back; key hints render on desktop.

Browser-verified in the production build with Playwright: no-reload marker survives multi-page nav chains, push-at-top / back-restores (y=1485) / forward-at-top all pass, hash nav scrolls to section, mobile drawer closes, keyboard draft completes a season, zero page errors.

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (277/277, including new `spaNavigation.test.ts`)
- [ ] Vercel Preview looks correct for UI changes (verified locally via `vite preview` + Playwright as above)
- [x] New secrets documented in `.env.example` / `README.md` if applicable — none added

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeFt9Zbn4pwKhxWZwxCKdN)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site-wide SPA navigation with prefetching and scroll management
> - Introduces [`SpaNavigator`](https://github.com/hondoentertainment/hoops-intel/pull/316/files#diff-157ab8e6b676ef4c84de68a7f66b5260afa0e4ab74946b379cb93e573de195bd), a headless component mounted globally in [`App.tsx`](https://github.com/hondoentertainment/hoops-intel/pull/316/files#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337) that intercepts qualifying same-origin anchor clicks and routes them through wouter instead of triggering full-page reloads.
> - Manages scroll state manually: back/forward restores saved positions, hash links scroll to anchors, and new navigations scroll to top. Scroll position is persisted per path+search in sessionStorage.
> - Route chunks are preloaded on hover/touch via [`routePreload.ts`](https://github.com/hondoentertainment/hoops-intel/pull/316/files#diff-99108f45534b567ed30f399decf69187885a733b9e7cf1a989856e2511bbfc7c), which maps static paths and dynamic prefixes to importers. A curated set of hot routes is also warmed during idle time.
> - Closes the mobile nav panel and open `<details>` menus in [`SiteHeader`](https://github.com/hondoentertainment/hoops-intel/pull/316/files#diff-6c9e909f1a2593ba81efaaa649dda03642303b13148d47db86f2fe7d9b1917c6) on route change, since client-side navigation no longer reloads the document.
> - Behavioral Change: navigation across the app shifts from full-page reloads to SPA transitions for all qualifying in-app links; `history.scrollRestoration` is forced to `'manual'` while `SpaNavigator` is mounted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6688de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->