### PR TITLE
Fix sitemap lastmod and SEO signals from site review #348

### DIFF
--- a/client/src/__tests__/seoConfig.test.ts
+++ b/client/src/__tests__/seoConfig.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { NOINDEX_PATHS, resolveRouteSeo, toMetaTags } from "../lib/seoConfig";
+
+describe("publisher dashboard SEO", () => {
+  it("noindexes embed analytics shells and canonicalizes them to /widgets", () => {
+    for (const path of ["/embed-stats", "/widgets/analytics"]) {
+      expect(NOINDEX_PATHS.has(path)).toBe(true);
+      const seo = resolveRouteSeo(path);
+      expect(seo?.noindex).toBe(true);
+      expect(seo?.canonicalPath).toBe("/widgets");
+      expect(toMetaTags(seo!).canonicalUrl).toBe("https://hoopsintel.net/widgets");
+    }
+  });
+
+  it("keeps the public widgets page indexable with a self canonical", () => {
+    const seo = resolveRouteSeo("/widgets");
+    expect(seo?.noindex).toBeUndefined();
+    expect(seo?.canonicalPath).toBe("/widgets");
+  });
+
+  it("does not treat account as a widgets canonical", () => {
+    const seo = resolveRouteSeo("/account");
+    expect(seo?.noindex).toBe(true);
+    expect(seo?.canonicalPath).toBe("/account");
+  });
+});

