### PR TITLE
Ship Enhanced Figma UI to the production desk

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -61,7 +61,7 @@
     <link rel="dns-prefetch" href="https://a.espncdn.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700;800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700;800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=Geist+Mono:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;0,6..72,700;1,6..72,400&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,7 @@ const PlayoffSeriesRedirect = lazy(() => import("./pages/PlayoffSeriesRedirect")
 const PickEm = lazy(() => import("./pages/PickEm"));
 const TradeValue = lazy(() => import("./pages/TradeValue"));
 const InjuryReport = lazy(() => import("./pages/InjuryReport"));
+const Tonight = lazy(() => import("./pages/Tonight"));
 const Trivia = lazy(() => import("./pages/Trivia"));
 const EightyTwoZero = lazy(() => import("./pages/EightyTwoZero"));
 const PlayerCard = lazy(() => import("./pages/PlayerCard"));
@@ -94,6 +95,7 @@ function pageLoaderLabel(path: string): string {
   if (path.startsWith("/playoffs")) return "Loading playoffs";
   if (path.startsWith("/ask")) return "Loading Ask Hoops Intel";
   if (path.startsWith("/injuries")) return "Loading injury report";
+  if (path.startsWith("/tonight")) return "Loading tonight's slate";
   if (path.startsWith("/archive")) return "Loading archive";
   if (path.startsWith("/my-pulse")) return "Loading My Pulse";
   if (path.startsWith("/pro")) return "Loading Pro";
@@ -173,6 +175,7 @@ export default function App() {
             <Route path="/pick-em" component={PickEm} />
             <Route path="/trade-value" component={TradeValue} />
             <Route path="/injuries" component={InjuryReport} />
+            <Route path="/tonight" component={Tonight} />
             <Route path="/card/:player" component={PlayerCard} />
             <Route path="/trivia" component={Trivia} />
             <Route path="/82-0" component={EightyTwoZero} />

--- a/client/src/__tests__/enhancedDesk.test.ts
+++ b/client/src/__tests__/enhancedDesk.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  daysUntilIso,
+  deskAskChips,
+  formatPulseScore,
+  hasTonightSlate,
+  heroStats,
+  injuryChipTone,
+  injuryCounts,
+  padRank,
+  pulseTrendMark,
+  shortInjuryLine,
+} from "../lib/enhancedDesk";
+import { gamePreviews, pulseIndex, westStandings } from "../lib/pulseData";
+
+describe("enhancedDesk", () => {
+  it("formats pulse scores and ranks for the homepage module", () => {
+    expect(formatPulseScore(99)).toBe("99");
+    expect(formatPulseScore(96.5)).toBe("96.5");
+    expect(padRank(1)).toBe("01");
+    expect(pulseTrendMark("up").mark).toBe("▲");
+    expect(pulseTrendMark("stable").mark).toBe("●");
+  });
+
+  it("derives hero stats from live edition data, not invented scores", () => {
+    const cards = heroStats();
+    expect(cards[0]?.kicker).toBe("PULSE LEADER");
+    expect(cards[0]?.value).toBe(formatPulseScore(pulseIndex[0]!.indexScore));
+    expect(cards.some((c) => c.kicker === "WEST NO. 1" && c.value === `${westStandings[0]!.wins}-${westStandings[0]!.losses}`)).toBe(true);
+    expect(hasTonightSlate()).toBe(gamePreviews.length > 0);
+  });
+
+  it("counts injury statuses for the full report header", () => {
+    const counts = injuryCounts();
+    expect(counts.all).toBeGreaterThan(0);
+    expect(counts.dtd + counts.probable + counts.out + counts.questionable).toBe(counts.all);
+    expect(injuryChipTone("Day-to-Day")).toBe("danger");
+    expect(injuryChipTone("Probable")).toBe("success");
+    expect(shortInjuryLine("Right knee soreness (chronic management)")).toMatch(/knee/i);
+  });
+
+  it("uses closed-slate Ask chips when there are no games", () => {
+    const chips = deskAskChips();
+    expect(chips).toContain("Who's rising on the Pulse Index?");
+    expect(daysUntilIso("2026-10-03", new Date("2026-09-01T12:00:00"))).toBe(32);
+  });
+});

--- a/client/src/__tests__/siteNav.test.ts
+++ b/client/src/__tests__/siteNav.test.ts
@@ -1,28 +1,32 @@
 import { describe, expect, it } from "vitest";
 import { headerNavLinks, mobileBottomNavLinks, publicToolsDirectory, TOOLS_DIRECTORY } from "../lib/siteNav";
 
+const ENHANCED_HEADER = ["Desk", "Injuries", "Tonight", "Pick 'Em", "Archive", "Ask"];
+const ENHANCED_MOBILE = ["Desk", "Injuries", "Tonight", "Pick 'Em", "Ask"];
+
 describe("siteNav", () => {
-  it("uses offseason chrome in August dead period", () => {
+  it("uses Enhanced IA in August dead period", () => {
     const august = new Date(Date.UTC(2026, 7, 29));
     const header = headerNavLinks(august).map((l) => l.label);
     const mobile = mobileBottomNavLinks(august).map((l) => l.label);
 
-    expect(header).toEqual(["Pulse", "Briefing", "Injuries", "Projections", "Tools"]);
-    expect(mobile).toEqual(["Today", "Pulse", "Projections", "My Pulse", "Ask"]);
-    expect(header).not.toContain("Playoffs");
+    expect(header).toEqual(ENHANCED_HEADER);
+    expect(mobile).toEqual(ENHANCED_MOBILE);
+    expect(header).not.toContain("Scores");
     expect(mobile).not.toContain("Live");
   });
 
-  it("uses in-season chrome in January", () => {
+  it("uses the same Enhanced IA in January", () => {
     const january = new Date(Date.UTC(2026, 0, 15));
     const header = headerNavLinks(january).map((l) => l.label);
     const mobile = mobileBottomNavLinks(january).map((l) => l.label);
 
-    expect(header).toContain("Scores");
-    expect(header).toContain("Tonight");
-    expect(mobile).toContain("Scores");
-    expect(mobile).not.toContain("Live");
-    expect(mobile).toContain("Picks");
+    expect(header).toEqual(ENHANCED_HEADER);
+    expect(mobile).toEqual(ENHANCED_MOBILE);
+    expect(header).not.toContain("Scores");
+    expect(mobile).not.toContain("Picks");
+    expect(mobile).toContain("Pick 'Em");
+    expect(headerNavLinks(january).find((l) => l.label === "Tonight")?.href).toBe("/tonight");
   });
 
   it("hides admin and opt-out routes from the public tools grid", () => {
@@ -31,5 +35,6 @@ describe("siteNav", () => {
     expect(hrefs).not.toContain("/unsubscribe");
     expect(hrefs).not.toContain("/embed-stats");
     expect(TOOLS_DIRECTORY.some((t) => t.href === "/creator-queue")).toBe(true);
+    expect(TOOLS_DIRECTORY.some((t) => t.href === "/tonight")).toBe(true);
   });
 });

--- a/client/src/components/MobileBottomNav.tsx
+++ b/client/src/components/MobileBottomNav.tsx
@@ -1,109 +1,11 @@
 import { useLocation } from "wouter";
-import { mobileBottomNavLinks, PLAYOFFS_NAV_HREF, playoffsNavLabel } from "../lib/siteNav";
+import { mobileBottomNavLinks } from "../lib/siteNav";
 import { hapticTap } from "../lib/haptic";
-
-function NavIcon({ label, href }: { label: string; href: string }) {
-  const stroke = "currentColor";
-  const common = { fill: "none", stroke, strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
-
-  if (label === "Today") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-        <polyline points="9 22 9 12 15 12 15 22" />
-      </svg>
-    );
-  }
-  if (label === "Pulse") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-      </svg>
-    );
-  }
-  if (label === "Projections") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
-        <polyline points="17 6 23 6 23 12" />
-      </svg>
-    );
-  }
-  if (label === "Ask") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />
-      </svg>
-    );
-  }
-  if (label === "Scores") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <rect x="3" y="4" width="18" height="16" rx="2" />
-        <line x1="12" y1="4" x2="12" y2="20" />
-        <line x1="7" y1="9" x2="10" y2="9" />
-        <line x1="14" y1="15" x2="17" y2="15" />
-      </svg>
-    );
-  }
-  if (href === PLAYOFFS_NAV_HREF) {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
-        <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
-        <path d="M4 22h16" />
-        <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20 7 22" />
-        <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20 17 22" />
-        <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
-      </svg>
-    );
-  }
-  if (label === "My Pulse") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-      </svg>
-    );
-  }
-  if (label === "Picks" || label === "Pick 'Em") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <path d="M9 11l3 3L22 4" />
-        <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-      </svg>
-    );
-  }
-  if (label === "Live") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <circle cx="12" cy="12" r="3" />
-        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-      </svg>
-    );
-  }
-  if (label === "Compare") {
-    return (
-      <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-        <circle cx="9" cy="7" r="4" />
-        <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-      </svg>
-    );
-  }
-  return (
-    <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden {...common}>
-      <rect x="3" y="3" width="7" height="7" rx="1" />
-      <rect x="14" y="3" width="7" height="7" rx="1" />
-      <rect x="3" y="14" width="7" height="7" rx="1" />
-      <rect x="14" y="14" width="7" height="7" rx="1" />
-    </svg>
-  );
-}
+import { ENHANCED_ACCENT } from "../lib/enhancedDesk";
 
 function linkActive(href: string, location: string) {
   const base = href.split("#")[0] || "/";
-  if (base === "/") return location === "/" || (href.includes("#") && location === "/");
+  if (base === "/") return location === "/";
   return location === base || location.startsWith(`${base}/`);
 }
 
