### PR TITLE
Ship UX Pilot desk: season-aware nav and offseason homepage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -89,7 +89,28 @@ function VercelAnalyticsScript() {
   return null;
 }
 
+function pageLoaderLabel(path: string): string {
+  if (path.startsWith("/pick-em") || path === "/picks") return "Loading picks";
+  if (path.startsWith("/playoffs")) return "Loading playoffs";
+  if (path.startsWith("/ask")) return "Loading Ask Hoops Intel";
+  if (path.startsWith("/injuries")) return "Loading injury report";
+  if (path.startsWith("/archive")) return "Loading archive";
+  if (path.startsWith("/my-pulse")) return "Loading My Pulse";
+  if (path.startsWith("/pro")) return "Loading Pro";
+  if (path.startsWith("/tools")) return "Loading tools";
+  return "Loading page";
+}
+
+function RedirectTo({ href }: { href: string }) {
+  const [, setLocation] = useLocation();
+  useEffect(() => {
+    setLocation(href);
+  }, [href, setLocation]);
+  return <PageLoader />;
+}
+
 function PageLoader() {
+  const [location] = useLocation();
   return (
     <div className="flex items-center justify-center min-h-[50vh] px-4" role="status" aria-live="polite">
       <div className="w-full max-w-md space-y-4">
@@ -100,7 +121,7 @@ function PageLoader() {
             aria-hidden
           />
           <div className="text-sm font-medium" style={{ color: "rgba(255,255,255,0.7)" }}>
-            Loading page…
+            {pageLoaderLabel(location)}…
           </div>
         </div>
         <div className="space-y-2" aria-hidden>
@@ -146,6 +167,9 @@ export default function App() {
             <Route path="/pulse-history" component={PulseHistory} />
             <Route path="/playoffs" component={PlayoffBracket} />
             <Route path="/playoffs/series/:seriesId" component={PlayoffSeriesRedirect} />
+            <Route path="/picks">
+              <RedirectTo href="/pick-em" />
+            </Route>
             <Route path="/pick-em" component={PickEm} />
             <Route path="/trade-value" component={TradeValue} />
             <Route path="/injuries" component={InjuryReport} />
@@ -188,19 +212,23 @@ export default function App() {
               <main id="main-content" tabIndex={-1} className="container py-20 text-center outline-none" lang="en">
                 <p className="section-label mb-3">NOT FOUND</p>
                 <h1 className="display-heading text-2xl font-bold text-white mb-4">404 — Page not found</h1>
-                <p className="text-sm mb-6" style={{ color: "rgba(255,255,255,0.55)" }}>
-                  That route is not part of Hoops Intel. Try search (⌘K / Ctrl+K) from any page.
+                <p className="text-sm mb-6" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+                  That route is not part of Hoops Intel.
                 </p>
-                <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm">
-                  <a href="/" className="text-sky-400 underline">
+                <div className="flex flex-wrap justify-center gap-x-6 gap-y-3 text-sm">
+                  <a href="/" className="text-sky-400 underline min-h-[44px] inline-flex items-center">
                     Today&apos;s desk
                   </a>
-                  <a href="/tools" className="text-sky-400 underline">
-                    All tools
+                  <a href="/tools" className="text-sky-400 underline min-h-[44px] inline-flex items-center">
+                    Tools
                   </a>
-                  <a href="/archive" className="text-sky-400 underline">
-                    Archive
-                  </a>
+                  <button
+                    type="button"
+                    className="text-sky-400 underline min-h-[44px] inline-flex items-center"
+                    onClick={() => window.dispatchEvent(new Event("hi-open-search"))}
+                  >
+                    Open search
+                  </button>
                 </div>
               </main>
             </Route>

--- a/client/src/__tests__/deskBriefing.test.ts
+++ b/client/src/__tests__/deskBriefing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../lib/pulseData", () => ({
   gamePreviews: [{ homeTeam: "NYK", awayTeam: "CLE" }],
@@ -31,6 +31,12 @@ import { buildSixtySecondBullets, editionContextLabel } from "../lib/deskBriefin
 describe("deskBriefing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 4, 19)));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("buildSixtySecondBullets returns up to five desk bullets", () => {

--- a/client/src/__tests__/deskMode.test.ts
+++ b/client/src/__tests__/deskMode.test.ts
@@ -4,6 +4,7 @@ import {
   clientSeasonMode,
   editionContextDeskLabel,
   isOffseasonDesk,
+  offseasonPrimaryHref,
   seasonModeToEditionContext,
   type ClientSeasonMode,
 } from "../lib/deskMode";
@@ -57,5 +58,21 @@ describe("committed edition context", () => {
 
   it("exposes offseason state as a boolean", () => {
     expect(typeof isOffseasonDesk()).toBe("boolean");
+  });
+});
+
+describe("calendar chrome", () => {
+  it("treats August as dead-period offseason even when edition metadata says regular", () => {
+    const august = new Date(Date.UTC(2026, 7, 29));
+    expect(clientSeasonMode(august)).toBe("dead-period");
+    expect(activeEditionContext(august)).toBe("dead-period");
+    expect(isOffseasonDesk(august)).toBe(true);
+    expect(offseasonPrimaryHref(august)).toBe("/projections");
+  });
+
+  it("keeps January as regular season", () => {
+    const january = new Date(Date.UTC(2026, 0, 15));
+    expect(isOffseasonDesk(january)).toBe(false);
+    expect(activeEditionContext(january)).toBe("regular");
   });
 });

--- a/client/src/__tests__/pulseRationale.test.ts
+++ b/client/src/__tests__/pulseRationale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { rationaleToBullets } from "../lib/pulseRationale";
+import { pulseLeadLine, rationaleToBullets } from "../lib/pulseRationale";
 
 describe("rationaleToBullets", () => {
   it("splits rationale into up to three sentences", () => {
@@ -13,5 +13,11 @@ describe("rationaleToBullets", () => {
   it("fills from note when rationale is short", () => {
     const bullets = rationaleToBullets("Single rationale.", "Note one. Note two.");
     expect(bullets.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("pulseLeadLine returns the first rationale sentence", () => {
+    expect(pulseLeadLine("Ranks first because the extension is imminent.", "Longer note.")).toBe(
+      "Ranks first because the extension is imminent",
+    );
   });
 });

--- a/client/src/__tests__/scorebarVisibility.test.ts
+++ b/client/src/__tests__/scorebarVisibility.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { scorebarGamesToShow, shouldShowLiveScorebar } from "../lib/scorebarVisibility";
+import type { LiveGame } from "../lib/espnApi";
+
+const pre: LiveGame = {
+  id: "1",
+  status: "pre",
+  statusDetail: "10/3 - 7:00 PM EDT",
+  clock: "",
+  period: 0,
+  homeTeam: "TOR",
+  homeScore: null,
+  homeRecord: "",
+  awayTeam: "MIA",
+  awayScore: null,
+  awayRecord: "",
+  venue: "",
+  tv: "",
+};
+
+const live: LiveGame = { ...pre, id: "2", status: "in", statusDetail: "Q2 4:12", homeScore: 40, awayScore: 38 };
+
+describe("scorebarVisibility", () => {
+  it("hides future preseason games during the offseason", () => {
+    expect(scorebarGamesToShow([pre], true)).toEqual([]);
+    expect(shouldShowLiveScorebar([pre], true)).toBe(false);
+  });
+
+  it("keeps live games in the offseason and all games in season", () => {
+    expect(shouldShowLiveScorebar([live], true)).toBe(true);
+    expect(scorebarGamesToShow([pre, live], false)).toHaveLength(2);
+  });
+});

--- a/client/src/__tests__/siteNav.test.ts
+++ b/client/src/__tests__/siteNav.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { headerNavLinks, mobileBottomNavLinks, publicToolsDirectory, TOOLS_DIRECTORY } from "../lib/siteNav";
+
+describe("siteNav", () => {
+  it("uses offseason chrome in August dead period", () => {
+    const august = new Date(Date.UTC(2026, 7, 29));
+    const header = headerNavLinks(august).map((l) => l.label);
+    const mobile = mobileBottomNavLinks(august).map((l) => l.label);
+
+    expect(header).toEqual(["Pulse", "Briefing", "Injuries", "Projections", "Tools"]);
+    expect(mobile).toEqual(["Today", "Pulse", "Projections", "My Pulse", "Ask"]);
+    expect(header).not.toContain("Playoffs");
+    expect(mobile).not.toContain("Live");
+  });
+
+  it("uses in-season chrome in January", () => {
+    const january = new Date(Date.UTC(2026, 0, 15));
+    const header = headerNavLinks(january).map((l) => l.label);
+    const mobile = mobileBottomNavLinks(january).map((l) => l.label);
+
+    expect(header).toContain("Scores");
+    expect(header).toContain("Tonight");
+    expect(mobile).toContain("Scores");
+    expect(mobile).not.toContain("Live");
+    expect(mobile).toContain("Picks");
+  });
+
+  it("hides admin and opt-out routes from the public tools grid", () => {
+    const hrefs = publicToolsDirectory().map((t) => t.href);
+    expect(hrefs).not.toContain("/creator-queue");
+    expect(hrefs).not.toContain("/unsubscribe");
+    expect(hrefs).not.toContain("/embed-stats");
+    expect(TOOLS_DIRECTORY.some((t) => t.href === "/creator-queue")).toBe(true);
+  });
+});

--- a/client/src/components/AskHoopsIntel.tsx
+++ b/client/src/components/AskHoopsIntel.tsx
@@ -1,4 +1,6 @@
 import { useState, useRef, useEffect, useCallback, type ReactElement } from "react";
+import { useFocusTrap } from "../hooks/useFocusTrap";
+import { useBodyScrollLock } from "../hooks/useBodyScrollLock";
 import { searchContext } from "../lib/hoopsSearch";
 import { contextualAskChips } from "../lib/askShortcuts";
 
@@ -214,7 +216,7 @@ export function AskPromptChips({ onSelect }: { onSelect: (q: string) => void }) 
           style={{
             background: "rgba(14,165,233,0.08)",
             border: "1px solid rgba(14,165,233,0.15)",
-            color: "rgba(255,255,255,0.6)",
+            color: "var(--hi-muted, rgba(255,255,255,0.72))",
           }}
           onMouseEnter={(e) => {
             e.currentTarget.style.background = "rgba(14,165,233,0.15)";
@@ -222,7 +224,7 @@ export function AskPromptChips({ onSelect }: { onSelect: (q: string) => void }) 
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.background = "rgba(14,165,233,0.08)";
-            e.currentTarget.style.color = "rgba(255,255,255,0.6)";
+            e.currentTarget.style.color = "var(--hi-muted, rgba(255,255,255,0.72))";
           }}
         >
           {q}
@@ -339,17 +341,22 @@ export function ChatInput({
   setInput,
   isLoading,
   onSend,
+  inputId = "ask-hoops-intel-input",
 }: {
   input: string;
   setInput: (v: string) => void;
   isLoading: boolean;
   onSend: () => void;
+  inputId?: string;
 }) {
   return (
     <div
       className="px-3 py-3 border-t"
       style={{ borderColor: "rgba(255,255,255,0.06)" }}
     >
+      <label htmlFor={inputId} className="block text-xs font-medium mb-2 text-white">
+        Ask Hoops Intel
+      </label>
       <div
         className="flex items-center gap-2 rounded-lg px-3 py-2"
         style={{
@@ -358,6 +365,7 @@ export function ChatInput({
         }}
       >
         <input
+          id={inputId}
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
@@ -369,7 +377,7 @@ export function ChatInput({
           }}
           placeholder="Ask about NBA games, players, stats..."
           maxLength={500}
-          className="flex-1 bg-transparent text-base sm:text-xs text-white placeholder-white/30 outline-none min-h-[44px] sm:min-h-0"
+          className="flex-1 bg-transparent text-base sm:text-sm text-white placeholder-white/40 outline-none min-h-[44px]"
           disabled={isLoading}
         />
         <button
@@ -377,7 +385,7 @@ export function ChatInput({
           onClick={onSend}
           disabled={isLoading || !input.trim()}
           aria-label="Send message"
-          className="flex-shrink-0 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0 sm:w-7 sm:h-7 rounded-lg flex items-center justify-center transition-all"
+          className="flex-shrink-0 min-h-[44px] px-3 rounded-lg flex items-center justify-center gap-1 text-xs font-semibold transition-all"
           style={{
             background:
               isLoading || !input.trim()
@@ -389,10 +397,11 @@ export function ChatInput({
                 : "#0EA5E9",
           }}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
             <line x1="22" y1="2" x2="11" y2="13" />
             <polygon points="22 2 15 22 11 13 2 9 22 2" />
           </svg>
+          <span>Send</span>
         </button>
       </div>
       <div
@@ -412,6 +421,15 @@ export function ChatInput({
 export default function AskHoopsIntel() {
   const [isOpen, setIsOpen] = useState(false);
   const { messages, input, setInput, isLoading, sendMessage } = useChatEngine();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  useFocusTrap(isOpen, panelRef);
+  useBodyScrollLock(isOpen);
+
+  const closePanel = useCallback(() => {
+    setIsOpen(false);
+    queueMicrotask(() => triggerRef.current?.focus());
+  }, []);
 
   useEffect(() => {
     const handler = (event: Event) => {
@@ -424,12 +442,25 @@ export default function AskHoopsIntel() {
     return () => window.removeEventListener("hoops-intel:ask", handler);
   }, [sendMessage]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closePanel();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, closePanel]);
+
   return (
     <>
       {/* Floating Button */}
       {!isOpen && (
         <button
           type="button"
+          ref={triggerRef}
           onClick={() => setIsOpen(true)}
           className="fixed z-50 flex items-center gap-2 min-h-[48px] px-4 py-3 rounded-full shadow-lg transition-all hover:scale-[1.02] md:bottom-6"
           style={{
@@ -446,13 +477,14 @@ export default function AskHoopsIntel() {
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />
           </svg>
-          <span className="text-sm font-semibold">Ask AI</span>
+          <span className="text-sm font-semibold">Ask Hoops Intel</span>
         </button>
       )}
 
       {/* Chat Panel */}
       {isOpen && (
         <div
+          ref={panelRef}
           className="ask-chat-panel fixed z-50 flex flex-col"
           role="dialog"
           aria-labelledby="floating-chat-title"
@@ -497,7 +529,7 @@ export default function AskHoopsIntel() {
                 className="text-xs min-h-[44px] min-w-[44px] flex items-center justify-center px-2 py-2 rounded-lg transition-colors hover:text-sky-400"
                 style={{ color: "rgba(255,255,255,0.55)", background: "rgba(255,255,255,0.05)" }}
                 title="Open full page"
-                aria-label="Open full Ask AI page"
+                aria-label="Open full Ask Hoops Intel page"
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
@@ -505,7 +537,7 @@ export default function AskHoopsIntel() {
               </a>
               <button
                 type="button"
-                onClick={() => setIsOpen(false)}
+                onClick={closePanel}
                 className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-xs transition-colors hover:bg-white/10"
                 style={{ color: "rgba(255,255,255,0.6)" }}
                 aria-label="Close assistant"
@@ -531,6 +563,7 @@ export default function AskHoopsIntel() {
             setInput={setInput}
             isLoading={isLoading}
             onSend={() => sendMessage()}
+            inputId="ask-hoops-intel-floating"
           />
         </div>
       )}

--- a/client/src/components/DeskSectionNav.tsx
+++ b/client/src/components/DeskSectionNav.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
-import { DESK_SECTION_LINKS } from "../lib/siteNav";
+import { deskSectionLinks } from "../lib/siteNav";
 import { isPlayoffsActive } from "../lib/playoffData";
 
 export default function DeskSectionNav() {
   const [activeId, setActiveId] = useState<string>("");
 
   const links = useMemo(() => {
-    if (!isPlayoffsActive()) return DESK_SECTION_LINKS;
+    const base = deskSectionLinks();
+    if (!isPlayoffsActive()) return base;
     const playoffLink = { label: "Playoffs", href: "#playoffs" };
-    const idx = DESK_SECTION_LINKS.findIndex((l) => l.href === "#injuries");
-    const next = [...DESK_SECTION_LINKS];
+    const idx = base.findIndex((l) => l.href === "#injuries");
+    const next = [...base];
     next.splice(idx + 1, 0, playoffLink);
     return next;
   }, []);

--- a/client/src/components/MobileBottomNav.tsx
+++ b/client/src/components/MobileBottomNav.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from "wouter";
-import { MOBILE_BOTTOM_NAV_LINKS, PLAYOFFS_NAV_HREF, playoffsNavLabel } from "../lib/siteNav";
+import { mobileBottomNavLinks, PLAYOFFS_NAV_HREF, playoffsNavLabel } from "../lib/siteNav";
 import { hapticTap } from "../lib/haptic";
 
 function NavIcon({ label, href }: { label: string; href: string }) {
@@ -11,6 +11,28 @@ function NavIcon({ label, href }: { label: string; href: string }) {
       <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
         <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
         <polyline points="9 22 9 12 15 12 15 22" />
+      </svg>
+    );
+  }
+  if (label === "Pulse") {
+    return (
+      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
+        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+      </svg>
+    );
+  }
+  if (label === "Projections") {
+    return (
+      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
+        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+        <polyline points="17 6 23 6 23 12" />
+      </svg>
+    );
+  }
+  if (label === "Ask") {
+    return (
+      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
+        <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />
       </svg>
     );
   }
@@ -100,7 +122,7 @@ export default function MobileBottomNav() {
       aria-label="Primary mobile navigation"
     >
       <div className="grid grid-cols-5">
-        {MOBILE_BOTTOM_NAV_LINKS.map((link) => {
+        {mobileBottomNavLinks().map((link) => {
           const active = linkActive(link.href, location);
           const navLabel = link.href === PLAYOFFS_NAV_HREF ? playoffsNavLabel() : link.label;
           return (

--- a/client/src/components/OffseasonDeskStrip.tsx
+++ b/client/src/components/OffseasonDeskStrip.tsx
@@ -1,7 +1,6 @@
 import { draftData } from "../lib/draftData";
 import {
   activeEditionContext,
-  activeGeneratorScript,
   editionContextDeskLabel,
   isOffseasonDesk,
   offseasonPrimaryCta,
@@ -43,7 +42,7 @@ export default function OffseasonDeskStrip() {
             className="min-h-[44px] inline-flex items-center px-4 py-2 rounded text-sm font-semibold text-white transition-all hover:opacity-95"
             style={{ background: "linear-gradient(135deg, #8B5CF6, #6D28D9)" }}
           >
-            {cta.emoji} {cta.label} →
+            {cta.label} →
           </a>
         </div>
 
@@ -97,9 +96,6 @@ export default function OffseasonDeskStrip() {
             {topRiser.reason}
           </p>
         ) : null}
-        <p className="text-[10px] mt-4 text-white/30 mono-data">
-          Pipeline: {activeGeneratorScript()} · desk label synced with season-mode
-        </p>
       </div>
     </section>
   );

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { useTheme } from "../contexts/ThemeContext";
-import { MAIN_NAV_LINKS, HEADER_NAV_LINKS, PLAYOFFS_NAV_HREF, playoffsNavLabel } from "../lib/siteNav";
+import { headerNavLinks, mainNavLinks, PLAYOFFS_NAV_HREF, playoffsNavLabel } from "../lib/siteNav";
 import { globalSearch, type SearchResult } from "../lib/searchUtils";
 import AuthModal from "./AuthModal";
 import { getUser, type User } from "../lib/supabaseClient";
@@ -92,7 +92,7 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
       <button
         type="button"
         onClick={() => setShowModal(!showModal)}
-        className="relative min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors hover:bg-white/10 sm:min-h-0 sm:min-w-0 sm:p-1.5"
+        className="relative min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors hover:bg-white/10"
         title="Notifications"
         aria-label="Notifications menu"
       >
@@ -126,36 +126,29 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
           <div className="p-4">
             <div className="section-label mb-3">NOTIFICATIONS</div>
 
-            <p className="text-[11px] leading-relaxed mb-3" style={{ color: "rgba(255,255,255,0.45)" }}>
-              <span className="text-white/60 font-medium">Email digest:</span> morning drop at 5 AM PST (sign up below).
-              Push alerts use a separate flow:{" "}
-              <span className="text-white/60 font-medium">sign in</span>, then{" "}
-              <a href="/account#browser-push" className="underline text-sky-400/95">
-                Account → Browser push
-              </a>{" "}
-              to register this device and choose topics (elimination, clinchers, injury wire, fantasy).&nbsp;
-              <a href="/playoffs" className="underline text-sky-400/95">
-                Playoff board →
-              </a>
-            </p>
-
-            <div className="mb-4">
+            <div className="mb-4 space-y-2">
+              <p className="text-xs font-semibold text-white">Email digest</p>
+              <p className="text-xs leading-relaxed" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+                Morning edition at 5 AM PST.
+              </p>
+            </div>
+            <div className="mb-4 space-y-2">
+              <p className="text-xs font-semibold text-white">Browser push</p>
+              <p className="text-xs leading-relaxed mb-2" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+                Sign in, then register this device and pick topics.
+              </p>
               <a
                 href="/account#browser-push"
-                className="block w-full text-left px-3 py-2 rounded text-xs font-medium transition-colors min-h-[44px] sm:min-h-0 flex items-center"
+                className="block w-full text-left px-3 py-2 rounded text-xs font-medium transition-colors min-h-[44px] flex items-center"
                 style={{
                   background: "rgba(14,165,233,0.1)",
                   color: "#0EA5E9",
                   border: "1px solid rgba(14,165,233,0.2)",
                 }}
               >
-                Set up browser push & topics →
+                Set up browser push →
               </a>
             </div>
-
-            <p className="text-xs mb-2" style={{ color: "rgba(255,255,255,0.5)" }}>
-              Daily email digest at 5 AM PST
-            </p>
 
             {subscribed ? (
               <div className="px-3 py-2 rounded text-xs" style={{ background: "rgba(16,185,129,0.1)", color: "#10B981" }}>
@@ -283,20 +276,20 @@ function SearchDialog({
 
   if (!open) return null;
 
-  const iconForType = (type: string) => {
+  const labelForType = (type: string) => {
     switch (type) {
       case "player":
-        return "👤";
+        return "Player";
       case "team":
-        return "🏀";
+        return "Team";
       case "game":
-        return "📊";
+        return "Game";
       case "injury":
-        return "🏥";
+        return "Injury";
       case "story":
-        return "📰";
+        return "Story";
       default:
-        return "📌";
+        return "Page";
     }
   };
 
@@ -357,8 +350,33 @@ function SearchDialog({
         </div>
         <div className="max-h-[min(20rem,50vh)] overflow-y-auto overscroll-contain">
           {results.length === 0 && query.length >= 2 && (
-            <div className="px-4 py-8 text-center text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>
-              No results found
+            <div className="px-4 py-6 text-center">
+              <p className="text-sm mb-3" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+                No results for “{query.trim()}”. Try a player, team, or one of these:
+              </p>
+              <div className="flex flex-wrap justify-center gap-2 mb-3">
+                {POPULAR_SEARCH_DESTINATIONS.map((d) => (
+                  <a
+                    key={d.href}
+                    href={d.href}
+                    className="text-xs px-3 py-2 rounded-lg min-h-[36px] inline-flex items-center"
+                    style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.8)" }}
+                    onClick={onClose}
+                  >
+                    {d.label}
+                  </a>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="text-xs text-sky-400 underline min-h-[44px]"
+                onClick={() => {
+                  setQuery("");
+                  inputRef.current?.focus();
+                }}
+              >
+                Clear query
+              </button>
             </div>
           )}
           {results.length === 0 && query.length < 2 && (
@@ -419,8 +437,11 @@ function SearchDialog({
                 }
               }}
             >
-              <span className="text-base" aria-hidden>
-                {iconForType(r.type)}
+              <span
+                className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0"
+                style={{ background: "rgba(255,255,255,0.08)", color: "var(--hi-muted, rgba(255,255,255,0.72))" }}
+              >
+                {labelForType(r.type)}
               </span>
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium text-white truncate">{r.title}</div>
@@ -512,7 +533,7 @@ export default function SiteHeader({
   }, [mobileOpen]);
 
   const navLinkClass =
-    "text-xs font-medium transition-colors hover:text-[#0EA5E9] px-3 py-2 rounded-lg min-h-[44px] flex items-center md:min-h-0 md:inline-flex md:py-1 md:px-0 [&:focus-visible]:outline [&:focus-visible]:outline-offset-2 [&:focus-visible]:outline-sky-500";
+    "text-xs font-medium transition-colors hover:text-[#0EA5E9] px-3 py-2 rounded-lg min-h-[44px] flex items-center md:inline-flex [&:focus-visible]:outline [&:focus-visible]:outline-offset-2 [&:focus-visible]:outline-sky-500";
 
   return (
     <>
@@ -572,7 +593,7 @@ export default function SiteHeader({
             </div>
 
             <nav className="hidden md:flex items-center gap-3 xl:gap-5" aria-label="Primary">
-              {HEADER_NAV_LINKS.map(({ label, href }) => {
+              {headerNavLinks().map(({ label, href }) => {
                 const navLabel = href === PLAYOFFS_NAV_HREF ? playoffsNavLabel() : label;
                 return (
                 <a
@@ -580,7 +601,7 @@ export default function SiteHeader({
                   href={href}
                   className={navLinkClass}
                   style={{
-                    color: navRouteMatches(href, locationPath) ? "#0EA5E9" : "rgba(255,255,255,0.5)",
+                    color: navRouteMatches(href, locationPath) ? "#0EA5E9" : "var(--hi-muted, rgba(255,255,255,0.72))",
                   }}
                   {...navAriaCurrent(href, locationPath)}
                 >
@@ -591,7 +612,7 @@ export default function SiteHeader({
               <details className="relative group">
                 <summary
                   className={`${navLinkClass} list-none cursor-pointer [&::-webkit-details-marker]:hidden`}
-                  style={{ color: "rgba(255,255,255,0.5)" }}
+                  style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}
                 >
                   More
                 </summary>
@@ -599,7 +620,7 @@ export default function SiteHeader({
                   className="absolute right-0 top-full mt-2 min-w-[11rem] rounded-lg py-2 shadow-xl z-[60]"
                   style={{ background: "#0A1628", border: "1px solid rgba(255,255,255,0.1)" }}
                 >
-                  {MAIN_NAV_LINKS.filter((l) => !HEADER_NAV_LINKS.some((h) => h.href === l.href)).map(({ label, href }) => (
+                  {mainNavLinks().filter((l) => !headerNavLinks().some((h) => h.href === l.href)).map(({ label, href }) => (
                     <a
                       key={`more-${label}`}
                       href={href}
@@ -621,7 +642,7 @@ export default function SiteHeader({
               <button
                 type="button"
                 onClick={() => setSearchOpen(true)}
-                className="flex items-center gap-2 min-h-[44px] px-3 py-2 rounded-lg text-xs transition-colors hover:bg-white/10 sm:min-h-0 sm:py-1.5"
+                className="flex items-center gap-2 min-h-[44px] px-3 py-2 rounded-lg text-xs transition-colors hover:bg-white/10"
                 style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.4)" }}
                 aria-haspopup="dialog"
                 aria-label="Open search"
@@ -639,7 +660,7 @@ export default function SiteHeader({
               <button
                 type="button"
                 onClick={toggleTheme}
-                className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors hover:bg-white/10 sm:min-h-0 sm:min-w-0 sm:p-1.5"
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors hover:bg-white/10"
                 title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
                 aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
               >
@@ -673,7 +694,7 @@ export default function SiteHeader({
               ) : sessionUser ? (
                 <a
                   href="/account"
-                  className="hidden sm:flex items-center gap-1 min-h-[44px] px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10 sm:min-h-0 sm:py-1.5"
+                  className="flex items-center gap-1 min-h-[44px] px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
                   style={{ background: "rgba(14,165,233,0.12)", color: "#7dd3fc", border: "1px solid rgba(14,165,233,0.25)" }}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
@@ -687,8 +708,8 @@ export default function SiteHeader({
                   type="button"
                   onClick={() => setShowAuth(true)}
                   aria-label="Sign in to your account"
-                  className="hidden sm:flex items-center gap-1 min-h-[44px] px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10 sm:min-h-0 sm:py-1.5"
-                  style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.5)" }}
+                  className="flex items-center gap-1 min-h-[44px] px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
+                  style={{ background: "rgba(255,255,255,0.05)", color: "var(--hi-muted, rgba(255,255,255,0.72))" }}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
                     <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
@@ -730,7 +751,7 @@ export default function SiteHeader({
               <a href="/" className="text-sm font-semibold text-sky-400 py-3 px-3 rounded-lg hover:bg-white/5" onClick={() => setMobileOpen(false)}>
                 Today’s desk →
               </a>
-              {MAIN_NAV_LINKS.map(({ label, href }) => {
+              {mainNavLinks().map(({ label, href }) => {
                 const active = navRouteMatches(href, locationPath);
                 const navLabel = href === PLAYOFFS_NAV_HREF ? playoffsNavLabel() : label;
                 return (

--- a/client/src/lib/deskBriefing.ts
+++ b/client/src/lib/deskBriefing.ts
@@ -37,6 +37,8 @@ export function buildSixtySecondBullets(): string[] {
       bullets.push("Free agency desk — cap tiers and rotation fit on Trade Value");
     } else if (ctx === "preseason") {
       bullets.push("Preseason desk — rotation battles and minutes caps on Lineups");
+    } else if (ctx === "dead-period") {
+      bullets.push("Offseason desk — roster construction and season-ahead projections");
     }
   }
 

--- a/client/src/lib/deskMode.ts
+++ b/client/src/lib/deskMode.ts
@@ -80,11 +80,17 @@ export function seasonModeToEditionContext(mode: ClientSeasonMode): EditionConte
   }
 }
 
-/** Edition context from pulse data, with calendar fallback when unset or legacy. */
+/** Edition context from pulse data, with calendar fallback when unset or stale. */
 export function activeEditionContext(date = new Date()): EditionContext {
+  const cal = seasonModeToEditionContext(clientSeasonMode(date));
   const raw = pulseEdition.editionContext;
-  if (raw && EDITION_CONTEXTS.has(raw)) return raw as EditionContext;
-  return seasonModeToEditionContext(clientSeasonMode(date));
+  if (raw && EDITION_CONTEXTS.has(raw)) {
+    const fromData = raw as EditionContext;
+    // Stale "regular" metadata during calendar offseason — chrome follows the calendar.
+    if (fromData === "regular" && OFFSEASON_CONTEXTS.has(cal)) return cal;
+    return fromData;
+  }
+  return cal;
 }
 
 export function isOffseasonDesk(date = new Date()): boolean {
@@ -112,20 +118,20 @@ export function offseasonPrimaryHref(date = new Date()): string {
   }
 }
 
-export function offseasonPrimaryCta(date = new Date()): { label: string; href: string; emoji: string } {
+export function offseasonPrimaryCta(date = new Date()): { label: string; href: string } {
   switch (activeEditionContext(date)) {
     case "draft":
-      return { label: "Draft big board", href: "/draft", emoji: "📋" };
+      return { label: "Draft big board", href: "/draft" };
     case "free-agency":
-      return { label: "Free agency desk", href: "/trade-value", emoji: "💰" };
+      return { label: "Free agency desk", href: "/trade-value" };
     case "summer-league":
-      return { label: "Summer League watch", href: "/draft", emoji: "☀️" };
+      return { label: "Summer League watch", href: "/draft" };
     case "preseason":
-      return { label: "Rotation battles", href: "/lineups", emoji: "🏀" };
+      return { label: "Rotation battles", href: "/lineups" };
     case "dead-period":
-      return { label: "Season projections", href: "/projections", emoji: "📈" };
+      return { label: "Season projections", href: "/projections" };
     default:
-      return { label: "All tools", href: "/tools", emoji: "🛠️" };
+      return { label: "All tools", href: "/tools" };
   }
 }
 

--- a/client/src/lib/deskMode.ts
+++ b/client/src/lib/deskMode.ts
@@ -80,16 +80,18 @@ export function seasonModeToEditionContext(mode: ClientSeasonMode): EditionConte
   }
 }
 
-/** Edition context from pulse data, with calendar fallback when unset or stale. */
+/**
+ * Chrome follows the calendar for `date`. Edition metadata can only pull
+ * regular-season chrome into playoffs/finals (series started early).
+ * Stale "regular" or leftover "dead-period" never overrides a later window.
+ */
 export function activeEditionContext(date = new Date()): EditionContext {
   const cal = seasonModeToEditionContext(clientSeasonMode(date));
   const raw = pulseEdition.editionContext;
-  if (raw && EDITION_CONTEXTS.has(raw)) {
-    const fromData = raw as EditionContext;
-    // Stale "regular" metadata during calendar offseason — chrome follows the calendar.
-    if (fromData === "regular" && OFFSEASON_CONTEXTS.has(cal)) return cal;
-    return fromData;
-  }
+  const fromData = raw && EDITION_CONTEXTS.has(raw) ? (raw as EditionContext) : null;
+
+  if (OFFSEASON_CONTEXTS.has(cal)) return cal;
+  if (cal === "regular" && (fromData === "playoffs" || fromData === "finals")) return fromData;
   return cal;
 }
 

--- a/client/src/lib/pulseRationale.ts
+++ b/client/src/lib/pulseRationale.ts
@@ -1,3 +1,8 @@
+/** First plain-language reason for a Pulse row — shown on the card, not behind ?. */
+export function pulseLeadLine(rationale: string, note?: string): string {
+  return rationaleToBullets(rationale, note)[0] || "";
+}
+
 /** Split editorial rationale into up to three scannable bullets for the rank explainer. */
 export function rationaleToBullets(rationale: string, note?: string): string[] {
   const splitSentences = (text: string) =>

--- a/client/src/lib/scorebarVisibility.ts
+++ b/client/src/lib/scorebarVisibility.ts
@@ -1,0 +1,11 @@
+import type { LiveGame } from "./espnApi";
+
+/** Games that belong on the homepage ticker. Future preseason slates stay hidden in the offseason. */
+export function scorebarGamesToShow(games: LiveGame[], offseason: boolean): LiveGame[] {
+  if (!offseason) return games;
+  return games.filter((g) => g.status === "in" || g.status === "post");
+}
+
+export function shouldShowLiveScorebar(games: LiveGame[], offseason: boolean): boolean {
+  return scorebarGamesToShow(games, offseason).length > 0;
+}

--- a/client/src/lib/searchHistory.ts
+++ b/client/src/lib/searchHistory.ts
@@ -2,14 +2,12 @@ const KEY = "hi-recent-searches";
 const MAX = 5;
 
 export const POPULAR_SEARCH_DESTINATIONS = [
-  { label: "Playoffs bracket", href: "/playoffs" },
+  { label: "Pulse", href: "/#pulse-index" },
   { label: "Injury report", href: "/injuries" },
-  { label: "Watch guide", href: "/watch-guide" },
-  { label: "Projections", href: "/projections" },
+  { label: "Season projections", href: "/projections" },
   { label: "Compare players", href: "/compare-players" },
-  { label: "History engine", href: "/history" },
-  { label: "Pulse history", href: "/pulse-history" },
-  { label: "Ask AI", href: "/ask" },
+  { label: "Watch guide", href: "/watch-guide" },
+  { label: "Ask Hoops Intel", href: "/ask" },
 ];
 
 export function readRecentSearches(): string[] {

--- a/client/src/lib/siteNav.ts
+++ b/client/src/lib/siteNav.ts
@@ -5,7 +5,7 @@ export const PLAYOFFS_NAV_HREF = "/playoffs";
 
 /** Header + mobile bottom nav label during synced postseason. */
 export function playoffsNavLabel(): string {
-  return isPlayoffsActive() ? "Playoff bracket" : "Playoffs";
+  return isPlayoffsActive() ? "Playoffs" : "Playoffs";
 }
 
 /** Primary desk navigation — hashes resolve on home */
@@ -14,44 +14,67 @@ export interface MainNavLink {
   href: string;
 }
 
-/** Compact header links (desktop) */
-export const HEADER_NAV_LINKS: MainNavLink[] = [
-  { label: "Scores", href: "/#scores" },
-  { label: "Pulse", href: "/#pulse-index" },
-  { label: "Injuries", href: "/injuries" },
-  { label: "Tonight", href: "/#tonight" },
-  { label: "Playoffs", href: "/playoffs" },
-  { label: "Tools", href: "/tools" },
-];
+/** Compact header links (desktop) — season-aware. */
+export function headerNavLinks(date = new Date()): MainNavLink[] {
+  if (isOffseasonDesk(date)) {
+    return [
+      { label: "Pulse", href: "/#pulse-index" },
+      { label: "Briefing", href: "/#today-desk" },
+      { label: "Injuries", href: "/injuries" },
+      { label: "Projections", href: offseasonPrimaryHref(date) },
+      { label: "Tools", href: "/tools" },
+    ];
+  }
+  return [
+    { label: "Scores", href: "/#scores" },
+    { label: "Pulse", href: "/#pulse-index" },
+    { label: "Injuries", href: "/injuries" },
+    { label: "Tonight", href: "/#tonight" },
+    { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
+    { label: "Tools", href: "/tools" },
+  ];
+}
 
 /** Full drawer navigation (mobile menu + overflow) */
-export const MAIN_NAV_LINKS: MainNavLink[] = [
-  { label: "Scores", href: "/#scores" },
-  { label: "Pulse Index", href: "/#pulse-index" },
-  { label: "Injuries", href: "/injuries" },
-  { label: "Tonight", href: "/#tonight" },
-  { label: "Watch guide", href: "/watch-guide" },
-  { label: "Playoffs", href: "/playoffs" },
-  { label: "Archive", href: "/archive" },
-  { label: "All tools", href: "/tools" },
-  { label: "Projections", href: "/projections" },
-  { label: "Compare", href: "/compare-players" },
-  { label: "Performance", href: "/performance" },
-  { label: "Hoops IQ", href: "/trivia" },
-  { label: "Ask AI", href: "/ask" },
-];
+export function mainNavLinks(date = new Date()): MainNavLink[] {
+  const seasonal = isOffseasonDesk(date)
+    ? [
+        { label: "Pulse", href: "/#pulse-index" },
+        { label: "Briefing", href: "/#today-desk" },
+        { label: "Injuries", href: "/injuries" },
+        { label: "Projections", href: offseasonPrimaryHref(date) },
+      ]
+    : [
+        { label: "Scores", href: "/#scores" },
+        { label: "Pulse", href: "/#pulse-index" },
+        { label: "Injuries", href: "/injuries" },
+        { label: "Tonight", href: "/#tonight" },
+        { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
+      ];
+
+  return [
+    ...seasonal,
+    { label: "Watch guide", href: "/watch-guide" },
+    { label: "Archive", href: "/archive" },
+    { label: "Tools", href: "/tools" },
+    { label: "Projections", href: "/projections" },
+    { label: "Compare", href: "/compare-players" },
+    { label: "Performance", href: "/performance" },
+    { label: "Hoops IQ", href: "/trivia" },
+    { label: "Ask Hoops Intel", href: "/ask" },
+  ].filter((link, index, all) => all.findIndex((l) => l.href === link.href) === index);
+}
 
 /** Home footer explore links — keep discoverable product routes out of crawl orphan status. */
 export const FOOTER_QUICK_LINKS: MainNavLink[] = [
-  { label: "Scores", href: "#scores" },
-  { label: "Pulse Index", href: "#pulse-index" },
+  { label: "Briefing", href: "#today-desk" },
+  { label: "Pulse", href: "#pulse-index" },
   { label: "Injuries", href: "#injuries" },
-  { label: "Tonight", href: "#tonight" },
-  { label: "Archive", href: "/archive" },
-  { label: "All tools", href: "/tools" },
-  { label: "Playoffs", href: "/playoffs" },
-  { label: "Watch guide", href: "/watch-guide" },
   { label: "Projections", href: "/projections" },
+  { label: "Archive", href: "/archive" },
+  { label: "Tools", href: "/tools" },
+  { label: "My Pulse", href: "/my-pulse" },
+  { label: "Watch guide", href: "/watch-guide" },
   { label: "Compare players", href: "/compare-players" },
   { label: "History", href: "/history" },
   { label: "Refs", href: "/refs" },
@@ -63,22 +86,53 @@ export const FOOTER_QUICK_LINKS: MainNavLink[] = [
 ];
 
 /** Sticky in-page section jumps on today's desk */
-export const DESK_SECTION_LINKS: MainNavLink[] = [
-  { label: "Briefing", href: "#today-desk" },
-  { label: "Scores", href: "#scores" },
-  { label: "Pulse", href: "#pulse-index" },
-  { label: "Injuries", href: "#injuries" },
-  { label: "Tonight", href: "#tonight" },
-  { label: "Standings", href: "#standings" },
-];
+export function deskSectionLinks(date = new Date()): MainNavLink[] {
+  if (isOffseasonDesk(date)) {
+    return [
+      { label: "Briefing", href: "#today-desk" },
+      { label: "Pulse", href: "#pulse-index" },
+      { label: "Injuries", href: "#injuries" },
+      { label: "Outlook", href: "#offseason-desk" },
+      { label: "Standings", href: "#standings" },
+    ];
+  }
+  return [
+    { label: "Briefing", href: "#today-desk" },
+    { label: "Scores", href: "#scores" },
+    { label: "Pulse", href: "#pulse-index" },
+    { label: "Injuries", href: "#injuries" },
+    { label: "Tonight", href: "#tonight" },
+    { label: "Standings", href: "#standings" },
+  ];
+}
 
-export const MOBILE_BOTTOM_NAV_LINKS: MainNavLink[] = [
-  { label: "Today", href: "/" },
-  { label: "Live", href: "/#scores" },
-  { label: "Playoffs", href: PLAYOFFS_NAV_HREF },
-  { label: "My Pulse", href: "/my-pulse" },
-  { label: "Picks", href: "/pick-em" },
-];
+export function mobileBottomNavLinks(date = new Date()): MainNavLink[] {
+  if (isOffseasonDesk(date)) {
+    return [
+      { label: "Today", href: "/" },
+      { label: "Pulse", href: "/#pulse-index" },
+      { label: "Projections", href: offseasonPrimaryHref(date) },
+      { label: "My Pulse", href: "/my-pulse" },
+      { label: "Ask", href: "/ask" },
+    ];
+  }
+  return [
+    { label: "Today", href: "/" },
+    { label: "Scores", href: "/#scores" },
+    { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
+    { label: "My Pulse", href: "/my-pulse" },
+    { label: "Picks", href: "/pick-em" },
+  ];
+}
+
+/** @deprecated Prefer headerNavLinks() — snapshot at module load for older imports. */
+export const HEADER_NAV_LINKS: MainNavLink[] = headerNavLinks();
+/** @deprecated Prefer mainNavLinks() */
+export const MAIN_NAV_LINKS: MainNavLink[] = mainNavLinks();
+/** @deprecated Prefer deskSectionLinks() */
+export const DESK_SECTION_LINKS: MainNavLink[] = deskSectionLinks();
+/** @deprecated Prefer mobileBottomNavLinks() */
+export const MOBILE_BOTTOM_NAV_LINKS: MainNavLink[] = mobileBottomNavLinks();
 
 /** All feature routes — Tools directory */
 export type ToolCategory = "desk" | "postseason" | "analysis" | "community" | "publishing";
@@ -98,6 +152,8 @@ export interface ToolLink {
   href: string;
   description: string;
   category: ToolCategory;
+  /** Hide from the public /tools grid (admin, opt-out, internals). */
+  hideFromDirectory?: boolean;
 }
 
 export const TOOLS_DIRECTORY: ToolLink[] = [
@@ -107,7 +163,7 @@ export const TOOLS_DIRECTORY: ToolLink[] = [
   { label: "My Pulse", href: "/my-pulse", description: "Personalized edition", category: "desk" },
   { label: "Print edition", href: "/print-edition", description: "Clean PDF / print sheet", category: "desk" },
   { label: "Playoffs", href: "/playoffs", description: "Bracket and series board", category: "postseason" },
-  { label: "Pick ’Em", href: "/pick-em", description: "Bracket-style picks", category: "postseason" },
+  { label: "Picks", href: "/pick-em", description: "Bracket-style picks", category: "postseason" },
   { label: "Injuries", href: "/injuries", description: "Full injury report", category: "postseason" },
   { label: "Rival alerts", href: "/rivals", description: "Headline banners for grudge games", category: "postseason" },
   { label: "Performance", href: "/performance", description: "AI season tracker", category: "analysis" },
@@ -123,7 +179,7 @@ export const TOOLS_DIRECTORY: ToolLink[] = [
   { label: "Badges", href: "/badges", description: "Achievement badges", category: "analysis" },
   { label: "History engine", href: "/history", description: "Historical lookups", category: "analysis" },
   { label: "Ref reports", href: "/refs", description: "Crew tendencies", category: "analysis" },
-  { label: "Ask AI", href: "/ask", description: "Full-page assistant", category: "analysis" },
+  { label: "Ask Hoops Intel", href: "/ask", description: "Full-page assistant", category: "analysis" },
   { label: "Player compare", href: "/compare-players", description: "Pulse Index side-by-side", category: "analysis" },
   { label: "Pulse methodology", href: "/pulse-methodology", description: "How Pulse rankings are judged", category: "analysis" },
   { label: "82-0 Challenge", href: "/82-0", description: "Spin eras, draft a five, chase the perfect season", category: "community" },
@@ -137,23 +193,32 @@ export const TOOLS_DIRECTORY: ToolLink[] = [
     href: "/embed-stats",
     description: "Publisher dashboard — embed load trends and CSV export",
     category: "publishing",
+    hideFromDirectory: true,
   },
   {
     label: "Widget load timeline",
     href: "/widgets/analytics",
     description: "Stacked daily embed loads — pulse vs ticker vs injury",
     category: "publishing",
+    hideFromDirectory: true,
   },
   {
     label: "Guest Pulse queue",
     href: "/creator-queue",
     description: "Moderate Guest Pulse submissions (admin secret)",
     category: "publishing",
+    hideFromDirectory: true,
   },
   { label: "Account", href: "/account", description: "Profile, Pro billing, shortcuts", category: "publishing" },
   { label: "Hoops Intel Pro", href: "/pro", description: "Pro tier", category: "publishing" },
   { label: "Hoops IQ (Trivia)", href: "/trivia", description: "IQ challenges", category: "publishing" },
-  { label: "Unsubscribe digest", href: "/unsubscribe", description: "Email opt-out page", category: "publishing" },
+  {
+    label: "Unsubscribe digest",
+    href: "/unsubscribe",
+    description: "Email opt-out page",
+    category: "publishing",
+    hideFromDirectory: true,
+  },
 ];
 
 /** Publisher / embed surfaces — linked from /tools and /pro (noindex, not in sitemap). */
@@ -165,10 +230,16 @@ export function distributionTools() {
   );
 }
 
+export function publicToolsDirectory() {
+  return TOOLS_DIRECTORY.filter((t) => !t.hideFromDirectory);
+}
+
 /** Related tools in the same category (excluding current route). */
 export function relatedToolsForHref(href: string, limit = 4) {
   const path = href.split("#")[0] || href;
   const current = TOOLS_DIRECTORY.find((t) => t.href === path || path.startsWith(`${t.href}/`));
   const category = current?.category ?? "analysis";
-  return TOOLS_DIRECTORY.filter((t) => t.href !== path && t.category === category).slice(0, limit);
+  return publicToolsDirectory()
+    .filter((t) => t.href !== path && t.category === category)
+    .slice(0, limit);
 }

--- a/client/src/pages/AskAI.tsx
+++ b/client/src/pages/AskAI.tsx
@@ -90,6 +90,7 @@ export default function AskAI() {
             setInput={setInput}
             isLoading={isLoading}
             onSend={() => sendMessage()}
+            inputId="ask-hoops-intel-page"
           />
         </div>
       </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -59,10 +59,11 @@ import SixtySecondBriefing from "../components/SixtySecondBriefing";
 import SectionErrorBoundary from "../components/SectionErrorBoundary";
 import { AskPromptChips } from "../components/AskHoopsIntel";
 import { dispatchAskPrompt } from "../lib/askShortcuts";
-import { rationaleToBullets } from "../lib/pulseRationale";
+import { rationaleToBullets, pulseLeadLine } from "../lib/pulseRationale";
+import { shouldShowLiveScorebar, scorebarGamesToShow } from "../lib/scorebarVisibility";
 import PickEmHomeBanner from "../components/PickEmHomeBanner";
 import OffseasonDeskStrip from "../components/OffseasonDeskStrip";
-import { isOffseasonDesk, offseasonPrimaryCta, activeEditionContext, editionContextDeskLabel } from "../lib/deskMode";
+import { isOffseasonDesk, offseasonPrimaryCta, editionContextDeskLabel } from "../lib/deskMode";
 import { FOOTER_QUICK_LINKS } from "../lib/siteNav";
 import { liveScoresTrustLabel } from "../lib/dataTrust";
 import { lineMovementForMatchup, spreadMoved } from "../lib/lineMovement";
@@ -139,11 +140,15 @@ function ScoreboardCell({ g }: { g: LiveGame }) {
 
 function LiveScorebar() {
   const { data, error, refresh, loading } = useLiveScores();
-  const games = data?.games ?? [];
+  const games = scorebarGamesToShow(data?.games ?? [], isOffseasonDesk());
   const anyLive = games.some((g) => g.status === "in");
 
   if (loading && !data) {
     return <LiveScoreSkeleton />;
+  }
+
+  if (!shouldShowLiveScorebar(games, isOffseasonDesk()) && games.length === 0) {
+    return null;
   }
 
   if (games.length > 0) {
@@ -294,7 +299,7 @@ function PlayoffHeroCta() {
           : "linear-gradient(135deg, #F59E0B, #D97706)",
       }}
     >
-      <span>{finalsOn ? "🏆 NBA Finals desk" : `🏆 Playoffs live · ${activeCount} active series`}</span>
+      <span>{finalsOn ? "NBA Finals desk" : `Playoffs live · ${activeCount} active series`}</span>
       <span className="text-xs font-medium opacity-90 mono-data">{nextLabel}</span>
     </a>
   );
@@ -349,7 +354,9 @@ function HeroSection({ showMyPulse }: { showMyPulse: boolean }) {
       <div className="container py-12 md:py-16">
         <div className="max-w-4xl animate-fade-up">
           <div className="flex flex-wrap items-center gap-3 mb-3">
-            <div className="section-label">{finalsOn ? "NBA Finals Desk" : pulseEdition.edition}</div>
+            <div className="section-label">
+              {finalsOn ? "NBA Finals desk" : `${editionContextDeskLabel()} · ${pulseEdition.date}`}
+            </div>
             <DataTrustBadge variant="edition" />
           </div>
           <h1 className="display-heading text-white mb-4" style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}>
@@ -370,8 +377,15 @@ function HeroSection({ showMyPulse }: { showMyPulse: boolean }) {
               How Pulse works
             </a>
           </div>
-          <HeroLeadStory />
+          {!isOffseasonDesk() ? <HeroLeadStory /> : null}
           <div className="flex flex-wrap gap-3 items-center">
+            <a
+              href="#today-desk"
+              className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold text-white transition-all"
+              style={{ background: "#0EA5E9" }}
+            >
+              Read the brief
+            </a>
             {showMyPulse ? (
               <a
                 href="/my-pulse"
@@ -380,18 +394,25 @@ function HeroSection({ showMyPulse }: { showMyPulse: boolean }) {
               >
                 Your desk →
               </a>
-            ) : null}
-            {playoffsOn ? (
-              <PlayoffHeroCta />
             ) : (
               <a
-                href="/playoffs"
-                className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold text-white transition-all hover:opacity-95"
-                style={{ background: "linear-gradient(135deg, #F59E0B, #D97706)" }}
+                href="/my-pulse"
+                className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold transition-all"
+                style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.9)", border: "1px solid rgba(255,255,255,0.12)" }}
               >
-                🏆 Playoff bracket
+                Set My Pulse
               </a>
             )}
+            {isOffseasonDesk() ? (
+              <a
+                href={offseasonPrimaryCta().href}
+                className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold transition-all"
+                style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.9)", border: "1px solid rgba(255,255,255,0.12)" }}
+              >
+                {offseasonPrimaryCta().label}
+              </a>
+            ) : null}
+            {playoffsOn ? <PlayoffHeroCta /> : null}
             {finalsOn ? (
               <a
                 href="/print-edition"
@@ -401,20 +422,24 @@ function HeroSection({ showMyPulse }: { showMyPulse: boolean }) {
                 Finals print edition
               </a>
             ) : null}
-            <a
-              href="#scores"
-              className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold text-white transition-all"
-              style={{ background: "#0EA5E9" }}
-            >
-              Today’s scores
-            </a>
-            <a
-              href="#tonight"
-              className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold transition-all"
-              style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.85)", border: "1px solid rgba(255,255,255,0.12)" }}
-            >
-              Tonight’s games
-            </a>
+            {!isOffseasonDesk() && gameResults.length > 0 ? (
+              <a
+                href="#scores"
+                className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold transition-all"
+                style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.9)", border: "1px solid rgba(255,255,255,0.12)" }}
+              >
+                Scores
+              </a>
+            ) : null}
+            {!isOffseasonDesk() && gamePreviews.length > 0 ? (
+              <a
+                href="#tonight"
+                className="min-h-[48px] inline-flex items-center px-5 py-2.5 rounded text-sm font-semibold transition-all"
+                style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.9)", border: "1px solid rgba(255,255,255,0.12)" }}
+              >
+                Tonight
+              </a>
+            ) : null}
           </div>
           <details className="mt-4 max-w-xl rounded-lg border border-white/10 bg-black/25 open:bg-black/35 px-4 py-2">
             <summary className="text-xs cursor-pointer select-none outline-none hover:text-sky-400 [&::-webkit-details-marker]:hidden [&::marker]:content-none flex items-center gap-2 justify-between py-2" style={{ color: "rgba(255,255,255,0.45)" }}>
@@ -444,7 +469,7 @@ function HeroSection({ showMyPulse }: { showMyPulse: boolean }) {
                 My Pulse
               </a>
               <a href="/tools" className="text-xs font-medium underline-offset-4 hover:text-sky-400" style={{ color: "rgba(255,255,255,0.5)" }}>
-                All tools →
+                Tools →
               </a>
             </div>
           </details>
@@ -483,33 +508,33 @@ function TodayDeskSection() {
   return (
     <section id="today-desk" className="py-8 border-t border-white/[0.06]" aria-labelledby="today-desk-title">
       <div className="container">
-        <div className="mb-5 space-y-4">
+        <div className="mb-8 max-w-3xl">
+          <p className="section-label mb-2">Morning briefing</p>
+          <h2 id="today-desk-title" className="sr-only">
+            Today&apos;s desk
+          </h2>
+          <p className="text-lg leading-relaxed mb-5" style={{ color: "var(--hi-heading, #fff)" }}>
+            {narrative.subhead}
+          </p>
           <SectionErrorBoundary section="60-second read">
             <SixtySecondBriefing />
           </SectionErrorBoundary>
-          <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
-            <div className="section-label mb-2">ASK HOOPS INTEL</div>
-            <p className="text-xs mb-3" style={{ color: "rgba(255,255,255,0.45)" }}>
-              Tap a shortcut — opens the AI assistant with today&apos;s edition context
-            </p>
-            <AskPromptChips onSelect={dispatchAskPrompt} />
-          </div>
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-[1.35fr_0.9fr] gap-5">
-          <div className="glass-card rounded-xl p-5">
-            <div className="section-label mb-2">MORNING BRIEFING</div>
-            <h2 id="today-desk-title" className="display-heading text-white text-2xl mb-3">{narrative.headline}</h2>
-            <p className="text-sm leading-relaxed mb-4" style={{ color: "rgba(255,255,255,0.68)" }}>{narrative.subhead}</p>
+          {deskGames.length > 0 ? (
+          <div className="rounded-xl p-5 border border-white/[0.08]">
+            <div className="section-label mb-3">On the slate</div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {deskGames.map((game) => (
                 <a key={game.gameId} href={`/game/${game.gameId}`} className="rounded-lg p-3 bg-white/[0.04] hover:bg-white/[0.07] transition-colors">
                   <div className="section-label mb-1">{game.status} · {game.source.replace(/-/g, " ")}</div>
                   <div className="text-sm font-semibold text-white">{game.away.abbr} at {game.home.abbr}</div>
-                  <div className="text-xs mt-1" style={{ color: "rgba(255,255,255,0.5)" }}>{shortenPulsePreview(game.subtitle || game.whyItMatters, 86)}</div>
+                  <div className="text-xs mt-1" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>{shortenPulsePreview(game.subtitle || game.whyItMatters, 86)}</div>
                 </a>
               ))}
             </div>
           </div>
+          ) : null}
 
           <div className="space-y-4">
             <div className="glass-card rounded-xl p-4">
@@ -522,18 +547,25 @@ function TodayDeskSection() {
                 ))}
               </div>
             </div>
-            <div className="glass-card rounded-xl p-4">
+            <div className="rounded-xl p-4 border border-white/[0.08]">
               <div className="section-label mb-3">HOW THIS EDITION WAS BUILT</div>
               <div className="grid grid-cols-1 gap-2">
                 {trust.map((signal) => (
                   <div key={signal.label} className="flex justify-between gap-3 text-xs">
-                    <span style={{ color: "rgba(255,255,255,0.4)" }}>{signal.label}</span>
+                    <span style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>{signal.label}</span>
                     <span className="text-right text-white/75">{signal.value}</span>
                   </div>
                 ))}
               </div>
             </div>
           </div>
+        </div>
+        <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4 mt-5">
+          <div className="section-label mb-2">Ask Hoops Intel</div>
+          <p className="text-xs mb-3" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+            Tap a shortcut — opens the assistant with today&apos;s edition context
+          </p>
+          <AskPromptChips onSelect={dispatchAskPrompt} />
         </div>
       </div>
     </section>
@@ -913,13 +945,15 @@ function PulseIndexSection() {
           <a href="/pulse-history" className="text-xs font-medium hover:underline" style={{ color: "#0EA5E9" }}>View History &rarr;</a>
         </div>
         <h2 className="display-heading text-white text-2xl mb-2">Pulse Index</h2>
-        {finalsOn ? (
-          <p className="text-xs mb-6 max-w-2xl leading-relaxed" style={{ color: "rgba(255,255,255,0.45)" }}>
-            Scoped to finalist teams{finalists.length ? ` (${finalists.join(" · ")})` : ""} while the NBA Finals desk is active.
-          </p>
-        ) : (
-          <div className="mb-6" />
-        )}
+        <p className="text-sm mb-6 max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+          Pulse 0–100 is today&apos;s organizational and on-court weight.{" "}
+          <a href="/pulse-methodology" className="text-sky-400 underline-offset-2 hover:underline">
+            How Pulse works
+          </a>
+          {finalsOn
+            ? ` Scoped to finalist teams${finalists.length ? ` (${finalists.join(" · ")})` : ""} while the NBA Finals desk is active.`
+            : ""}
+        </p>
         {finalsOn && pulseRows.length === 0 ? (
           <p className="text-sm rounded-lg px-4 py-3 mb-4" style={{ background: "rgba(255,255,255,0.04)", color: "rgba(255,255,255,0.55)" }}>
             No Pulse rows match the synced finalist teams yet — check back after the next edition refresh.
@@ -949,7 +983,10 @@ function PulseIndexSection() {
                     <Sparkline trend={player.trend} />
                   </div>
                   <div className="mono-data text-xs mb-1" style={{ color: "#10B981" }}>{player.keyStats}</div>
-                  <div className="text-xs leading-snug" style={{ color: "rgba(255,255,255,0.5)" }}>
+                  <div className="text-sm leading-snug mb-1" style={{ color: "rgba(255,255,255,0.85)" }}>
+                    {pulseLeadLine(String(player.rationale || ""), String(player.note || ""))}
+                  </div>
+                  <div className="text-xs leading-snug" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
                     {shortenPulsePreview(String(player.note || ""))}
                   </div>
                 </div>
@@ -959,7 +996,6 @@ function PulseIndexSection() {
                     <div className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>{player.teamRecord}</div>
                   </div>
                   <div className="flex items-center gap-1.5">
-                    {/* "Why ranked here?" button */}
                     <button
                       type="button"
                       onClick={() =>
@@ -972,7 +1008,7 @@ function PulseIndexSection() {
                           ),
                         })
                       }
-                      className="min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0 flex items-center justify-center px-3 sm:w-9 sm:h-9 sm:p-0 rounded-full text-xs font-bold transition-colors hover:bg-sky-500/25"
+                      className="min-h-[44px] min-w-[44px] flex items-center justify-center px-3 rounded-full text-xs font-bold transition-colors hover:bg-sky-500/25"
                       style={{
                         background: "rgba(14,165,233,0.1)",
                         color: "#0EA5E9",
@@ -983,12 +1019,6 @@ function PulseIndexSection() {
                     >
                       ?
                     </button>
-                    {/* Share player card */}
-                    <ShareButton
-                      url={`https://hoopsintel.net/player/${slugify(player.player)}`}
-                      tweetText={`${player.player} — Pulse Rank #${player.rank} | ${player.keyStats} hoopsintel.net/player/${slugify(player.player)}`}
-                      size="sm"
-                    />
                   </div>
                 </div>
               </div>
@@ -1075,9 +1105,12 @@ function InjurySection() {
             return (
               <div key={i} className="glass-card rounded-lg p-4">
                 <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <a href={`/player/${slugify(injury.player)}`} className="text-sm font-semibold text-white hover:text-sky-400 transition-colors">{injury.player}</a>
-                    <a href={`/team/${injury.team.toLowerCase()}`} className="text-xs px-1.5 py-0.5 rounded hover:bg-white/10 transition-colors" style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.5)" }}>{injury.team}</a>
+                  <div className="flex items-center gap-2 min-w-0">
+                    <PlayerAvatar name={String(injury.player || "Unnamed player")} team={injury.team} size={36} />
+                    <a href={`/player/${slugify(injury.player || "player")}`} className="text-sm font-semibold text-white hover:text-sky-400 transition-colors truncate">
+                      {injury.player?.trim() || "Unnamed player"}
+                    </a>
+                    <a href={`/team/${String(injury.team || "nba").toLowerCase()}`} className="text-xs px-1.5 py-0.5 rounded hover:bg-white/10 transition-colors shrink-0" style={{ background: "rgba(255,255,255,0.06)", color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>{injury.team || "NBA"}</a>
                   </div>
                   <span className="text-xs font-semibold px-2 py-0.5 rounded uppercase" style={{ background: ss.bg, color: ss.color }}>{injury.status}</span>
                 </div>
@@ -1711,8 +1744,8 @@ function Footer() {
               <div className="w-6 h-6 rounded flex items-center justify-center font-bold text-white text-xs" style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)" }}>HI</div>
               <span className="display-heading text-white text-sm">HOOPS INTEL</span>
             </div>
-            <p className="text-xs mb-3" style={{ color: "rgba(255,255,255,0.3)" }}>
-              Daily NBA Intelligence · Updated Every Morning · {pulseEdition.edition}
+            <p className="text-xs mb-3" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+              Daily NBA intelligence · {pulseEdition.date}
             </p>
             <div className="flex gap-3">
               <a href="/archive" className="text-xs" style={{ color: "#0EA5E9" }}>Archive</a>
@@ -1785,7 +1818,7 @@ function Footer() {
                   key={link.href}
                   href={link.href}
                   className="text-xs hover:text-sky-400 transition-colors"
-                  style={{ color: "rgba(255,255,255,0.4)" }}
+                  style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}
                 >
                   {link.label}
                 </a>
@@ -1842,13 +1875,14 @@ export default function Home() {
         <HeroSection showMyPulse={showMyPulse} />
         <DeskSectionNav />
         <TodayDeskSection />
-        <PickEmHomeBanner />
+        <OffseasonDeskStrip />
+        {!isOffseasonDesk() || gamePreviews.length > 0 ? <PickEmHomeBanner /> : null}
         {!showMyPulse ? <MyPulseBanner onSetup={() => setShowPrefsSetup(true)} /> : null}
         {isPlayoffsActive() ? <PlayoffSection /> : null}
-        <ScoresSection favoriteTeams={favoriteTeams} />
+        {!(isOffseasonDesk() && gameResults.length === 0) ? <ScoresSection favoriteTeams={favoriteTeams} /> : null}
         <PulseIndexSection />
         <InjurySection />
-        <TonightSection />
+        {!(isOffseasonDesk() && gamePreviews.length === 0) ? <TonightSection /> : null}
         <CollapsibleEditionExtras
           narrative={<NarrativeSection />}
           media={<MediaReactionsSection />}

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -1,16 +1,18 @@
 import { useMemo, useState } from "react";
 import ToolPageLayout from "../components/ToolPageLayout";
 import {
-  TOOLS_DIRECTORY,
+  publicToolsDirectory,
   TOOL_CATEGORY_ORDER,
   TOOL_CATEGORY_LABELS,
   type ToolCategory,
 } from "../lib/siteNav";
 import { POPULAR_SEARCH_DESTINATIONS } from "../lib/searchHistory";
 
-const bySection = TOOL_CATEGORY_ORDER.reduce<Record<ToolCategory, typeof TOOLS_DIRECTORY>>(
+const PUBLIC_TOOLS = publicToolsDirectory();
+
+const bySection = TOOL_CATEGORY_ORDER.reduce<Record<ToolCategory, typeof PUBLIC_TOOLS>>(
   (acc, cat) => {
-    acc[cat] = TOOLS_DIRECTORY.filter((t) => t.category === cat);
+    acc[cat] = PUBLIC_TOOLS.filter((t) => t.category === cat);
     return acc;
   },
   { desk: [], postseason: [], analysis: [], community: [], publishing: [] },
@@ -44,8 +46,8 @@ export default function Tools() {
           Every Hoops Intel tool
         </h1>
         <p className="text-sm mb-6 max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted,rgba(255,255,255,0.6))" }}>
-          Jump straight to standings intel, simulations, embeddings, podcast mode, and the rest — same shell and search as the
-          main desk (⌘K / Ctrl+K or press <kbd className="mono-data text-[10px] px-1 py-0.5 rounded bg-white/10">/</kbd>).
+          Daily desk and analysis tools. Search from any page, or press{" "}
+          <kbd className="mono-data text-[10px] px-1 py-0.5 rounded bg-white/10">/</kbd> to jump to a player, team, or story.
         </p>
 
         <div className="mb-4 flex flex-wrap gap-2">

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -22,8 +22,8 @@ html.dark {
   --hi-mobile-sheet: #081018;
   --hi-border-soft: rgba(255, 255, 255, 0.08);
   --hi-heading: #ffffff;
-  --hi-muted: rgba(255, 255, 255, 0.6);
-  --hi-muted-sub: rgba(255, 255, 255, 0.5);
+  --hi-muted: rgba(255, 255, 255, 0.72);
+  --hi-muted-sub: rgba(255, 255, 255, 0.68);
 }
 
 html.light {

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -405,7 +405,24 @@ ${urls.map((u) => `  <url>
   console.log(`✓ Sitemap written with ${urls.length} URLs (${distinctLastmods.size} distinct lastmod dates)`);
 }
 
+function writeFallbackSitemap() {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${xmlEscape(BASE + "/")}</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>`;
+  writeFileSync(join(ROOT, "public", "sitemap.xml"), xml, "utf8");
+}
+
 // ── Standalone CLI entry point ────────────────────────────
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  generate();
+  try {
+    generate();
+  } catch (err) {
+    console.error("Sitemap generation failed — writing fallback so /sitemap.xml stays valid.", err);
+    writeFallbackSitemap();
+  }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,11 @@
       "has": [{ "type": "host", "value": "www.hoopsintel.net" }],
       "destination": "https://hoopsintel.net/:path",
       "permanent": true
+    },
+    {
+      "source": "/picks",
+      "destination": "/pick-em",
+      "permanent": true
     }
   ],
   "rewrites": [
@@ -18,6 +23,13 @@
     }
   ],
   "headers": [
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        { "key": "Content-Type", "value": "application/xml; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
     {
       "source": "/embed/(.*)",
       "headers": [


### PR DESCRIPTION
## Summary
- Rebase the UX Pilot desk onto current `main` (August 29 edition) so production keeps daily content.
- Season-aware chrome: Pulse / Briefing / Injuries / Projections in the dead period; Scores / Tonight / Picks in-season.
- Calendar wins over stale edition metadata so August never shows a regular-season or playoffs desk.

## Test plan
- [x] `npx vitest run` — 294 passed
- [x] `npx vite build` — passed
- [ ] Confirm hoopsintel.net header is Pulse / Briefing / Injuries / Projections / Tools
- [ ] Confirm empty Scores / Tonight / Playoffs chips are hidden