--- a/client/src/lib/momentumData.ts
+++ b/client/src/lib/momentumData.ts
@@ -26,6 +26,7 @@ export interface MomentumSwing {
 }
 
 export interface MomentumData {
+  generatedDate: string;
   date: string;
   games: MomentumSwing[];
   gameOfTheNight: string;
@@ -33,6 +34,7 @@ export interface MomentumData {
 }
 
 export const momentumData: MomentumData = {
+  generatedDate: "2026-08-25",
   date: "June 14, 2026",
   gameOfTheNight: "NYK-SAS-20260613",
   topClutchPerformer: {

--- a/client/src/lib/podcastData.ts
+++ b/client/src/lib/podcastData.ts
@@ -13,6 +13,7 @@ export interface TalkingPoint {
 }
 
 export interface PodcastCompanionData {
+  generatedDate: string;
   date: string;
   episodeTitle: string;
   rundown: TalkingPoint[];
@@ -22,6 +23,7 @@ export interface PodcastCompanionData {
 }
 
 export const podcastCompanion: PodcastCompanionData = {
+  generatedDate: "2026-08-25",
   date: "June 9, 2026",
 
   episodeTitle:

--- a/client/src/lib/seoConfig.ts
+++ b/client/src/lib/seoConfig.ts
@@ -195,7 +195,13 @@ const STATIC_ROUTE_SEO: Record<string, PageSeo> = {
   "/embed-stats": {
     title: "Embed Publisher Stats | Hoops Intel",
     description: "Publisher dashboard for embed load trends and export.",
-    canonicalPath: "/embed-stats",
+    canonicalPath: "/widgets",
+    noindex: true,
+  },
+  "/widgets/analytics": {
+    title: "Widget Load Timeline | Hoops Intel",
+    description: "Publisher dashboard for stacked daily embed loads — pulse, ticker, and injury.",
+    canonicalPath: "/widgets",
     noindex: true,
   },
   "/pro": {
@@ -376,7 +382,7 @@ export function resolveRouteSeo(pathname: string): PageSeo | null {
     return {
       title: base?.title ?? `${SITE_NAME}`,
       description: base?.description ?? "Hoops Intel account and settings.",
-      canonicalPath: path,
+      canonicalPath: base?.canonicalPath ?? path,
       noindex: true,
     };
   }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,153 +25,27 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/tools</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
     <loc>https://hoopsintel.net/injuries</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/pick-em</loc>
+    <loc>https://hoopsintel.net/betting-intel</loc>
     <lastmod>2026-08-25</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.65</priority>
+    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/trade-value</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/trivia</loc>
+    <loc>https://hoopsintel.net/watch-guide</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/82-0</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/performance</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>daily</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/momentum</loc>
-    <lastmod>2026-06-14</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/lineups</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/trade-simulator</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/clutch</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/draft</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/sentiment</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/tactics</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/projections</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/badges</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/community-pulse</loc>
-    <lastmod>2026-08-24</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/watch-guide</loc>
-    <lastmod>2026-08-24</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/podcast-companion</loc>
-    <lastmod>2026-06-09</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/history</loc>
-    <lastmod>2026-06-09</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/refs</loc>
-    <lastmod>2026-06-09</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/ask</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/compare-players</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/pulse-methodology</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.55</priority>
-  </url>
-  <url>
-    <loc>https://hoopsintel.net/rivals</loc>
-    <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
@@ -187,40 +61,166 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/widgets</loc>
+    <loc>https://hoopsintel.net/pick-em</loc>
+    <lastmod>2026-07-21</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/podcast-companion</loc>
     <lastmod>2026-08-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/widgets</loc>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/pro</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/betting-intel</loc>
+    <loc>https://hoopsintel.net/lineups</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/clutch</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/draft</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/sentiment</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.65</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/tactics</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/projections</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/history</loc>
+    <lastmod>2026-06-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/refs</loc>
+    <lastmod>2026-06-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/rivals</loc>
+    <lastmod>2026-05-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/community-pulse</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/guest-pulse</loc>
+    <lastmod>2026-07-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.55</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/pulse-methodology</loc>
+    <lastmod>2026-05-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.55</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/tools</loc>
+    <lastmod>2026-08-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.55</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/trade-value</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.55</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/performance</loc>
+    <lastmod>2026-05-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.55</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/ask</loc>
     <lastmod>2026-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.55</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/player/victor-wembanyama</loc>
+    <loc>https://hoopsintel.net/compare-players</loc>
     <lastmod>2026-08-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.55</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/trade-simulator</loc>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://hoopsintel.net/player/jalen-brunson</loc>
-    <lastmod>2026-08-25</lastmod>
+    <loc>https://hoopsintel.net/trivia</loc>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/82-0</loc>
+    <lastmod>2026-08-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/badges</loc>
+    <lastmod>2026-05-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/player/victor-wembanyama</loc>
+    <lastmod>2026-08-25</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
+  </url>
+  <url>
+    <loc>https://hoopsintel.net/player/jalen-brunson</loc>
+    <lastmod>2026-08-25</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/joel-embiid</loc>
@@ -243,8 +243,8 @@
   <url>
     <loc>https://hoopsintel.net/player/anthony-edwards</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/josh-hart</loc>
@@ -279,8 +279,8 @@
   <url>
     <loc>https://hoopsintel.net/player/karl-anthony-towns</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/isaiah-hartenstein</loc>
@@ -315,8 +315,8 @@
   <url>
     <loc>https://hoopsintel.net/player/shai-gilgeous-alexander</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/lebron-james</loc>
@@ -345,8 +345,8 @@
   <url>
     <loc>https://hoopsintel.net/player/alperen-sengun</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/paolo-banchero</loc>
@@ -393,8 +393,8 @@
   <url>
     <loc>https://hoopsintel.net/player/jamal-murray</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/chet-holmgren</loc>
@@ -429,8 +429,8 @@
   <url>
     <loc>https://hoopsintel.net/player/nikola-jokic</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/brandon-miller</loc>
@@ -687,8 +687,8 @@
   <url>
     <loc>https://hoopsintel.net/player/stephon-castle</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/jalen-johnson</loc>
@@ -783,8 +783,8 @@
   <url>
     <loc>https://hoopsintel.net/player/de-aaron-fox</loc>
     <lastmod>2026-08-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>daily</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/player/coby-white</loc>

--- a/scripts/generate-momentum.mjs
+++ b/scripts/generate-momentum.mjs
@@ -10,7 +10,8 @@ import { claudeGenerate } from "./lib/claude-client.mjs";
 import { readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { toESPNDate, toDisplayDate } from "./lib/daily-dates.mjs";
+import { toESPNDate, toDisplayDate, toISODate } from "./lib/daily-dates.mjs";
+import { stampGeneratedDate } from "./lib/stamp-generated-date.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -117,6 +118,7 @@ export interface MomentumSwing {
 }
 
 export interface MomentumData {
+  generatedDate: string;
   date: string;
   games: MomentumSwing[];
   gameOfTheNight: string;
@@ -124,6 +126,7 @@ export interface MomentumData {
 }
 
 export const momentumData: MomentumData = {
+  generatedDate: "${toISODate(0)}",
   date: "${displayDate}",
   gameOfTheNight: "...", // gameId of the most dramatic game
   topClutchPerformer: { ... },
@@ -179,7 +182,10 @@ async function main() {
   console.log(`   Found ${finalGames.length} completed games`);
 
   if (finalGames.length === 0) {
-    console.log("⚠  No completed games found. Skipping generation.");
+    const outPath = join(ROOT, "client", "src", "lib", "momentumData.ts");
+    const next = stampGeneratedDate(readFileSync(outPath, "utf8"), toISODate(0));
+    writeFileSync(outPath, next, "utf8");
+    console.log("⚠  No completed games found. Stamped generatedDate; left game narratives unchanged.");
     process.exit(0);
   }
 

--- a/scripts/generate-podcast.mjs
+++ b/scripts/generate-podcast.mjs
@@ -7,7 +7,7 @@ import { claudeGenerate } from "./lib/claude-client.mjs";
 import { readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { toDisplayDate } from "./lib/daily-dates.mjs";
+import { toDisplayDate, toISODate } from "./lib/daily-dates.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -46,6 +46,7 @@ export interface TalkingPoint {
 }
 
 export interface PodcastCompanionData {
+  generatedDate: string;
   date: string;
   episodeTitle: string;
   rundown: TalkingPoint[];
@@ -54,7 +55,7 @@ export interface PodcastCompanionData {
   tweetThread: string[];
 }
 
-export const podcastCompanion: PodcastCompanionData = { ... };
+export const podcastCompanion: PodcastCompanionData = { generatedDate: "${toISODate(0)}", ... };
 \`\`\`
 
 ## Instructions

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import {
   SITEMAP_GAME_META,
+  SITEMAP_PLAYER_DESK_META,
   SITEMAP_PLAYER_META,
   SITEMAP_PLAYOFFS_HUB_META,
   SITEMAP_PLAYOFFS_HUB_OFFSEASON_META,
@@ -179,6 +180,11 @@ function extractLatestArchiveIso(archiveFile) {
   return maxIso(...dates);
 }
 
+/** Pulse Index membership is the only popularity signal we trust for crawl weight. */
+export function playerSitemapMeta({ inPulse } = {}) {
+  return inPulse ? SITEMAP_PLAYER_DESK_META : SITEMAP_PLAYER_META;
+}
+
 /** Prefer content dates / source mtimes so crawlers see selective freshness. */
 export const STATIC_ROUTE_SOURCES = {
   "/tools": ["client/src/lib/siteNav.ts"],
@@ -333,6 +339,13 @@ export function generate() {
     pulsePlayers.add(canonical);
     bumpMention(canonical);
   }
+  const pulseIndexPlayers = new Set();
+  const pulseIndexBlock = pulseFile.match(/export const pulseIndex\s*=\s*\[([\s\S]*?)\]/);
+  if (pulseIndexBlock) {
+    for (const m of pulseIndexBlock[1].matchAll(/\bplayer:\s*"([^"]+)"/g)) {
+      pulseIndexPlayers.add(canonicalPlayerName(m[1]));
+    }
+  }
 
   const playerSlugs = new Map();
   for (const [canonical, mentions] of mentionCounts) {
@@ -348,7 +361,10 @@ export function generate() {
       continue;
     }
     playerSlugs.set(slug, canonical);
-    urls.push({ loc: `/player/${slug}`, ...SITEMAP_PLAYER_META });
+    urls.push({
+      loc: `/player/${slug}`,
+      ...playerSitemapMeta({ inPulse: pulseIndexPlayers.has(canonical) }),
+    });
   }
   const teamSlugs = new Set();
   for (const team of teams) {

--- a/scripts/lib/public-routes.mjs
+++ b/scripts/lib/public-routes.mjs
@@ -48,40 +48,45 @@ export const SITE_REVIEW_PATHS = [
 
 /** Static tool paths written to sitemap.xml (excludes /, /archive, /pulse-history, /playoffs). */
 export const SITEMAP_STATIC_ROUTES = [
-  { loc: "/tools", priority: "0.65", changefreq: "weekly" },
-  { loc: "/injuries", priority: "0.65", changefreq: "weekly" },
-  { loc: "/pick-em", priority: "0.65", changefreq: "daily" },
-  { loc: "/trade-value", priority: "0.65", changefreq: "weekly" },
-  { loc: "/trivia", priority: "0.65", changefreq: "weekly" },
-  { loc: "/82-0", priority: "0.65", changefreq: "weekly" },
-  { loc: "/performance", priority: "0.65", changefreq: "weekly" },
-  { loc: "/momentum", priority: "0.65", changefreq: "weekly" },
-  { loc: "/lineups", priority: "0.65", changefreq: "weekly" },
-  { loc: "/trade-simulator", priority: "0.65", changefreq: "weekly" },
-  { loc: "/clutch", priority: "0.65", changefreq: "weekly" },
-  { loc: "/draft", priority: "0.65", changefreq: "weekly" },
-  { loc: "/sentiment", priority: "0.65", changefreq: "weekly" },
-  { loc: "/tactics", priority: "0.65", changefreq: "weekly" },
-  { loc: "/projections", priority: "0.65", changefreq: "weekly" },
-  { loc: "/badges", priority: "0.65", changefreq: "weekly" },
-  { loc: "/community-pulse", priority: "0.65", changefreq: "weekly" },
+  // Daily desk — crawl above interactive tools
+  { loc: "/injuries", priority: "0.7", changefreq: "daily" },
+  { loc: "/betting-intel", priority: "0.7", changefreq: "daily" },
   { loc: "/watch-guide", priority: "0.65", changefreq: "daily" },
-  { loc: "/podcast-companion", priority: "0.65", changefreq: "weekly" },
-  { loc: "/history", priority: "0.65", changefreq: "weekly" },
-  { loc: "/refs", priority: "0.65", changefreq: "weekly" },
-  { loc: "/ask", priority: "0.65", changefreq: "weekly" },
-  { loc: "/compare-players", priority: "0.65", changefreq: "weekly" },
-  { loc: "/pulse-methodology", priority: "0.55", changefreq: "monthly" },
-  { loc: "/rivals", priority: "0.65", changefreq: "weekly" },
+  { loc: "/momentum", priority: "0.65", changefreq: "daily" },
   { loc: "/my-pulse", priority: "0.6", changefreq: "daily" },
   { loc: "/print-edition", priority: "0.6", changefreq: "daily" },
+  { loc: "/pick-em", priority: "0.65", changefreq: "daily" },
+  { loc: "/podcast-companion", priority: "0.6", changefreq: "weekly" },
   { loc: "/widgets", priority: "0.6", changefreq: "daily" },
   { loc: "/pro", priority: "0.7", changefreq: "weekly" },
-  { loc: "/betting-intel", priority: "0.65", changefreq: "daily" },
+  // Analysis / content
+  { loc: "/lineups", priority: "0.6", changefreq: "weekly" },
+  { loc: "/clutch", priority: "0.6", changefreq: "weekly" },
+  { loc: "/draft", priority: "0.6", changefreq: "weekly" },
+  { loc: "/sentiment", priority: "0.6", changefreq: "weekly" },
+  { loc: "/tactics", priority: "0.6", changefreq: "weekly" },
+  { loc: "/projections", priority: "0.6", changefreq: "weekly" },
+  { loc: "/history", priority: "0.6", changefreq: "weekly" },
+  { loc: "/refs", priority: "0.6", changefreq: "weekly" },
+  { loc: "/rivals", priority: "0.6", changefreq: "weekly" },
+  { loc: "/community-pulse", priority: "0.6", changefreq: "weekly" },
   { loc: "/guest-pulse", priority: "0.55", changefreq: "weekly" },
+  { loc: "/pulse-methodology", priority: "0.55", changefreq: "monthly" },
+  // Interactive tools — below daily desk so crawl budget is not flattened
+  { loc: "/tools", priority: "0.55", changefreq: "weekly" },
+  { loc: "/trade-value", priority: "0.55", changefreq: "weekly" },
+  { loc: "/performance", priority: "0.55", changefreq: "weekly" },
+  { loc: "/ask", priority: "0.55", changefreq: "weekly" },
+  { loc: "/compare-players", priority: "0.55", changefreq: "weekly" },
+  { loc: "/trade-simulator", priority: "0.5", changefreq: "weekly" },
+  { loc: "/trivia", priority: "0.5", changefreq: "weekly" },
+  { loc: "/82-0", priority: "0.5", changefreq: "weekly" },
+  { loc: "/badges", priority: "0.5", changefreq: "weekly" },
 ];
 
 export const SITEMAP_PLAYER_META = { priority: "0.5", changefreq: "weekly" };
+/** Pulse Index names — existing daily desk signal, not a handmade celebrity list. */
+export const SITEMAP_PLAYER_DESK_META = { priority: "0.65", changefreq: "daily" };
 export const SITEMAP_TEAM_META = { priority: "0.6", changefreq: "weekly" };
 export const SITEMAP_GAME_META = { priority: "0.55", changefreq: "daily" };
 /** Default series sitemap meta; generate-sitemap.mjs bumps during active playoffs. */

--- a/scripts/lib/stamp-generated-date.mjs
+++ b/scripts/lib/stamp-generated-date.mjs
@@ -1,0 +1,17 @@
+/**
+ * Upsert ISO `generatedDate` on the first exported data object.
+ * Lets sitemap lastmod advance when a generator skips an empty slate
+ * without rewriting editorial fields like `date` or game narratives.
+ */
+export function stampGeneratedDate(fileText, iso) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    throw new Error(`stampGeneratedDate: invalid ISO date: ${iso}`);
+  }
+  if (/\bgeneratedDate:\s*"\d{4}-\d{2}-\d{2}"/.test(fileText)) {
+    return fileText.replace(/\bgeneratedDate:\s*"\d{4}-\d{2}-\d{2}"/, `generatedDate: "${iso}"`);
+  }
+  return fileText.replace(
+    /(export const \w[\w]*\s*(?::\s*\w[\w]*)?\s*=\s*\{)/,
+    `$1\n  generatedDate: "${iso}",`,
+  );
+}

--- a/scripts/tests/sitemap-lastmod.test.mjs
+++ b/scripts/tests/sitemap-lastmod.test.mjs
@@ -8,7 +8,10 @@ import {
   extractExportedTimestamp,
   isSitemapIndexablePlayer,
   lastmodForLoc,
+  playerSitemapMeta,
 } from "../generate-sitemap.mjs";
+import { SITEMAP_STATIC_ROUTES } from "../lib/public-routes.mjs";
+import { stampGeneratedDate } from "../lib/stamp-generated-date.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -53,15 +56,56 @@ test("game lastmod uses the game date in the URL", () => {
   );
 });
 
-test("momentum lastmod matches the published content date, not git/mtime", () => {
+test("momentum lastmod prefers generatedDate over the frozen game-night date", () => {
   const file = readFileSync(join(ROOT, "client/src/lib/momentumData.ts"), "utf8");
   const contentDate = extractExportedTimestamp(file);
   assert.ok(contentDate, "momentumData.ts should export a date");
+  assert.match(file, /generatedDate:\s*"\d{4}-\d{2}-\d{2}"/);
+  assert.match(file, /date:\s*"June 14, 2026"/);
+  assert.notEqual(contentDate, "2026-06-14", "lastmod source must not stay stuck on last game night");
   assert.equal(
     lastmodForLoc("/momentum", { buildDay: "2026-08-21", editionIso: "2026-08-20" }),
     contentDate,
   );
   assert.notEqual(contentDate, "2026-08-21");
+});
+
+test("podcast lastmod prefers generatedDate over the episode date", () => {
+  const file = readFileSync(join(ROOT, "client/src/lib/podcastData.ts"), "utf8");
+  const contentDate = extractExportedTimestamp(file);
+  assert.ok(contentDate, "podcastData.ts should export a date");
+  assert.match(file, /generatedDate:\s*"\d{4}-\d{2}-\d{2}"/);
+  assert.match(file, /date:\s*"June 9, 2026"/);
+  assert.notEqual(contentDate, "2026-06-09");
+  assert.equal(
+    lastmodForLoc("/podcast-companion", { buildDay: "2026-08-21", editionIso: "2026-08-20" }),
+    contentDate,
+  );
+});
+
+test("stampGeneratedDate upserts ISO generatedDate without rewriting date", () => {
+  const src = `export const momentumData: MomentumData = {\n  date: "June 14, 2026",\n};\n`;
+  const stamped = stampGeneratedDate(src, "2026-08-25");
+  assert.match(stamped, /generatedDate: "2026-08-25"/);
+  assert.match(stamped, /date: "June 14, 2026"/);
+  assert.equal(stampGeneratedDate(stamped, "2026-08-26").includes('generatedDate: "2026-08-26"'), true);
+});
+
+test("Pulse Index players get higher sitemap priority; others stay default", () => {
+  assert.deepEqual(playerSitemapMeta({ inPulse: true }), { priority: "0.65", changefreq: "daily" });
+  assert.deepEqual(playerSitemapMeta({ inPulse: false }), { priority: "0.5", changefreq: "weekly" });
+});
+
+test("daily desk sitemap priority sits above interactive tools", () => {
+  const byLoc = Object.fromEntries(SITEMAP_STATIC_ROUTES.map((r) => [r.loc, r]));
+  assert.ok(Number(byLoc["/betting-intel"].priority) > Number(byLoc["/tools"].priority));
+  assert.ok(Number(byLoc["/betting-intel"].priority) > Number(byLoc["/trade-simulator"].priority));
+  assert.ok(Number(byLoc["/injuries"].priority) > Number(byLoc["/compare-players"].priority));
+  assert.ok(Number(byLoc["/tools"].priority) <= 0.55);
+  assert.ok(Number(byLoc["/trade-simulator"].priority) <= 0.55);
+  assert.ok(Number(byLoc["/compare-players"].priority) <= 0.55);
+  assert.equal(byLoc["/injuries"].changefreq, "daily");
+  assert.equal(byLoc["/betting-intel"].changefreq, "daily");
 });
 
 test("historical comparison names are not sitemap-indexable", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Code-side SEO/sitemap fixes from the 2026-08-25 site review ([#348](https://github.com/hondoentertainment/hoops-intel/issues/348)). This is not a down-site incident — all listed paths already return 200.

**Verified hypothesis:** sitemap lastmod was not hardcoded stale. `/momentum` (2026-06-14) and `/podcast-companion` (2026-06-09) correctly reflected the last generated *content* dates. `generate-momentum.mjs` skips when there are no completed games and never wrote a newer timestamp, so lastmod froze on the last Finals slate.

### What changed

1. **Lastmod source** — daily generators now stamp ISO `generatedDate` (momentum also stamps on empty-slate skip without rewriting game narratives). Sitemap already prefers `generatedDate` over `date`, so lastmod is no longer stuck in June. Editorial `date` fields stay June 14 / June 9.
2. **Player crawl weight** — only Pulse Index names get `0.65` / `daily`. Everyone else stays `0.5` / `weekly`. No handmade celebrity list (LeBron stays default).
3. **`/embed-stats` and `/widgets/analytics`** — confirmed publisher dashboards (not public embed iframes; those are `/embed/`). Already `noindex` + `robots.txt` Disallow + omitted from the sitemap. Added a `/widgets/analytics` SEO entry and canonical both dashboards to `/widgets`.
4. **Desk vs tools priority** — daily desk (`/injuries`, `/betting-intel`) at `0.7` / `daily`; interactive tools (`/tools`, `/trade-simulator`, `/compare-players`, `/82-0`, `/trivia`) at `0.5–0.55`.
5. **Monitoring baseline** — not changed. Registering the 19 new-to-fingerprint routes is owner ops (Actions baseline snapshot), left untouched.

Closes #348.

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (286/286)
- [x] Hydrated preview: `/embed-stats` and `/widgets/analytics` emit `noindex, nofollow` + canonical `https://hoopsintel.net/widgets`
- [ ] New secrets documented in `.env.example` / `README.md` if applicable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65ef5acb-99df-4ed9-ab0b-286e0ae990a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65ef5acb-99df-4ed9-ab0b-286e0ae990a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sitemap SEO signals: canonicalize noindex routes and prioritize Pulse Index players
> - Changes `/embed-stats` and `/widgets/analytics` to canonicalize to `/widgets` while remaining `noindex`, via updated entries in `STATIC_ROUTE_SEO` and a `resolveRouteSeo` override that prefers configured `canonicalPath`
> - Adds a required `generatedDate: string` field to `MomentumData` and `PodcastCompanionData` interfaces, populated by `generate-momentum.mjs` and `generate-podcast.mjs`; on no-game days, the momentum script now stamps `generatedDate` instead of making no changes
> - Introduces `playerSitemapMeta({ inPulse })` in `generate-sitemap.mjs` to give Pulse Index players priority 0.65 / daily changefreq versus default weekly; reorders `SITEMAP_STATIC_ROUTES` to elevate daily desk routes over interactive tools
> - Adds `stampGeneratedDate` utility in [stamp-generated-date.mjs](https://github.com/hondoentertainment/hoops-intel/pull/349/files#diff-53a8a051fb393ad225e1048df9d2a6ad69fe3bf9c21ab851b57ab4ea5e1725c0) that upserts `generatedDate` into the first exported object literal without altering existing `date` fields; sitemap `lastmod` now prefers `generatedDate` over content `date`
> - Risk: `MomentumData` and `PodcastCompanionData` interfaces now require `generatedDate` — any out-of-tree consumers or hand-edited data files missing this field will fail type checks
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50b1980.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->