@@ -115,34 +17,30 @@ export default function MobileBottomNav() {
       className="mobile-bottom-nav fixed bottom-0 left-0 right-0 z-50 md:hidden border-t"
       style={{
         paddingBottom: "env(safe-area-inset-bottom)",
-        background: "rgba(5,13,26,0.94)",
-        borderColor: "rgba(255,255,255,0.1)",
-        backdropFilter: "blur(14px)",
+        background: "var(--hi-surface,#0c1522)",
+        borderColor: "var(--hi-border,#1e2c40)",
       }}
       aria-label="Primary mobile navigation"
     >
-      <div className="grid grid-cols-5">
+      <div className="grid grid-cols-5 px-2 pt-2.5 pb-4">
         {mobileBottomNavLinks().map((link) => {
           const active = linkActive(link.href, location);
-          const navLabel = link.href === PLAYOFFS_NAV_HREF ? playoffsNavLabel() : link.label;
           return (
             <a
               key={link.href}
               href={link.href}
               aria-current={active ? "page" : undefined}
-              className="mobile-bottom-nav-item relative min-h-[56px] flex flex-col items-center justify-center gap-0.5 text-[10px] font-semibold tracking-wide active:scale-[0.97] transition-transform"
-              style={{ color: active ? "#38BDF8" : "rgba(255,255,255,0.52)" }}
+              className="mobile-bottom-nav-item relative min-h-[48px] flex flex-col items-center justify-center gap-0.5 text-[10px] tracking-wide active:scale-[0.97] transition-transform"
+              style={{
+                color: active ? ENHANCED_ACCENT : "var(--hi-text-secondary,#8b9bb0)",
+                fontWeight: active ? 600 : 500,
+              }}
               onClick={() => hapticTap()}
             >
-              {active && (
-                <span
-                  className="absolute top-0 left-1/2 -translate-x-1/2 h-0.5 w-8 rounded-full"
-                  style={{ background: "#38BDF8" }}
-                  aria-hidden
-                />
-              )}
-              <NavIcon label={navLabel} href={link.href} />
-              {navLabel}
+              <span className="text-[8px] font-bold leading-none" aria-hidden>
+                {active ? "●" : "○"}
+              </span>
+              {link.label}
             </a>
           );
         })}

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -14,6 +14,10 @@ import {
   readRecentSearches,
   POPULAR_SEARCH_DESTINATIONS,
 } from "../lib/searchHistory";
+import { BrandLockup } from "./enhanced/EnhancedUi";
+import { ENHANCED_ACCENT } from "../lib/enhancedDesk";
+import { pulseEdition } from "../lib/pulseData";
+import { compactEditionDate } from "../lib/enhancedDesk";
 
 export type SiteHeaderProps = {
   /** Secondary line under brand (e.g. ARCHIVE, DAILY INTELLIGENCE). */
@@ -533,7 +537,7 @@ export default function SiteHeader({
   }, [mobileOpen]);
 
   const navLinkClass =
-    "text-xs font-medium transition-colors hover:text-[#0EA5E9] px-3 py-2 rounded-lg min-h-[44px] flex items-center md:inline-flex [&:focus-visible]:outline [&:focus-visible]:outline-offset-2 [&:focus-visible]:outline-sky-500";
+    "text-[13px] font-medium transition-colors px-3 py-2 min-h-[44px] flex items-center md:inline-flex border-b-2 border-transparent [&:focus-visible]:outline [&:focus-visible]:outline-offset-2 [&:focus-visible]:outline-sky-500";
 
   return (
     <>
@@ -568,40 +572,24 @@ export default function SiteHeader({
                 </svg>
               </button>
 
-              <a href="/" className="flex items-center gap-2 sm:gap-3 min-w-0 shrink-0 py-2">
-                <div
-                  className="w-8 h-8 rounded flex items-center justify-center font-bold text-white text-sm shrink-0"
-                  style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)" }}
-                >
-                  HI
-                </div>
-                <div className="min-w-0">
-                  <div className="display-heading text-[var(--hi-heading,#ffffff)] text-base sm:text-lg leading-none truncate">
-                    {brandTitle}
-                  </div>
-                  <div
-                    className="section-label !text-[max(10px,0.625rem)]"
-                    style={{
-                      fontSize: "0.6rem",
-                      color: subtitleAccent ? "#F59E0B" : undefined,
-                    }}
-                  >
-                    {subtitle}
-                  </div>
-                </div>
-              </a>
+              <div className="flex items-center gap-3 min-w-0 shrink-0 py-1">
+                <BrandLockup compact />
+              </div>
             </div>
 
-            <nav className="hidden md:flex items-center gap-3 xl:gap-5" aria-label="Primary">
+            <nav className="hidden md:flex items-center gap-1 xl:gap-1 flex-1" aria-label="Primary">
               {headerNavLinks().map(({ label, href }) => {
                 const navLabel = href === PLAYOFFS_NAV_HREF ? playoffsNavLabel() : label;
+                const active = navRouteMatches(href, locationPath);
                 return (
                 <a
                   key={label}
                   href={href}
                   className={navLinkClass}
                   style={{
-                    color: navRouteMatches(href, locationPath) ? "#0EA5E9" : "var(--hi-muted, rgba(255,255,255,0.72))",
+                    color: active ? ENHANCED_ACCENT : "var(--hi-text-secondary,#8b9bb0)",
+                    borderBottomColor: active ? ENHANCED_ACCENT : "transparent",
+                    fontWeight: active ? 600 : 500,
                   }}
                   {...navAriaCurrent(href, locationPath)}
                 >
@@ -638,24 +626,39 @@ export default function SiteHeader({
             </nav>
 
             <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+              <span
+                className="mono-data text-[11px] md:hidden mr-1"
+                style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}
+              >
+                {compactEditionDate(editionBadge ?? pulseEdition.date)}
+              </span>
               {toolbarExtra}
               <button
                 type="button"
                 onClick={() => setSearchOpen(true)}
-                className="flex items-center gap-2 min-h-[44px] px-3 py-2 rounded-lg text-xs transition-colors hover:bg-white/10"
-                style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.4)" }}
+                className="flex items-center gap-2 min-h-[36px] px-2.5 py-1.5 rounded-md text-xs transition-colors hover:bg-white/10"
+                style={{
+                  background: "var(--hi-surface-2,#121c2c)",
+                  color: "var(--hi-text-secondary,#8b9bb0)",
+                  border: "1px solid var(--hi-border,#1e2c40)",
+                }}
                 aria-haspopup="dialog"
                 aria-label="Open search"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-                  <circle cx="11" cy="11" r="8" />
-                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
-                </svg>
-                <span className="hidden sm:inline">Search</span>
-                <span className="hidden lg:inline px-1 py-0.5 rounded text-[10px]" style={{ background: "rgba(255,255,255,0.08)" }}>
-                  ⌘K
-                </span>
+                <span className="hidden sm:inline">Search desk</span>
+                <span className="sm:hidden">Search</span>
+                <span className="hidden lg:inline mono-data text-[11px]">⌘K</span>
               </button>
+              <a
+                href="/pro"
+                className="hidden sm:inline-flex items-center justify-center min-h-[36px] px-4 py-[9px] rounded-md text-[13px] font-semibold"
+                style={{
+                  color: "var(--hi-text,#f3f6fa)",
+                  border: "1px solid var(--hi-border,#1e2c40)",
+                }}
+              >
+                Pro
+              </a>
 
               <button
                 type="button"

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -1,0 +1,208 @@
+import { pulseEdition, pulseIndex, injuryUpdates, narrative } from "../../lib/pulseData";
+import { slugify } from "../../lib/searchUtils";
+import { dispatchAskPrompt } from "../../lib/askShortcuts";
+import { isFinalsActive, finalistTeams } from "../../lib/playoffData";
+import {
+  deskAskChips,
+  deskEyebrow,
+  editionUpdatedLabel,
+  formatPulseScore,
+  hasTonightSlate,
+  heroStats,
+  mobileHeroStats,
+  padRank,
+  pulseTrendMark,
+  shortInjuryLine,
+  tickerWireText,
+} from "../../lib/enhancedDesk";
+import { EnhancedButton, InjuryChip, SectionHeader, StatCard } from "./EnhancedUi";
+
+function PulseRow({
+  rank,
+  player,
+  team,
+  keyStats,
+  note,
+  indexScore,
+  teamRecord,
+  trend,
+}: (typeof pulseIndex)[number]) {
+  const mark = pulseTrendMark(trend);
+  return (
+    <a
+      href={`/player/${slugify(player)}`}
+      className="enhanced-card flex items-center gap-4 px-4 py-3 w-full min-w-0 hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
+    >
+      <p className="mono-data font-bold text-xl shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+        {padRank(rank)}
+      </p>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-semibold text-[var(--hi-text,#f3f6fa)]">{player}</span>
+          <span className="text-[11px] font-bold tracking-[0.6px]" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+            {team}
+          </span>
+        </div>
+        <p className="text-[11px] mt-0.5 truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          {keyStats}
+        </p>
+        <p className="editorial-body text-xs leading-4 mt-0.5 line-clamp-2 text-[var(--hi-text,#f3f6fa)]">{note}</p>
+      </div>
+      <div className="flex flex-col items-end gap-0.5 shrink-0 w-[72px] text-right">
+        <span className="text-[11px] font-bold" style={{ color: mark.color }}>
+          {mark.mark}
+        </span>
+        <span className="mono-data font-bold text-[22px] text-[var(--hi-text,#f3f6fa)]">{formatPulseScore(indexScore)}</span>
+        <span className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          {teamRecord}
+        </span>
+      </div>
+    </a>
+  );
+}
+
+export function EnhancedTicker() {
+  return (
+    <div
+      className="flex items-center gap-4 px-4 md:px-7 py-2 overflow-hidden"
+      style={{ background: "var(--hi-surface-2,#121c2c)" }}
+      aria-label="Edition wire"
+    >
+      <p className="enhanced-kicker shrink-0">{deskEyebrow()}</p>
+      <p className="text-xs truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        {tickerWireText()}
+      </p>
+    </div>
+  );
+}
+
+export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) {
+  const finalsOn = isFinalsActive();
+  const finalists = finalistTeams();
+  const finalistSet = new Set(finalists.map((t) => t.toUpperCase()));
+  const pulseRows = finalsOn
+    ? pulseIndex.filter((player) => finalistSet.has(player.team.toUpperCase()))
+    : pulseIndex;
+  const desktopPulse = pulseRows.slice(0, 4);
+  const mobilePulse = pulseRows.slice(0, 3);
+  const railInjuries = injuryUpdates.slice(0, 4);
+  const chips = deskAskChips();
+  const desktopStats = heroStats();
+  const mobileStats = mobileHeroStats();
+
+  return (
+    <div className="px-4 md:px-7 py-4 md:py-5">
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+        <div className="flex-1 min-w-0 flex flex-col gap-3.5">
+          <div className="flex flex-col gap-2">
+            <p className="enhanced-kicker">
+              {deskEyebrow()} · {pulseEdition.date.toUpperCase()}
+            </p>
+            <h1 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[30px] leading-[34px] md:text-[30px] max-md:text-2xl max-md:leading-7">
+              {narrative.headline}
+            </h1>
+            <p className="text-xs max-md:text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+              <span className="hidden md:inline">By Will Henderson · Hoops Intel · {editionUpdatedLabel()}</span>
+              <span className="md:hidden">
+                Will Henderson · 5:03 AM PT
+                {hasTonightSlate() ? "" : " · no games tonight"}
+              </span>
+            </p>
+            <div className="flex flex-wrap gap-2 items-center">
+              <EnhancedButton href="#pulse-index">Read the brief</EnhancedButton>
+              <EnhancedButton href="/my-pulse" variant="ghost">
+                {showMyPulse ? "My Pulse" : "Set My Pulse"}
+              </EnhancedButton>
+            </div>
+          </div>
+
+          <div className="hidden md:grid grid-cols-2 xl:grid-cols-4 gap-2.5">
+            {desktopStats.map((card) => (
+              <StatCard key={card.kicker} {...card} />
+            ))}
+          </div>
+          <div className="grid grid-cols-2 gap-2 md:hidden">
+            {mobileStats.map((card) => (
+              <StatCard key={card.kicker} {...card} />
+            ))}
+          </div>
+
+          <div id="pulse-index" className="hidden md:block">
+            <SectionHeader
+              eyebrow="HOMEPAGE MODULE"
+              title="Pulse Index"
+              action="How Pulse works →"
+              actionHref="/pulse-methodology"
+            />
+          </div>
+          <div className="md:hidden">
+            <SectionHeader
+              eyebrow="PULSE INDEX"
+              title="Today's board"
+              action="Full →"
+              actionHref="/pulse-history"
+            />
+          </div>
+
+          <div className="hidden md:flex flex-col gap-2">
+            {desktopPulse.map((row) => (
+              <PulseRow key={row.rank} {...row} />
+            ))}
+          </div>
+          <div className="flex flex-col gap-2 md:hidden">
+            {mobilePulse.map((row) => (
+              <PulseRow key={row.rank} {...row} />
+            ))}
+          </div>
+        </div>
+
+        <aside className="w-full lg:w-[320px] shrink-0 flex flex-col gap-4 max-md:pt-2">
+          <SectionHeader
+            eyebrow="INJURY WIRE"
+            title="Desk tags"
+            action="Full report →"
+            actionHref="/injuries"
+          />
+          <div className="flex flex-col gap-2">
+            {railInjuries.map((injury) => (
+              <a
+                key={injury.player}
+                href={`/player/${slugify(injury.player)}`}
+                className="enhanced-card flex flex-col gap-1 p-2.5"
+              >
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-xs font-semibold text-[var(--hi-text,#f3f6fa)]">{injury.player}</span>
+                  <span className="text-[11px] font-bold" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+                    {injury.team}
+                  </span>
+                  <InjuryChip status={injury.status} />
+                </div>
+                <p className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+                  {shortInjuryLine(injury.injury)}
+                </p>
+              </a>
+            ))}
+          </div>
+
+          <div className="enhanced-card flex flex-col gap-2 p-3.5">
+            <p className="enhanced-kicker">Ask Hoops Intel</p>
+            <p className="editorial-body text-xs leading-4 text-[var(--hi-text,#f3f6fa)]">
+              Shortcuts open the assistant with today’s edition context.
+            </p>
+            {chips.map((chip) => (
+              <button
+                key={chip}
+                type="button"
+                className="text-left text-[11px] font-medium px-2.5 py-2 rounded-md min-h-[36px]"
+                style={{ background: "var(--hi-surface-2,#121c2c)", color: "var(--hi-text,#f3f6fa)" }}
+                onClick={() => dispatchAskPrompt(chip)}
+              >
+                {chip}
+              </button>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -1,0 +1,177 @@
+import type { ReactNode } from "react";
+import { ENHANCED_ACCENT, injuryChipTone, injuryStatusLabel } from "../../lib/enhancedDesk";
+
+export function BrandMark({ size = 14 }: { size?: number }) {
+  return (
+    <img
+      src="/assets/brand-diamond.svg"
+      alt=""
+      width={size}
+      height={size}
+      className="shrink-0"
+      style={{ width: size, height: size }}
+    />
+  );
+}
+
+export function BrandLockup({ compact = false }: { compact?: boolean }) {
+  return (
+    <a href="/" className="flex items-center gap-2.5 min-w-0 py-1">
+      <BrandMark size={compact ? 12 : 14} />
+      <span
+        className="font-bold tracking-[1.2px] text-[var(--hi-text,#f3f6fa)] truncate"
+        style={{ fontSize: compact ? 12 : 13, letterSpacing: compact ? "0.8px" : "1.2px" }}
+      >
+        HOOPS INTEL
+      </span>
+    </a>
+  );
+}
+
+export function SectionHeader({
+  eyebrow,
+  title,
+  action,
+  actionHref,
+}: {
+  eyebrow: string;
+  title: string;
+  action?: string;
+  actionHref?: string;
+}) {
+  return (
+    <div className="flex items-end gap-3 w-full">
+      <div className="flex-1 min-w-0">
+        <p className="enhanced-kicker">{eyebrow}</p>
+        <h2 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[28px] leading-8 max-md:text-2xl">
+          {title}
+        </h2>
+      </div>
+      {action && actionHref ? (
+        <a href={actionHref} className="text-xs font-medium shrink-0 pb-1" style={{ color: ENHANCED_ACCENT }}>
+          {action}
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+export function StatCard({
+  kicker,
+  value,
+  sub,
+}: {
+  kicker: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="enhanced-card flex flex-col gap-1.5 px-4 py-3.5 min-w-0">
+      <p className="text-[10px] font-semibold tracking-[1.2px] uppercase" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        {kicker}
+      </p>
+      <p className="mono-data font-bold leading-9 text-[32px] max-md:text-[28px]" style={{ color: ENHANCED_ACCENT }}>
+        {value}
+      </p>
+      <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        {sub}
+      </p>
+    </div>
+  );
+}
+
+export function InjuryChip({ status }: { status: string }) {
+  const tone = injuryChipTone(status);
+  const bg = tone === "success" ? "var(--hi-success,#3ddc97)" : tone === "danger" ? "var(--hi-danger,#ff4d6a)" : "#F59E0B";
+  const color = tone === "success" ? "var(--hi-bg-page,#050d1a)" : "#F3F6FA";
+  return (
+    <span
+      className="inline-flex items-center justify-center px-2 py-[3px] rounded text-[10px] font-semibold tracking-[0.5px] uppercase shrink-0"
+      style={{ background: bg, color }}
+    >
+      {injuryStatusLabel(status)}
+    </span>
+  );
+}
+
+export function EnhancedButton({
+  href,
+  children,
+  variant = "primary",
+  onClick,
+  type = "button",
+}: {
+  href?: string;
+  children: ReactNode;
+  variant?: "primary" | "ghost";
+  onClick?: () => void;
+  type?: "button" | "submit";
+}) {
+  const className =
+    "inline-flex items-center justify-center px-4 py-[9px] rounded-md text-[13px] font-semibold min-h-[40px] transition-opacity hover:opacity-90";
+  const style =
+    variant === "primary"
+      ? { background: ENHANCED_ACCENT, color: "#050d1a" }
+      : { background: "transparent", color: "var(--hi-text,#f3f6fa)", border: "1px solid var(--hi-border,#1e2c40)" };
+
+  if (href) {
+    return (
+      <a href={href} className={className} style={style}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <button type={type} onClick={onClick} className={className} style={style}>
+      {children}
+    </button>
+  );
+}
+
+export function GamePreviewCard({
+  status,
+  when,
+  away,
+  home,
+  network,
+  note,
+}: {
+  status: string;
+  when: string;
+  away: string;
+  home: string;
+  network: string;
+  note: string;
+}) {
+  return (
+    <div className="enhanced-card flex flex-col gap-2.5 px-4 py-3.5 min-w-0">
+      <div className="flex items-center gap-2">
+        <p className="enhanced-kicker">{status}</p>
+        <span className="flex-1" />
+        <p className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          {when}
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <p className="mono-data font-bold text-[26px] text-[var(--hi-text,#f3f6fa)]">{away}</p>
+        <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          @
+        </p>
+        <p className="mono-data font-bold text-[26px] text-[var(--hi-text,#f3f6fa)]">{home}</p>
+        <span className="flex-1" />
+        <p className="text-[11px] font-semibold tracking-[0.8px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          {network}
+        </p>
+      </div>
+      <p className="editorial-body text-xs leading-4 text-[var(--hi-text,#f3f6fa)]">{note}</p>
+    </div>
+  );
+}
+
+export function EnhancedPageFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+      {children}
+    </div>
+  );
+}

--- a/client/src/lib/enhancedDesk.ts
+++ b/client/src/lib/enhancedDesk.ts
@@ -1,0 +1,244 @@
+import { gamePreviews, injuryUpdates, narrative, pulseEdition, pulseIndex, tickerItems, westStandings } from "./pulseData";
+import { contextualAskChips } from "./askShortcuts";
+import { activeEditionContext, editionContextDeskLabel, type EditionContext } from "./deskMode";
+
+export const ENHANCED_ACCENT = "#1EC8F5";
+export const CAMP_OPEN_ISO = "2026-10-03";
+
+const WORD_DAYS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+  twenty: 20,
+};
+
+export function parseEditionDisplayDate(display = pulseEdition.date): Date | null {
+  const parsed = new Date(`${display} 12:00:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function daysUntilIso(targetIso: string, from = parseEditionDisplayDate()): number {
+  const start = from ?? new Date();
+  const target = new Date(`${targetIso}T12:00:00`);
+  const a = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate());
+  const b = Date.UTC(target.getFullYear(), target.getMonth(), target.getDate());
+  return Math.round((b - a) / 86_400_000);
+}
+
+export function formatPulseScore(score: number): string {
+  return Number.isInteger(score) ? String(score) : score.toFixed(1);
+}
+
+export function padRank(rank: number): string {
+  return String(rank).padStart(2, "0");
+}
+
+export function pulseTrendMark(trend: string): { mark: string; color: string } {
+  if (trend === "up") return { mark: "▲", color: "#3DDC97" };
+  if (trend === "down") return { mark: "▼", color: "#FF4D6A" };
+  return { mark: "●", color: "#3DDC97" };
+}
+
+export function injuryStatusKey(status: string): string {
+  return status.toLowerCase();
+}
+
+export function injuryChipTone(status: string): "danger" | "success" | "warn" {
+  const key = injuryStatusKey(status);
+  if (key === "out" || key === "day-to-day" || key === "doubtful") return "danger";
+  if (key === "probable") return "success";
+  return "warn";
+}
+
+export function injuryStatusLabel(status: string): string {
+  return status.replace(/-/g, "-").toUpperCase();
+}
+
+export function injuryCounts(rows = injuryUpdates) {
+  const out = rows.filter((r) => injuryStatusKey(r.status) === "out").length;
+  const dtd = rows.filter((r) => injuryStatusKey(r.status) === "day-to-day").length;
+  const probable = rows.filter((r) => injuryStatusKey(r.status) === "probable").length;
+  const questionable = rows.filter((r) => injuryStatusKey(r.status) === "questionable").length;
+  return { out, dtd, probable, questionable, all: rows.length };
+}
+
+export function shortInjuryLine(injury: string): string {
+  const cleaned = injury.replace(/\s+/g, " ").trim();
+  const paren = cleaned.match(/^(.+?)\s*\((.+)\)$/);
+  if (paren) {
+    const part = paren[1]!.replace(/\s+(soreness|sprain|strain|management)$/i, "").trim();
+    const qualifier = paren[2]!.split(/\s+/)[0] ?? paren[2];
+    return `${part} · ${qualifier.toLowerCase()}`;
+  }
+  return cleaned;
+}
+
+export function deskEyebrow(ctx: EditionContext = activeEditionContext()): string {
+  return editionContextDeskLabel(ctx).toUpperCase();
+}
+
+export function editionUpdatedLabel(display = pulseEdition.date): string {
+  return `Updated 5:03 AM PT`;
+}
+
+export function compactEditionDate(display = pulseEdition.date): string {
+  const parsed = parseEditionDisplayDate(display);
+  if (!parsed) return display;
+  return parsed
+    .toLocaleDateString("en-US", { month: "short", day: "numeric" })
+    .replace(" ", " ")
+    .toUpperCase();
+}
+
+export function murrayStandoff(): { value: string; sub: string } | null {
+  const hay = [pulseEdition.subtitle, narrative.subhead, ...tickerItems.map((t) => t.text)].join(" ");
+  const numbered = hay.match(/day\s+(\d+)/i);
+  const spoken = hay.match(/day\s+(seventeen|eighteen|nineteen|twenty|sixteen|fifteen|fourteen)/i);
+  const day = numbered ? Number(numbered[1]) : spoken ? WORD_DAYS[spoken[1]!.toLowerCase()] : null;
+  if (!day) return null;
+  return {
+    value: `D${day}`,
+    sub: /institutional/i.test(hay) ? "Silence now institutional" : "Extension silence ongoing",
+  };
+}
+
+export type HeroStat = { kicker: string; value: string; sub: string };
+
+export function heroStats(): HeroStat[] {
+  const leader = pulseIndex[0];
+  const west1 = westStandings[0];
+  const campDays = daysUntilIso(CAMP_OPEN_ISO);
+  const murray = murrayStandoff();
+  const lastName = leader?.player.split(" ").slice(-1)[0] ?? "—";
+
+  const cards: HeroStat[] = [];
+  if (leader) {
+    cards.push({
+      kicker: "PULSE LEADER",
+      value: formatPulseScore(leader.indexScore),
+      sub: `${lastName} · ${leader.team}`,
+    });
+  }
+  cards.push({
+    kicker: "PRESEASON",
+    value: campDays > 0 ? `${campDays} days` : campDays === 0 ? "Today" : "Open",
+    sub: "Camp opens October 3",
+  });
+  if (murray) {
+    cards.push({ kicker: "MURRAY", value: murray.value, sub: murray.sub });
+  }
+  if (west1) {
+    cards.push({
+      kicker: "WEST NO. 1",
+      value: `${west1.wins}-${west1.losses}`,
+      sub: `${west1.team} · full prep runway`,
+    });
+  }
+  return cards;
+}
+
+export function mobileHeroStats(): HeroStat[] {
+  const all = heroStats();
+  const pulse = all.find((c) => c.kicker === "PULSE LEADER");
+  const camp = all.find((c) => c.kicker === "PRESEASON");
+  return [
+    pulse
+      ? { kicker: "PULSE", value: pulse.value, sub: pulse.sub.replace(/Wembanyama/, "Wemby") }
+      : { kicker: "PULSE", value: "—", sub: "Board idle" },
+    camp
+      ? { kicker: "CAMP", value: camp.value.replace(/ days$/, "d"), sub: "Opens Oct 3" }
+      : { kicker: "CAMP", value: "—", sub: "Opens Oct 3" },
+  ];
+}
+
+export function deskAskChips(): string[] {
+  if (gamePreviews.length === 0) {
+    return [
+      "Who's rising on the Pulse Index?",
+      "Injury impact on the slate?",
+      "When does camp actually start?",
+    ];
+  }
+  return contextualAskChips().slice(0, 3);
+}
+
+export function tickerWireText(): string {
+  return tickerItems
+    .slice(0, 4)
+    .map((item) => item.text.replace(/^(NEWS|ALERT|INJURY):\s*/i, ""))
+    .join("  ·  ");
+}
+
+export type CampOpenerPreview = {
+  away: string;
+  home: string;
+  when: string;
+  network: string;
+  note: string;
+};
+
+/** Editorial camp-open previews — not a live ESPN slate and never shown as scores. */
+export const CAMP_OPENER_PREVIEWS: CampOpenerPreview[] = [
+  {
+    away: "NYK",
+    home: "BOS",
+    when: "Oct 3 · 7:00 PM ET",
+    network: "ESPN",
+    note: "Minutes-cap watch: Anunoby probable, Brunson settled, East’s cleanest camp open.",
+  },
+  {
+    away: "LAL",
+    home: "GSW",
+    when: "Oct 3 · 10:00 PM ET",
+    network: "NBATV",
+    note: "West coast opener — scheme teases only; no Pulse weight until regular season.",
+  },
+  {
+    away: "SAS",
+    home: "HOU",
+    when: "Oct 4 · 8:00 PM ET",
+    network: "ESPN",
+    note: "Fox-Sengun minutes. Houston freeze is already a training-camp design cost.",
+  },
+];
+
+export type SampleLock = CampOpenerPreview & { lean: string };
+
+export const SAMPLE_LOCKS: SampleLock[] = [
+  {
+    away: "NYK",
+    home: "BOS",
+    when: "Oct 3 · 7:00 PM ET",
+    network: "LEAN NYK",
+    lean: "LEAN NYK",
+    note: "Camp-open lean only — Brunson settled, Anunoby probable. Not a Pulse bet.",
+  },
+  {
+    away: "SAS",
+    home: "HOU",
+    when: "Oct 4 · 8:00 PM ET",
+    network: "LEAN SAS",
+    lean: "LEAN SAS",
+    note: "Fox-Sengun. Houston freeze is already priced into camp design, not the spread.",
+  },
+];
+
+export function hasTonightSlate(): boolean {
+  return gamePreviews.length > 0;
+}

--- a/client/src/lib/routePreload.ts
+++ b/client/src/lib/routePreload.ts
@@ -11,6 +11,7 @@ const STATIC_IMPORTERS: Record<string, Importer> = {
   "/pick-em": () => import("../pages/PickEm"),
   "/trade-value": () => import("../pages/TradeValue"),
   "/injuries": () => import("../pages/InjuryReport"),
+  "/tonight": () => import("../pages/Tonight"),
   "/trivia": () => import("../pages/Trivia"),
   "/82-0": () => import("../pages/EightyTwoZero"),
   "/performance": () => import("../pages/SeasonPerformance"),
@@ -55,7 +56,7 @@ const PREFIX_IMPORTERS: [string, Importer][] = [
 ];
 
 /** Most-travelled destinations, warmed during idle time after first paint. */
-export const HOT_ROUTES = ["/tools", "/archive", "/injuries", "/playoffs", "/82-0", "/trivia", "/pick-em", "/my-pulse", "/ask"];
+export const HOT_ROUTES = ["/tools", "/archive", "/injuries", "/tonight", "/playoffs", "/82-0", "/trivia", "/pick-em", "/my-pulse", "/ask"];
 
 export function importerForPath(pathname: string): Importer | null {
   const direct = STATIC_IMPORTERS[pathname];

--- a/client/src/lib/seoConfig.ts
+++ b/client/src/lib/seoConfig.ts
@@ -62,6 +62,11 @@ const STATIC_ROUTE_SEO: Record<string, PageSeo> = {
     description: "Daily injury wire with status updates, return timelines, and impact on tonight's slate.",
     canonicalPath: "/injuries",
   },
+  "/tonight": {
+    title: "Tonight's NBA Slate | Hoops Intel",
+    description: "Tonight's games, camp-open previews, and honest empty-slate coverage when the league is dark.",
+    canonicalPath: "/tonight",
+  },
   "/pick-em": {
     title: "NBA Playoff Pick 'Em | Hoops Intel",
     description: "Bracket-style playoff picks and series predictions on Hoops Intel.",
@@ -228,6 +233,7 @@ export const STATIC_SITEMAP_PATHS: string[] = [
   "/playoffs",
   "/tools",
   "/injuries",
+  "/tonight",
   "/pick-em",
   "/trade-value",
   "/trivia",

--- a/client/src/lib/siteNav.ts
+++ b/client/src/lib/siteNav.ts
@@ -14,73 +14,50 @@ export interface MainNavLink {
   href: string;
 }
 
-/** Compact header links (desktop) — season-aware. */
-export function headerNavLinks(date = new Date()): MainNavLink[] {
-  if (isOffseasonDesk(date)) {
-    return [
-      { label: "Pulse", href: "/#pulse-index" },
-      { label: "Briefing", href: "/#today-desk" },
-      { label: "Injuries", href: "/injuries" },
-      { label: "Projections", href: offseasonPrimaryHref(date) },
-      { label: "Tools", href: "/tools" },
-    ];
-  }
+/** Compact header links (desktop) — Enhanced IA. */
+export function headerNavLinks(_date = new Date()): MainNavLink[] {
   return [
-    { label: "Scores", href: "/#scores" },
-    { label: "Pulse", href: "/#pulse-index" },
+    { label: "Desk", href: "/" },
     { label: "Injuries", href: "/injuries" },
-    { label: "Tonight", href: "/#tonight" },
-    { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
-    { label: "Tools", href: "/tools" },
+    { label: "Tonight", href: "/tonight" },
+    { label: "Pick 'Em", href: "/pick-em" },
+    { label: "Archive", href: "/archive" },
+    { label: "Ask", href: "/ask" },
   ];
 }
 
 /** Full drawer navigation (mobile menu + overflow) */
 export function mainNavLinks(date = new Date()): MainNavLink[] {
-  const seasonal = isOffseasonDesk(date)
-    ? [
-        { label: "Pulse", href: "/#pulse-index" },
-        { label: "Briefing", href: "/#today-desk" },
-        { label: "Injuries", href: "/injuries" },
-        { label: "Projections", href: offseasonPrimaryHref(date) },
-      ]
-    : [
-        { label: "Scores", href: "/#scores" },
-        { label: "Pulse", href: "/#pulse-index" },
-        { label: "Injuries", href: "/injuries" },
-        { label: "Tonight", href: "/#tonight" },
-        { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
-      ];
-
-  return [
-    ...seasonal,
+  const primary = headerNavLinks(date);
+  const extra = [
+    { label: "Pulse", href: "/#pulse-index" },
+    { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
     { label: "Watch guide", href: "/watch-guide" },
-    { label: "Archive", href: "/archive" },
     { label: "Tools", href: "/tools" },
-    { label: "Projections", href: "/projections" },
+    { label: "Projections", href: offseasonPrimaryHref(date) },
     { label: "Compare", href: "/compare-players" },
     { label: "Performance", href: "/performance" },
     { label: "Hoops IQ", href: "/trivia" },
-    { label: "Ask Hoops Intel", href: "/ask" },
-  ].filter((link, index, all) => all.findIndex((l) => l.href === link.href) === index);
+    { label: "My Pulse", href: "/my-pulse" },
+  ];
+
+  return [...primary, ...extra].filter(
+    (link, index, all) => all.findIndex((l) => l.href === link.href) === index,
+  );
 }
 
 /** Home footer explore links — keep discoverable product routes out of crawl orphan status. */
 export const FOOTER_QUICK_LINKS: MainNavLink[] = [
-  { label: "Briefing", href: "#today-desk" },
-  { label: "Pulse", href: "#pulse-index" },
-  { label: "Injuries", href: "#injuries" },
-  { label: "Projections", href: "/projections" },
+  { label: "Desk", href: "/" },
+  { label: "Pulse", href: "/#pulse-index" },
+  { label: "Injuries", href: "/injuries" },
+  { label: "Tonight", href: "/tonight" },
+  { label: "Pick 'Em", href: "/pick-em" },
   { label: "Archive", href: "/archive" },
+  { label: "Ask", href: "/ask" },
   { label: "Tools", href: "/tools" },
   { label: "My Pulse", href: "/my-pulse" },
   { label: "Watch guide", href: "/watch-guide" },
-  { label: "Compare players", href: "/compare-players" },
-  { label: "History", href: "/history" },
-  { label: "Refs", href: "/refs" },
-  { label: "Podcast companion", href: "/podcast-companion" },
-  { label: "Guest Pulse", href: "/guest-pulse" },
-  { label: "Rivals", href: "/rivals" },
   { label: "How Pulse works", href: "/pulse-methodology" },
   { label: "RSS", href: "/feed.xml" },
 ];
@@ -106,22 +83,13 @@ export function deskSectionLinks(date = new Date()): MainNavLink[] {
   ];
 }
 
-export function mobileBottomNavLinks(date = new Date()): MainNavLink[] {
-  if (isOffseasonDesk(date)) {
-    return [
-      { label: "Today", href: "/" },
-      { label: "Pulse", href: "/#pulse-index" },
-      { label: "Projections", href: offseasonPrimaryHref(date) },
-      { label: "My Pulse", href: "/my-pulse" },
-      { label: "Ask", href: "/ask" },
-    ];
-  }
+export function mobileBottomNavLinks(_date = new Date()): MainNavLink[] {
   return [
-    { label: "Today", href: "/" },
-    { label: "Scores", href: "/#scores" },
-    { label: playoffsNavLabel(), href: PLAYOFFS_NAV_HREF },
-    { label: "My Pulse", href: "/my-pulse" },
-    { label: "Picks", href: "/pick-em" },
+    { label: "Desk", href: "/" },
+    { label: "Injuries", href: "/injuries" },
+    { label: "Tonight", href: "/tonight" },
+    { label: "Pick 'Em", href: "/pick-em" },
+    { label: "Ask", href: "/ask" },
   ];
 }
 
@@ -157,7 +125,8 @@ export interface ToolLink {
 }
 
 export const TOOLS_DIRECTORY: ToolLink[] = [
-  { label: "Today’s desk", href: "/", description: "Daily briefing, scores, Pulse Index, slate", category: "desk" },
+  { label: "Desk", href: "/", description: "Daily briefing, Pulse Index, injury rail, slate", category: "desk" },
+  { label: "Tonight", href: "/tonight", description: "Tonight's slate and camp-open previews", category: "desk" },
   { label: "Archive", href: "/archive", description: "Past morning editions", category: "desk" },
   { label: "Pulse history", href: "/pulse-history", description: "Ranking history", category: "desk" },
   { label: "My Pulse", href: "/my-pulse", description: "Personalized edition", category: "desk" },

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -27,8 +27,6 @@ import { subscribeDigestEmail, readDigestSignupHint } from "../lib/subscribeDige
 import BoxScoreCard from "../components/BoxScoreCard";
 import ReactionBar from "../components/ReactionBar";
 import SiteHeader from "../components/SiteHeader";
-import DeskSectionNav from "../components/DeskSectionNav";
-import MyPulseBanner from "../components/MyPulseBanner";
 import PreferencesSetup from "../components/PreferencesSetup";
 import { LiveScoreSkeleton } from "../components/PageSkeletons";
 import { useToast } from "../contexts/ToastContext";
@@ -62,12 +60,12 @@ import { dispatchAskPrompt } from "../lib/askShortcuts";
 import { rationaleToBullets, pulseLeadLine } from "../lib/pulseRationale";
 import { shouldShowLiveScorebar, scorebarGamesToShow } from "../lib/scorebarVisibility";
 import PickEmHomeBanner from "../components/PickEmHomeBanner";
-import OffseasonDeskStrip from "../components/OffseasonDeskStrip";
 import { isOffseasonDesk, offseasonPrimaryCta, editionContextDeskLabel } from "../lib/deskMode";
 import { FOOTER_QUICK_LINKS } from "../lib/siteNav";
 import { liveScoresTrustLabel } from "../lib/dataTrust";
 import { lineMovementForMatchup, spreadMoved } from "../lib/lineMovement";
 import { formatLineMovementBadge } from "../lib/spreadMovement";
+import EnhancedDesk, { EnhancedTicker } from "../components/enhanced/EnhancedDesk";
 
 function shortenPulsePreview(text: string, max = 110) {
   const t = text.trim();
@@ -1869,20 +1867,13 @@ export default function Home() {
     <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
       <SiteHeader editionBadge={pulseEdition.date} />
       <RivalTonightBanner />
-      <LiveScorebar />
-      <TickerBar />
+      <EnhancedTicker />
       <main id="main-content" tabIndex={-1}>
-        <HeroSection showMyPulse={showMyPulse} />
-        <DeskSectionNav />
-        <TodayDeskSection />
-        <OffseasonDeskStrip />
-        {!isOffseasonDesk() || gamePreviews.length > 0 ? <PickEmHomeBanner /> : null}
-        {!showMyPulse ? <MyPulseBanner onSetup={() => setShowPrefsSetup(true)} /> : null}
+        <EnhancedDesk showMyPulse={showMyPulse} />
+        <LiveScorebar />
         {isPlayoffsActive() ? <PlayoffSection /> : null}
         {!(isOffseasonDesk() && gameResults.length === 0) ? <ScoresSection favoriteTeams={favoriteTeams} /> : null}
-        <PulseIndexSection />
-        <InjurySection />
-        {!(isOffseasonDesk() && gamePreviews.length === 0) ? <TonightSection /> : null}
+        {!isOffseasonDesk() || gamePreviews.length > 0 ? <PickEmHomeBanner /> : null}
         <CollapsibleEditionExtras
           narrative={<NarrativeSection />}
           media={<MediaReactionsSection />}

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -1,5 +1,8 @@
-import { useState } from "react";
-import ToolPageLayout from "../components/ToolPageLayout";
+import { useMemo, useState } from "react";
+import SiteHeader from "../components/SiteHeader";
+import { InjuryChip, SectionHeader } from "../components/enhanced/EnhancedUi";
+import { editionContextDeskLabel } from "../lib/deskMode";
+import { injuryCounts } from "../lib/enhancedDesk";
 import { injuryUpdates, fantasyAlerts, pulseEdition, pulseIndex } from "../lib/pulseData";
 import { slugify } from "../lib/searchUtils";
 import TeamLogo from "../components/TeamLogo";
@@ -292,115 +295,87 @@ function FilterButton({
 // ═══════════════════════════════════════════════════════════
 
 export default function InjuryReport() {
-  const [filter, setFilter] = useState<FilterType>("all");
-
-  // Sort by impact (highest first)
-  const sorted = [...injuryUpdates].sort((a, b) => {
-    return impactRating(b.impact) - impactRating(a.impact);
+  const [club, setClub] = useState("all");
+  const tallies = injuryCounts();
+  const clubs = useMemo(
+    () => ["all", ...Array.from(new Set(injuryUpdates.map((i) => i.team))).sort()],
+    [],
+  );
+  const rows = injuryUpdates.filter((injury) => club === "all" || injury.team === club);
+  const nextClub = () => {
+    const idx = clubs.indexOf(club);
+    setClub(clubs[(idx + 1) % clubs.length] ?? "all");
+  };
+  const shortDate = pulseEdition.date.replace(/,.*/, "").replace(/(\w+)\s+(\d+)/, (_, m, d) => {
+    const months: Record<string, string> = {
+      January: "Jan",
+      February: "Feb",
+      March: "Mar",
+      April: "Apr",
+      May: "May",
+      June: "Jun",
+      July: "Jul",
+      August: "Aug",
+      September: "Sep",
+      October: "Oct",
+      November: "Nov",
+      December: "Dec",
+    };
+    return `${months[m] ?? m} ${d}`;
   });
-
-  const filtered = sorted.filter((injury) => {
-    if (filter === "all") return true;
-    if (filter === "out") return injury.status.toLowerCase() === "out";
-    if (filter === "questionable")
-      return injury.status.toLowerCase() === "questionable";
-    if (filter === "high-impact") return impactRating(injury.impact) >= 8;
-    return true;
-  });
-
-  const counts = {
-    all: sorted.length,
-    out: sorted.filter((i) => i.status.toLowerCase() === "out").length,
-    questionable: sorted.filter((i) => i.status.toLowerCase() === "questionable").length,
-    "high-impact": sorted.filter((i) => impactRating(i.impact) >= 8).length,
-  }
 
   return (
-    <ToolPageLayout subtitle="INJURY REPORT">
-{/* ── Section label + title ── */}
-        <div className="mb-2">
-          <div
-            className="text-[10px] font-bold tracking-widest uppercase mb-1"
-            style={{ color: "rgba(255,255,255,0.35)" }}
+    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+      <SiteHeader />
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none">
+        <div className="flex items-end justify-between gap-3">
+          <SectionHeader eyebrow="INJURY WIRE" title="Full report" />
+          <button
+            type="button"
+            onClick={nextClub}
+            className="text-xs font-medium min-h-[36px] shrink-0 pb-1"
+            style={{ color: "var(--hi-accent,#1ec8f5)" }}
           >
-            INJURY WIRE
-          </div>
-          <div className="flex flex-wrap items-end gap-4 justify-between">
-            <div>
-              <h1
-                className="display-heading text-white mb-1"
-                style={{ fontSize: "clamp(1.75rem, 4vw, 2.5rem)" }}
-              >
-                Injury Report
-              </h1>
-              <div className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-                {pulseEdition.date} · {counts.all} players tracked
-              </div>
-            </div>
-            {/* Legend */}
-            <div className="flex items-center gap-4 flex-wrap">
-              {[
-                { label: "High Impact (8–10)", color: "#F43F5E" },
-                { label: "Mid Impact (5–7)", color: "#F59E0B" },
-                { label: "Low Impact (1–4)", color: "#10B981" },
-              ].map((item) => (
-                <div key={item.label} className="flex items-center gap-1.5">
-                  <span
-                    className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-                    style={{ background: item.color }}
-                  />
-                  <span className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
-                    {item.label}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
+            {club === "all" ? "Filter · all clubs" : `Filter · ${club}`}
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+            {shortDate} · {editionContextDeskLabel().toLowerCase()} · {tallies.dtd} day-to-day · {tallies.probable}{" "}
+            probable · {tallies.out} out
+          </p>
         </div>
 
-        {/* ── Filter buttons ── */}
-        <div className="flex flex-wrap gap-2 mt-6 mb-8">
-          <FilterButton
-            label="All"
-            active={filter === "all"}
-            onClick={() => setFilter("all")}
-            count={counts.all}
-          />
-          <FilterButton
-            label="OUT"
-            active={filter === "out"}
-            onClick={() => setFilter("out")}
-            count={counts.out}
-          />
-          <FilterButton
-            label="Questionable"
-            active={filter === "questionable"}
-            onClick={() => setFilter("questionable")}
-            count={counts.questionable}
-          />
-          <FilterButton
-            label="High Impact"
-            active={filter === "high-impact"}
-            onClick={() => setFilter("high-impact")}
-            count={counts["high-impact"]}
-          />
-        </div>
-
-        {/* ── Impact grid ── */}
-        {filtered.length === 0 ? (
-          <div
-            className="text-center py-20 text-sm"
-            style={{ color: "rgba(255,255,255,0.3)" }}
-          >
-            No injuries match this filter.
+        {rows.length === 0 ? (
+          <div className="text-sm py-16 text-center" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+            No injuries match this club filter.
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {filtered.map((injury, i) => (
-              <InjuryCard key={i} injury={injury} />
+          <div className="flex flex-col gap-2">
+            {rows.map((injury) => (
+              <a
+                key={`${injury.player}-${injury.team}`}
+                href={`/player/${slugify(injury.player)}`}
+                className="enhanced-card flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 p-3.5"
+              >
+                <div className="w-full sm:w-[220px] shrink-0">
+                  <p className="text-[15px] font-semibold text-[var(--hi-text,#f3f6fa)]">{injury.player}</p>
+                  <p className="text-[11px] font-bold tracking-[0.6px]" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+                    {injury.team}
+                  </p>
+                </div>
+                <InjuryChip status={injury.status} />
+                <div className="flex-1 min-w-0">
+                  <p className="text-[13px] font-medium text-[var(--hi-text,#f3f6fa)]">{injury.injury}</p>
+                  <p className="editorial-body text-xs leading-[17px] mt-1" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+                    {injury.timeline}
+                  </p>
+                </div>
+              </a>
             ))}
           </div>
         )}
-    </ToolPageLayout>
+      </main>
+    </div>
   );
 }

--- a/client/src/pages/PickEm.tsx
+++ b/client/src/pages/PickEm.tsx
@@ -24,6 +24,9 @@ import { isPlayoffsActive, playoffSeries } from "../lib/playoffData";
 import { playoffSnapshot, todayISOLocal } from "../lib/playoffAnalytics";
 import ToolPageLayout from "../components/ToolPageLayout";
 import PulseAccountabilityPanel from "../components/PulseAccountabilityPanel";
+import SiteHeader from "../components/SiteHeader";
+import { EnhancedButton, GamePreviewCard, SectionHeader, StatCard } from "../components/enhanced/EnhancedUi";
+import { SAMPLE_LOCKS } from "../lib/enhancedDesk";
 
 // ═══════════════════════════════════════════════════════════
 // TYPES
@@ -502,6 +505,67 @@ function HowItWorksSection() {
 // PICK'EM PAGE
 // ═══════════════════════════════════════════════════════════
 
+function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
+  const record =
+    pickStats.wins + pickStats.losses > 0 ? `${pickStats.wins}–${pickStats.losses}` : "0–0";
+  const streak = pickStats.streak > 0 ? String(pickStats.streak) : "—";
+
+  return (
+    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+      <SiteHeader />
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none">
+        <SectionHeader
+          eyebrow="PICK 'EM"
+          title="Lock tonight’s slate"
+          action="Season board →"
+          actionHref="/pick-em#season-board"
+        />
+        <div className="enhanced-card flex flex-col gap-2.5 p-[22px]">
+          <p className="editorial-heading text-2xl text-[var(--hi-text,#f3f6fa)]">No picks yet.</p>
+          <p className="editorial-body text-sm leading-5 text-[var(--hi-text,#f3f6fa)] max-w-3xl">
+            Nothing on tonight’s schedule, so the board is closed. Game and bracket picks count toward the
+            season board when the first tip lands. Lock picks to see how you stack up against the desk.
+          </p>
+          <div className="flex flex-wrap gap-2 pt-1">
+            <EnhancedButton href="/tonight">Open Pick &apos;Em</EnhancedButton>
+            <EnhancedButton href="/archive" variant="ghost">
+              View archive
+            </EnhancedButton>
+          </div>
+        </div>
+        <div id="season-board" className="grid grid-cols-2 xl:grid-cols-4 gap-3">
+          <StatCard kicker="SEASON RECORD" value={record} sub="No settled picks yet" />
+          <StatCard kicker="DESK RECORD" value="—" sub="The desk waits on October" />
+          <StatCard kicker="STREAK" value={streak} sub="First lock of 2026-27" />
+          <StatCard kicker="BRACKET" value="Open" sub="Playoff tooling idle" />
+        </div>
+        <SectionHeader
+          eyebrow="WHEN GAMES RETURN"
+          title="How a lock looks"
+          action="Scoring rules →"
+          actionHref="#how-it-works"
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {SAMPLE_LOCKS.map((lock) => (
+            <GamePreviewCard
+              key={`${lock.away}-${lock.home}`}
+              status="SAMPLE LOCK"
+              when={lock.when}
+              away={lock.away}
+              home={lock.home}
+              network={lock.lean}
+              note={lock.note}
+            />
+          ))}
+        </div>
+        <div id="how-it-works" className="pt-2">
+          <HowItWorksSection />
+        </div>
+      </main>
+    </div>
+  );
+}
+
 // Derive today's edition date string (YYYY-MM-DD) from pulseEdition
 function parseEditionDate(dateStr: string): string {
   return editionDateFromPulse(dateStr);
@@ -515,6 +579,7 @@ export default function PickEmPage() {
   const playoffSnap = isPlayoffsActive()
     ? playoffSnapshot(playoffSeries, todayISOLocal())
     : null;
+  const boardClosed = gamePreviews.length === 0 && !isPlayoffsActive();
 
   useEffect(() => {
     let cancelled = false;
@@ -525,6 +590,10 @@ export default function PickEmPage() {
       cancelled = true;
     };
   }, []);
+
+  if (boardClosed) {
+    return <ClosedBoardPickEm pickStats={pickStats} />;
+  }
 
   return (
     <ToolPageLayout subtitle="PICK EM">

--- a/client/src/pages/Tonight.tsx
+++ b/client/src/pages/Tonight.tsx
@@ -1,0 +1,123 @@
+import SiteHeader from "../components/SiteHeader";
+import { EnhancedButton, GamePreviewCard, SectionHeader, StatCard } from "../components/enhanced/EnhancedUi";
+import {
+  CAMP_OPENER_PREVIEWS,
+  daysUntilIso,
+  CAMP_OPEN_ISO,
+  hasTonightSlate,
+} from "../lib/enhancedDesk";
+import { gamePreviews, pulseEdition } from "../lib/pulseData";
+import { makeGameId } from "../lib/gameCenter";
+
+export default function Tonight() {
+  const campDays = daysUntilIso(CAMP_OPEN_ISO);
+  const slateOpen = hasTonightSlate();
+
+  return (
+    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+      <SiteHeader />
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none">
+        <SectionHeader
+          eyebrow="TONIGHT'S SLATE"
+          title={slateOpen ? `${gamePreviews.length} games tonight` : "No games tonight"}
+          action="Watch guide →"
+          actionHref="/watch-guide"
+        />
+
+        {slateOpen ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {(gamePreviews as Array<{
+              gameId?: string;
+              awayTeam: string;
+              homeTeam: string;
+              time?: string;
+              tv?: string;
+              featured?: boolean;
+              storyline?: string;
+              keyMatchup?: string;
+            }>).map((preview) => (
+              <a
+                key={preview.gameId || `${preview.awayTeam}-${preview.homeTeam}`}
+                href={`/game/${preview.gameId || makeGameId(preview.awayTeam, preview.homeTeam, pulseEdition.date)}`}
+              >
+                <GamePreviewCard
+                  status={preview.featured ? "FEATURED" : "TONIGHT"}
+                  when={`${preview.time ?? ""}${preview.tv ? ` · ${preview.tv}` : ""}`}
+                  away={preview.awayTeam}
+                  home={preview.homeTeam}
+                  network={preview.tv || ""}
+                  note={preview.storyline || preview.keyMatchup || ""}
+                />
+              </a>
+            ))}
+          </div>
+        ) : (
+          <div className="enhanced-card flex flex-col gap-2 p-5">
+            <p className="editorial-heading text-[22px] leading-[26px] text-[var(--hi-text,#f3f6fa)]">
+              The dead period still has the floor.
+            </p>
+            <p className="editorial-body text-sm leading-5 text-[var(--hi-text,#f3f6fa)]">
+              Nothing on tonight’s schedule. Preseason opens October 3
+              {campDays > 0 ? ` — ${campDays === 1 ? "one day" : `${campDays} days`}` : ""}. Rotation battles
+              and minutes caps move to Lineups until the first tip.
+            </p>
+            <p className="text-xs leading-[18px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+              Scores is not a standalone route — recaps live on the desk when games exist.
+            </p>
+            <div className="pt-1">
+              <EnhancedButton href="/lineups" variant="ghost">
+                Open lineups
+              </EnhancedButton>
+            </div>
+          </div>
+        )}
+
+        {!slateOpen ? (
+          <>
+            <SectionHeader
+              eyebrow="WHEN THE SLATE RETURNS"
+              title="Camp openers · Oct 3"
+              action="Add to Pulse →"
+              actionHref="/my-pulse"
+            />
+            <p className="text-xs -mt-2" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+              Editorial camp-open watch list — not a live ESPN slate and not tonight’s scores.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {CAMP_OPENER_PREVIEWS.map((game) => (
+                <GamePreviewCard
+                  key={`${game.away}-${game.home}`}
+                  status="PRESEASON"
+                  when={game.when}
+                  away={game.away}
+                  home={game.home}
+                  network={game.network}
+                  note={game.note}
+                />
+              ))}
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <a href="/lineups">
+                <StatCard
+                  kicker="ROTATION BATTLES"
+                  value="Lineups desk"
+                  sub="Preseason desk prioritizes minutes caps and scheme teases."
+                />
+              </a>
+              <StatCard
+                kicker="MURRAY D17"
+                value="DEN"
+                sub="Silence is now institutional precedent — not reversible by one announcement."
+              />
+              <StatCard
+                kicker="OKC PREP"
+                value="Operational"
+                sub="Preparation depth converting from abstract to camp decisions."
+              />
+            </div>
+          </>
+        ) : null}
+      </main>
+    </div>
+  );
+}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -24,6 +24,14 @@ html.dark {
   --hi-heading: #ffffff;
   --hi-muted: rgba(255, 255, 255, 0.72);
   --hi-muted-sub: rgba(255, 255, 255, 0.68);
+  --hi-accent: #1ec8f5;
+  --hi-surface: #0c1522;
+  --hi-surface-2: #121c2c;
+  --hi-border: #1e2c40;
+  --hi-text: #f3f6fa;
+  --hi-text-secondary: #8b9bb0;
+  --hi-success: #3ddc97;
+  --hi-danger: #ff4d6a;
 }
 
 html.light {
@@ -35,6 +43,14 @@ html.light {
   --hi-heading: #0f172a;
   --hi-muted: rgba(15, 23, 42, 0.68);
   --hi-muted-sub: rgba(15, 23, 42, 0.52);
+  --hi-accent: #0284c7;
+  --hi-surface: #ffffff;
+  --hi-surface-2: #e2e8f0;
+  --hi-border: rgba(15, 23, 42, 0.12);
+  --hi-text: #0f172a;
+  --hi-text-secondary: #475569;
+  --hi-success: #059669;
+  --hi-danger: #e11d48;
 }
 
 .sr-only {
@@ -152,12 +168,38 @@ html.light .section-label {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.15em;
-  color: #0ea5e9;
+  color: var(--hi-accent, #1ec8f5);
 }
 
 .mono-data {
-  font-family: "JetBrains Mono", monospace;
+  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, monospace;
   font-size: 0.85rem;
+}
+
+.editorial-heading {
+  font-family: "Newsreader", Georgia, "Times New Roman", serif;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.editorial-body {
+  font-family: "Newsreader", Georgia, "Times New Roman", serif;
+  font-weight: 400;
+}
+
+.enhanced-kicker {
+  font-family: "DM Sans", sans-serif;
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--hi-accent, #1ec8f5);
+}
+
+.enhanced-card {
+  background: var(--hi-surface, #0c1522);
+  border: 1px solid var(--hi-border, #1e2c40);
+  border-radius: 10px;
 }
 
 /* Container */

--- a/public/assets/brand-diamond.svg
+++ b/public/assets/brand-diamond.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7 0L14 7L7 14L0 7L7 0Z" fill="#1EC8F5"/>
+</svg>

--- a/scripts/deployment-smoke.mjs
+++ b/scripts/deployment-smoke.mjs
@@ -19,6 +19,7 @@ const staticChecks = [
   { path: "/", type: "html" },
   { path: "/playoffs", type: "html" },
   { path: "/pick-em", type: "html" },
+  { path: "/tonight", type: "html" },
   { path: "/betting-intel", type: "html" },
   { path: "/embed-stats", type: "html" },
   { path: "/print-edition", type: "html" },

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -189,6 +189,7 @@ export function playerSitemapMeta({ inPulse } = {}) {
 export const STATIC_ROUTE_SOURCES = {
   "/tools": ["client/src/lib/siteNav.ts"],
   "/injuries": ["client/src/lib/pulseData.ts"],
+  "/tonight": ["client/src/lib/pulseData.ts", "client/src/pages/Tonight.tsx"],
   "/pick-em": ["client/src/lib/playoffData.ts", "client/src/pages/PickEm.tsx"],
   "/trade-value": ["client/src/lib/tradeValueData.ts"],
   "/trivia": ["client/src/pages/Trivia.tsx"],
@@ -243,6 +244,7 @@ export function lastmodForLoc(loc, ctx) {
   }
   const deskTied = new Set([
     "/injuries",
+    "/tonight",
     "/my-pulse",
     "/print-edition",
     "/betting-intel",

--- a/scripts/lib/public-routes.mjs
+++ b/scripts/lib/public-routes.mjs
@@ -10,6 +10,7 @@ export const SITE_REVIEW_PATHS = [
   "/archive",
   "/playoffs",
   "/injuries",
+  "/tonight",
   "/performance",
   "/pulse-history",
   "/my-pulse",
@@ -50,6 +51,7 @@ export const SITE_REVIEW_PATHS = [
 export const SITEMAP_STATIC_ROUTES = [
   // Daily desk — crawl above interactive tools
   { loc: "/injuries", priority: "0.7", changefreq: "daily" },
+  { loc: "/tonight", priority: "0.7", changefreq: "daily" },
   { loc: "/betting-intel", priority: "0.7", changefreq: "daily" },
   { loc: "/watch-guide", priority: "0.65", changefreq: "daily" },
   { loc: "/momentum", priority: "0.65", changefreq: "daily" },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,8 @@ export default {
     extend: {
       colors: {
         navy: "#050D1A",
-        "electric-blue": "#0EA5E9",
+        "electric-blue": "#1EC8F5",
+        accent: "#1EC8F5",
         emerald: "#10B981",
         rose: "#F43F5E",
         amber: "#F59E0B",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships Hoops Intel’s Enhanced (Figma AI) UI on the existing React/Vite client. Data pipeline, ESPN fetch, `pulseData.ts`, auth, Pick ’Em backend, Pro/Stripe, and APIs are unchanged.

**Screens changed**
- **Desk (`/`)**: editorial hero, Pulse Index as a homepage module, injury rail (“Desk tags”), Ask shortcuts. Uses live `pulseData` / generated edition content.
- **Tonight (`/tonight`)**: new route. Honest empty slate when there are no NBA games (Sep 1 2026 / preseason). Camp-open cards are labeled editorial preview, not live scores.
- **Injury Wire (`/injuries`)**: full-report list matching the Figma frame, driven by real `injuryUpdates`.
- **Pick ’Em (`/pick-em`)**: closed-board empty state when there is no slate, plus sample-lock preview. Existing pick widget still renders when games exist.
- **Mobile**: bottom nav Desk / Injuries / Tonight / Pick ’Em / Ask and a stacked desk.

Nav labels: Desk, Injuries, Tonight, Pick ’Em, Archive, Ask. No new `/scores` or `/pulse` routes.

**Deploy note:** production is Vercel project **`hoops-intel` only** (`prj_uOMNFwlueYPsY5viw9Wxc3RqDn2S` → https://hoopsintel.net/). Do **not** deploy or relink `hoops-intel-1` or `hoops-intel-2` (paused and Git-disconnected on purpose).

Verified locally: `npm run test:unit` (298 passed), `vite build`, browser walkthrough of Desk / Tonight / Injuries / Pick ’Em.

[Enhanced Desk desktop](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenhanced_desk_desktop.webp)
[Tonight empty slate](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenhanced_tonight_desktop.webp)
[Injury Wire full report](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenhanced_injuries_desktop.webp)
[Pick Em closed board](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenhanced_pickem_desktop.webp)
[Mobile desk](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenhanced_desk_mobile.webp)
[enhanced_ui_desk_tonight_injuries_pickem.mp4](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenhanced_ui_desk_tonight_injuries_pickem.mp4)

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (298 tests)
- [x] Vercel Preview looks correct for UI changes
- [x] New secrets documented in `.env.example` / `README.md` if applicable (none)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c67090-ae48-4627-b405-8662b7d2c66c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Enhanced Desk UI, `/tonight` route, and revised site navigation
> - Introduces the Enhanced UI component set in [EnhancedUi.tsx](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-935c3e3d041a7d90a9914e6db9da66d38f8ba4c1ac87ad1e4f455ca38a69c383) (`BrandLockup`, `StatCard`, `InjuryChip`, `EnhancedButton`, `GamePreviewCard`) and the `EnhancedDesk` layout in [EnhancedDesk.tsx](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-0ee83f87c4980e1ca40078106d29e71029551935a8c56c5d5b5a60befb22430f) with hero stats, Pulse rows, injury rail, and Ask chips.
> - Adds a dedicated `/tonight` page in [Tonight.tsx](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-21ab0eee2637b89b6034854bcd179ed8378af5432dcb9f693966ab4a715c4371) wired into routing, preloading in [routePreload.ts](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-99108f45534b567ed30f399decf69187885a733b9e7cf1a989856e2511bbfc7c), SEO in [seoConfig.ts](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-02c7413553a9932e0c6a8cf743599055430076c4a06eb575c7f4a4643d06415c), and sitemap generation.
> - Replaces the site navigation IA in [siteNav.ts](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-e7b282b299b765e1660c97c854729922fe0e1f1ae97d2f720af386e33d245655): header, mobile bottom nav, footer, and tools directory now consistently expose Desk, Injuries, Tonight, Pick 'Em, and Ask regardless of season.
> - Reworks [Home.tsx](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-89afd9d1dc263b0fb25b7de782e8da5905de63d47c483bc69807c1449c19be01) to center the Enhanced desk/ticker and removes `DeskSectionNav`, `OffseasonDeskStrip`, `MyPulseBanner`, `PulseIndexSection`, `InjurySection`, and `TonightSection`; rewrites [InjuryReport.tsx](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-5c7c90f77cb31927da650482366b45da5b51c12d8dd9f746ad3c14030a2aa5b7) with team filters and enhanced cards; adds a closed-board state to [PickEm.tsx](https://github.com/hondoentertainment/hoops-intel/pull/360/files#diff-0d94d677ed994b2d94dcb0601f2a3a4e1ba572512111cabcba2fb953dc56a5b7).
> - Risk: `MobileBottomNav.linkActive` only marks root active for exact `/` (hash-only hrefs no longer count); `headerNavLinks` no longer varies by season; `electric-blue` Tailwind color changed to `#1EC8F5`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58fddda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->