### PR TITLE
Phone-first Enhanced UI for the primary mobile screens

### DIFF
--- a/client/src/__tests__/enhancedDesk.test.ts
+++ b/client/src/__tests__/enhancedDesk.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  compactPulseStats,
   daysUntilIso,
   deskAskChips,
   formatPulseScore,
@@ -7,6 +8,7 @@ import {
   heroStats,
   injuryChipTone,
   injuryCounts,
+  mobileHeroStats,
   padRank,
   pulseTrendMark,
   shortInjuryLine,
@@ -37,6 +39,17 @@ describe("enhancedDesk", () => {
     expect(injuryChipTone("Day-to-Day")).toBe("danger");
     expect(injuryChipTone("Probable")).toBe("success");
     expect(shortInjuryLine("Right knee soreness (chronic management)")).toMatch(/knee/i);
+  });
+
+  it("compacts Pulse stat lines and hero chips for a 390px desk", () => {
+    expect(compactPulseStats("32.8 PPG · 12.1 RPG · 4.2 BPG · Locked 2030-31")).toBe(
+      "32.8 · 12.1 · 4.2 · Locked 2030-31",
+    );
+    const chips = mobileHeroStats();
+    expect(chips).toHaveLength(2);
+    expect(chips[0]?.kicker).toBe("PULSE");
+    expect(chips[1]?.kicker).toBe("CAMP");
+    expect(chips[1]?.value).toMatch(/d$|Today|Open|—/);
   });
 
   it("uses closed-slate Ask chips when there are no games", () => {

--- a/client/src/components/AskHoopsIntel.tsx
+++ b/client/src/components/AskHoopsIntel.tsx
@@ -462,7 +462,7 @@ export default function AskHoopsIntel() {
           type="button"
           ref={triggerRef}
           onClick={() => setIsOpen(true)}
-          className="fixed z-50 flex items-center gap-2 min-h-[48px] px-4 py-3 rounded-full shadow-lg transition-all hover:scale-[1.02] md:bottom-6"
+          className="hidden md:flex fixed z-50 items-center gap-2 min-h-[48px] px-4 py-3 rounded-full shadow-lg transition-all hover:scale-[1.02] md:bottom-6"
           style={{
             background: "linear-gradient(135deg, #0EA5E9, #0284C7)",
             color: "white",

--- a/client/src/components/MobileBottomNav.tsx
+++ b/client/src/components/MobileBottomNav.tsx
@@ -16,7 +16,7 @@ export default function MobileBottomNav() {
     <nav
       className="mobile-bottom-nav fixed bottom-0 left-0 right-0 z-50 md:hidden border-t"
       style={{
-        paddingBottom: "env(safe-area-inset-bottom)",
+        paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))",
         background: "var(--hi-surface,#0c1522)",
         borderColor: "var(--hi-border,#1e2c40)",
       }}

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -549,12 +549,12 @@ export default function SiteHeader({
           backdropFilter: "blur(20px)",
         }}
       >
-        <div className="container">
-          <div className="flex items-center justify-between gap-3 h-14 min-h-[56px]">
-            <div className="flex items-center gap-2 min-w-0 flex-1">
+        <div className="container max-md:px-4">
+          <div className="flex items-center justify-between gap-2 h-14 min-h-[56px] overflow-hidden">
+            <div className="flex items-center gap-1 min-w-0">
               <button
                 type="button"
-                className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg border border-white/10 text-white hover:bg-white/10 focus-visible:outline focus-visible:outline-sky-500"
+                className="md:hidden min-h-11 min-w-11 flex items-center justify-center rounded-lg text-white hover:bg-white/10 focus-visible:outline focus-visible:outline-sky-500"
                 aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
                 aria-expanded={mobileOpen}
                 onClick={() => setMobileOpen((v) => !v)}
@@ -572,7 +572,7 @@ export default function SiteHeader({
                 </svg>
               </button>
 
-              <div className="flex items-center gap-3 min-w-0 shrink-0 py-1">
+              <div className="flex items-center min-w-0 py-1">
                 <BrandLockup compact />
               </div>
             </div>
@@ -625,9 +625,9 @@ export default function SiteHeader({
               </details>
             </nav>
 
-            <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+            <div className="flex items-center gap-0.5 sm:gap-2 shrink-0">
               <span
-                className="mono-data text-[11px] md:hidden mr-1"
+                className="mono-data text-[11px] md:hidden px-1"
                 style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}
               >
                 {compactEditionDate(editionBadge ?? pulseEdition.date)}
@@ -636,7 +636,19 @@ export default function SiteHeader({
               <button
                 type="button"
                 onClick={() => setSearchOpen(true)}
-                className="flex items-center gap-2 min-h-[36px] px-2.5 py-1.5 rounded-md text-xs transition-colors hover:bg-white/10"
+                className="md:hidden min-h-11 min-w-11 flex items-center justify-center rounded-lg hover:bg-white/10"
+                aria-haspopup="dialog"
+                aria-label="Open search"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={() => setSearchOpen(true)}
+                className="hidden md:flex items-center gap-2 min-h-11 px-2.5 py-1.5 rounded-md text-xs transition-colors hover:bg-white/10"
                 style={{
                   background: "var(--hi-surface-2,#121c2c)",
                   color: "var(--hi-text-secondary,#8b9bb0)",
@@ -645,13 +657,12 @@ export default function SiteHeader({
                 aria-haspopup="dialog"
                 aria-label="Open search"
               >
-                <span className="hidden sm:inline">Search desk</span>
-                <span className="sm:hidden">Search</span>
+                <span>Search desk</span>
                 <span className="hidden lg:inline mono-data text-[11px]">⌘K</span>
               </button>
               <a
                 href="/pro"
-                className="hidden sm:inline-flex items-center justify-center min-h-[36px] px-4 py-[9px] rounded-md text-[13px] font-semibold"
+                className="hidden md:inline-flex items-center justify-center min-h-11 px-4 py-[9px] rounded-md text-[13px] font-semibold"
                 style={{
                   color: "var(--hi-text,#f3f6fa)",
                   border: "1px solid var(--hi-border,#1e2c40)",
@@ -663,7 +674,7 @@ export default function SiteHeader({
               <button
                 type="button"
                 onClick={toggleTheme}
-                className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors hover:bg-white/10"
+                className="hidden md:flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors hover:bg-white/10"
                 title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
                 aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
               >
@@ -686,18 +697,20 @@ export default function SiteHeader({
                 )}
               </button>
 
-              <NotificationBell idPrefix="nav-bell" />
+              <div className="hidden md:block">
+                <NotificationBell idPrefix="nav-bell" />
+              </div>
 
               {sessionUser === undefined ? (
                 <span
-                  className="hidden sm:inline-block w-14 h-8 rounded-lg animate-pulse shrink-0"
+                  className="hidden md:inline-block w-14 h-8 rounded-lg animate-pulse shrink-0"
                   style={{ background: "rgba(255,255,255,0.06)" }}
                   aria-hidden
                 />
               ) : sessionUser ? (
                 <a
                   href="/account"
-                  className="flex items-center gap-1 min-h-[44px] px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
+                  className="hidden md:flex items-center gap-1 min-h-11 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
                   style={{ background: "rgba(14,165,233,0.12)", color: "#7dd3fc", border: "1px solid rgba(14,165,233,0.25)" }}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
@@ -711,7 +724,7 @@ export default function SiteHeader({
                   type="button"
                   onClick={() => setShowAuth(true)}
                   aria-label="Sign in to your account"
-                  className="flex items-center gap-1 min-h-[44px] px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
+                  className="hidden md:flex items-center gap-1 min-h-11 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
                   style={{ background: "rgba(255,255,255,0.05)", color: "var(--hi-muted, rgba(255,255,255,0.72))" }}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
@@ -770,22 +783,48 @@ export default function SiteHeader({
                   </a>
                 );
               })}
+              <div className="mt-2 pt-3 border-t border-white/10 flex flex-col gap-1">
+                <a
+                  href="/pro"
+                  className="py-3 px-3 rounded-lg text-sm hover:bg-white/5 min-h-12 flex items-center"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Pro
+                </a>
+                <a
+                  href="/account#browser-push"
+                  className="py-3 px-3 rounded-lg text-sm hover:bg-white/5 min-h-12 flex items-center"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  Notifications
+                </a>
+                <button
+                  type="button"
+                  className="w-full text-left py-3 px-3 rounded-lg text-sm hover:bg-white/5 min-h-12"
+                  onClick={() => {
+                    toggleTheme();
+                    setMobileOpen(false);
+                  }}
+                >
+                  {theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+                </button>
+              </div>
               {sessionUser ? (
                 <a
                   href="/account"
-                  className="py-3 px-3 rounded-lg text-sm hover:bg-white/5 text-sky-400 font-medium"
+                  className="py-3 px-3 rounded-lg text-sm hover:bg-white/5 text-sky-400 font-medium min-h-12 flex items-center"
                   onClick={() => setMobileOpen(false)}
                 >
                   Account
                 </a>
               ) : (
-                <div className="mt-2 pt-3 border-t border-white/10">
+                <div className="mt-1 pt-3 border-t border-white/10">
                   <p className="px-3 pb-2 text-xs" style={{ color: "rgba(255,255,255,0.45)" }}>
                     Sync favorites, reactions, and push alerts across devices.
                   </p>
                   <button
                     type="button"
-                    className="w-full text-left py-3 px-3 rounded-lg text-sm font-semibold text-sky-400 hover:bg-white/5 min-h-[48px]"
+                    className="w-full text-left py-3 px-3 rounded-lg text-sm font-semibold text-sky-400 hover:bg-white/5 min-h-12"
                     onClick={() => {
                       setMobileOpen(false);
                       setShowAuth(true);

--- a/client/src/components/ToolPageLayout.tsx
+++ b/client/src/components/ToolPageLayout.tsx
@@ -81,7 +81,7 @@ export default function ToolPageLayout({
 
   return (
     <div
-      className={`min-h-screen pb-8 ${shellClassName}`.trim()}
+      className={`min-h-screen pb-8 has-mobile-tabbar ${shellClassName}`.trim()}
       style={{ background: "var(--hi-bg-page, #050D1A)" }}
     >
       <SiteHeader

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -3,6 +3,7 @@ import { slugify } from "../../lib/searchUtils";
 import { dispatchAskPrompt } from "../../lib/askShortcuts";
 import { isFinalsActive, finalistTeams } from "../../lib/playoffData";
 import {
+  compactPulseStats,
   deskAskChips,
   deskEyebrow,
   editionUpdatedLabel,
@@ -26,33 +27,36 @@ function PulseRow({
   indexScore,
   teamRecord,
   trend,
-}: (typeof pulseIndex)[number]) {
+  compact = false,
+}: (typeof pulseIndex)[number] & { compact?: boolean }) {
   const mark = pulseTrendMark(trend);
   return (
     <a
       href={`/player/${slugify(player)}`}
-      className="enhanced-card flex items-center gap-4 px-4 py-3 w-full min-w-0 hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
+      className="enhanced-card flex items-center gap-3 md:gap-4 px-3 py-3 md:px-4 w-full min-w-0 overflow-hidden hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
     >
-      <p className="mono-data font-bold text-xl shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+      <p className="mono-data font-bold text-lg md:text-xl shrink-0 w-7 md:w-auto" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
         {padRank(rank)}
       </p>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-sm font-semibold text-[var(--hi-text,#f3f6fa)]">{player}</span>
-          <span className="text-[11px] font-bold tracking-[0.6px]" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+      <div className="flex-1 min-w-0 overflow-hidden">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-sm font-semibold text-[var(--hi-text,#f3f6fa)] truncate">{player}</span>
+          <span className="text-[11px] font-bold tracking-[0.6px] shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
             {team}
           </span>
         </div>
         <p className="text-[11px] mt-0.5 truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-          {keyStats}
+          {compact ? compactPulseStats(keyStats) : keyStats}
         </p>
-        <p className="editorial-body text-xs leading-4 mt-0.5 line-clamp-2 text-[var(--hi-text,#f3f6fa)]">{note}</p>
+        <p className={`editorial-body text-xs leading-4 mt-0.5 text-[var(--hi-text,#f3f6fa)] ${compact ? "line-clamp-1" : "line-clamp-2"}`}>
+          {note}
+        </p>
       </div>
-      <div className="flex flex-col items-end gap-0.5 shrink-0 w-[72px] text-right">
+      <div className="flex flex-col items-end gap-0.5 shrink-0 w-14 md:w-[72px] text-right">
         <span className="text-[11px] font-bold" style={{ color: mark.color }}>
           {mark.mark}
         </span>
-        <span className="mono-data font-bold text-[22px] text-[var(--hi-text,#f3f6fa)]">{formatPulseScore(indexScore)}</span>
+        <span className="mono-data font-bold text-[22px] leading-none text-[var(--hi-text,#f3f6fa)]">{formatPulseScore(indexScore)}</span>
         <span className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
           {teamRecord}
         </span>
@@ -64,7 +68,7 @@ function PulseRow({
 export function EnhancedTicker() {
   return (
     <div
-      className="flex items-center gap-4 px-4 md:px-7 py-2 overflow-hidden"
+      className="hidden md:flex items-center gap-4 px-4 md:px-7 py-2 overflow-hidden"
       style={{ background: "var(--hi-surface-2,#121c2c)" }}
       aria-label="Edition wire"
     >
@@ -151,12 +155,12 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
           </div>
           <div className="flex flex-col gap-2 md:hidden">
             {mobilePulse.map((row) => (
-              <PulseRow key={row.rank} {...row} />
+              <PulseRow key={row.rank} {...row} compact />
             ))}
           </div>
         </div>
 
-        <aside className="w-full lg:w-[320px] shrink-0 flex flex-col gap-4 max-md:pt-2">
+        <aside className="hidden md:flex w-full lg:w-[320px] shrink-0 flex-col gap-4">
           <SectionHeader
             eyebrow="INJURY WIRE"
             title="Desk tags"
@@ -193,7 +197,7 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
               <button
                 key={chip}
                 type="button"
-                className="text-left text-[11px] font-medium px-2.5 py-2 rounded-md min-h-[36px]"
+                className="text-left text-[11px] font-medium px-2.5 py-2 rounded-md min-h-11"
                 style={{ background: "var(--hi-surface-2,#121c2c)", color: "var(--hi-text,#f3f6fa)" }}
                 onClick={() => dispatchAskPrompt(chip)}
               >

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -40,15 +40,19 @@ export function SectionHeader({
   actionHref?: string;
 }) {
   return (
-    <div className="flex items-end gap-3 w-full">
+    <div className="flex items-end gap-3 w-full min-w-0">
       <div className="flex-1 min-w-0">
         <p className="enhanced-kicker">{eyebrow}</p>
-        <h2 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[28px] leading-8 max-md:text-2xl">
+        <h2 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[28px] leading-8 max-md:text-2xl max-md:leading-7 break-words">
           {title}
         </h2>
       </div>
       {action && actionHref ? (
-        <a href={actionHref} className="text-xs font-medium shrink-0 pb-1" style={{ color: ENHANCED_ACCENT }}>
+        <a
+          href={actionHref}
+          className="text-xs font-medium shrink-0 inline-flex items-end min-h-11 pb-1"
+          style={{ color: ENHANCED_ACCENT }}
+        >
           {action}
         </a>
       ) : null}
@@ -66,14 +70,14 @@ export function StatCard({
   sub: string;
 }) {
   return (
-    <div className="enhanced-card flex flex-col gap-1.5 px-4 py-3.5 min-w-0">
+    <div className="enhanced-card flex flex-col gap-1.5 px-4 py-3.5 max-md:px-3 max-md:py-3 min-w-0 overflow-hidden">
       <p className="text-[10px] font-semibold tracking-[1.2px] uppercase" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
         {kicker}
       </p>
-      <p className="mono-data font-bold leading-9 text-[32px] max-md:text-[28px]" style={{ color: ENHANCED_ACCENT }}>
+      <p className="mono-data font-bold leading-9 text-[32px] max-md:text-[28px] max-md:leading-8 break-words" style={{ color: ENHANCED_ACCENT }}>
         {value}
       </p>
-      <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+      <p className="text-xs leading-4" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
         {sub}
       </p>
     </div>
@@ -108,7 +112,7 @@ export function EnhancedButton({
   type?: "button" | "submit";
 }) {
   const className =
-    "inline-flex items-center justify-center px-4 py-[9px] rounded-md text-[13px] font-semibold min-h-[40px] transition-opacity hover:opacity-90";
+    "inline-flex items-center justify-center px-4 py-[9px] rounded-md text-[13px] font-semibold min-h-11 transition-opacity hover:opacity-90";
   const style =
     variant === "primary"
       ? { background: ENHANCED_ACCENT, color: "#050d1a" }
@@ -144,24 +148,23 @@ export function GamePreviewCard({
   note: string;
 }) {
   return (
-    <div className="enhanced-card flex flex-col gap-2.5 px-4 py-3.5 min-w-0">
-      <div className="flex items-center gap-2">
+    <div className="enhanced-card flex flex-col gap-2.5 px-4 py-3.5 max-md:px-3.5 min-w-0 overflow-hidden">
+      <div className="flex items-center gap-2 min-w-0">
         <p className="enhanced-kicker">{status}</p>
-        <span className="flex-1" />
-        <p className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <span className="flex-1 min-w-0" />
+        <p className="text-[11px] shrink-0 text-right" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
           {when}
         </p>
       </div>
-      <div className="flex items-center gap-3">
-        <p className="mono-data font-bold text-[26px] text-[var(--hi-text,#f3f6fa)]">{away}</p>
-        <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-          @
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 min-w-0">
+        <p className="mono-data font-bold text-[22px] md:text-[26px] text-[var(--hi-text,#f3f6fa)]">
+          {away} <span className="text-sm font-normal" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>@</span> {home}
         </p>
-        <p className="mono-data font-bold text-[26px] text-[var(--hi-text,#f3f6fa)]">{home}</p>
-        <span className="flex-1" />
-        <p className="text-[11px] font-semibold tracking-[0.8px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-          {network}
-        </p>
+        {network ? (
+          <p className="text-[11px] font-semibold tracking-[0.8px] ml-auto" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+            {network}
+          </p>
+        ) : null}
       </div>
       <p className="editorial-body text-xs leading-4 text-[var(--hi-text,#f3f6fa)]">{note}</p>
     </div>

--- a/client/src/lib/enhancedDesk.ts
+++ b/client/src/lib/enhancedDesk.ts
@@ -45,6 +45,15 @@ export function formatPulseScore(score: number): string {
   return Number.isInteger(score) ? String(score) : score.toFixed(1);
 }
 
+/** Phone Pulse rows: drop unit suffixes so the stat line fits a 390px card. */
+export function compactPulseStats(keyStats: string): string {
+  return keyStats
+    .replace(/\s+(PPG|RPG|BPG|APG|SPG|FG%|3P%)\b/gi, "")
+    .replace(/\s+·\s+·/g, " · ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
 export function padRank(rank: number): string {
   return String(rank).padStart(2, "0");
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1864,7 +1864,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
+    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
       <SiteHeader editionBadge={pulseEdition.date} />
       <RivalTonightBanner />
       <EnhancedTicker />

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -325,15 +325,15 @@ export default function InjuryReport() {
   });
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
       <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none">
-        <div className="flex items-end justify-between gap-3">
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
+        <div className="flex items-end justify-between gap-3 min-w-0">
           <SectionHeader eyebrow="INJURY WIRE" title="Full report" />
           <button
             type="button"
             onClick={nextClub}
-            className="text-xs font-medium min-h-[36px] shrink-0 pb-1"
+            className="text-xs font-medium min-h-11 shrink-0 inline-flex items-end pb-1"
             style={{ color: "var(--hi-accent,#1ec8f5)" }}
           >
             {club === "all" ? "Filter · all clubs" : `Filter · ${club}`}
@@ -356,10 +356,10 @@ export default function InjuryReport() {
               <a
                 key={`${injury.player}-${injury.team}`}
                 href={`/player/${slugify(injury.player)}`}
-                className="enhanced-card flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 p-3.5"
+                className="enhanced-card flex flex-col sm:flex-row sm:items-center gap-2.5 sm:gap-4 p-3.5 min-w-0 overflow-hidden"
               >
-                <div className="w-full sm:w-[220px] shrink-0">
-                  <p className="text-[15px] font-semibold text-[var(--hi-text,#f3f6fa)]">{injury.player}</p>
+                <div className="w-full sm:w-[220px] shrink-0 min-w-0">
+                  <p className="text-[15px] font-semibold text-[var(--hi-text,#f3f6fa)] truncate">{injury.player}</p>
                   <p className="text-[11px] font-bold tracking-[0.6px]" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
                     {injury.team}
                   </p>

--- a/client/src/pages/PickEm.tsx
+++ b/client/src/pages/PickEm.tsx
@@ -511,16 +511,16 @@ function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
   const streak = pickStats.streak > 0 ? String(pickStats.streak) : "—";
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
       <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none">
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
         <SectionHeader
           eyebrow="PICK 'EM"
           title="Lock tonight’s slate"
           action="Season board →"
           actionHref="/pick-em#season-board"
         />
-        <div className="enhanced-card flex flex-col gap-2.5 p-[22px]">
+        <div className="enhanced-card flex flex-col gap-2.5 p-[22px] max-md:p-4">
           <p className="editorial-heading text-2xl text-[var(--hi-text,#f3f6fa)]">No picks yet.</p>
           <p className="editorial-body text-sm leading-5 text-[var(--hi-text,#f3f6fa)] max-w-3xl">
             Nothing on tonight’s schedule, so the board is closed. Game and bracket picks count toward the
@@ -533,7 +533,7 @@ function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
             </EnhancedButton>
           </div>
         </div>
-        <div id="season-board" className="grid grid-cols-2 xl:grid-cols-4 gap-3">
+        <div id="season-board" className="grid grid-cols-2 xl:grid-cols-4 gap-2.5 md:gap-3">
           <StatCard kicker="SEASON RECORD" value={record} sub="No settled picks yet" />
           <StatCard kicker="DESK RECORD" value="—" sub="The desk waits on October" />
           <StatCard kicker="STREAK" value={streak} sub="First lock of 2026-27" />

--- a/client/src/pages/Tonight.tsx
+++ b/client/src/pages/Tonight.tsx
@@ -14,9 +14,9 @@ export default function Tonight() {
   const slateOpen = hasTonightSlate();
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
+    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
       <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none">
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
         <SectionHeader
           eyebrow="TONIGHT'S SLATE"
           title={slateOpen ? `${gamePreviews.length} games tonight` : "No games tonight"}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -69,12 +69,29 @@ html {
   scroll-behavior: smooth;
 }
 
+html,
+body {
+  overflow-x: clip;
+  max-width: 100%;
+}
+
 body {
   font-family: "DM Sans", sans-serif;
   background: var(--hi-bg-page, #050d1a);
   color: var(--hi-shell-text, rgba(255, 255, 255, 0.85));
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Fixed phone tab bar — keep page content and empty states clear of it. */
+.has-mobile-tabbar {
+  padding-bottom: calc(5.75rem + env(safe-area-inset-bottom, 0px));
+}
+
+@media (min-width: 768px) {
+  .has-mobile-tabbar {
+    padding-bottom: 0;
+  }
 }
 
 a,
@@ -591,7 +608,7 @@ html.light .desk-section-pill[data-active="true"] {
   position: fixed;
   left: 1rem;
   right: 1rem;
-  bottom: calc(5rem + env(safe-area-inset-bottom));
+  bottom: calc(5.25rem + env(safe-area-inset-bottom));
   z-index: 55;
   display: flex;
   flex-wrap: wrap;
@@ -603,6 +620,14 @@ html.light .desk-section-pill[data-active="true"] {
   border: 1px solid rgba(14, 165, 233, 0.25);
   background: rgba(10, 22, 40, 0.96);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+@media (max-width: 767px) {
+  .pwa-install-prompt {
+    padding: 0.75rem 0.875rem;
+    gap: 0.5rem;
+    border-radius: 0.75rem;
+  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phone-first restyle of the Enhanced desk so mobile is no longer a squeezed desktop. Branches from current `main` (PR #360 merged). Data pipeline, Pulse data, and desktop layout stay as-is.

**Screens changed**
- **Desk (`/`)**: compact header (logo + date + search), stacked hero, two stat chips, Pulse rows with rank + score that fit 390px, no injury rail or Ask FAB on phones.
- **Tonight (`/tonight`)**: honest empty slate with tab-bar clearance; camp cards stack; no invented scores.
- **Injuries (`/injuries`)**: full-report cards wrap instead of overflowing; 44px filter target.
- **Pick ’Em (`/pick-em`)**: closed-board empty state stacks on a phone; sample locks stay editorial.

**Mobile chrome**
- Bottom nav Desk / Injuries / Tonight / Pick ’Em / Ask with iOS safe-area padding.
- Page content padded so the tab bar does not cover the last card.
- PWA install prompt sits above the tab bar.
- Accent `#1EC8F5`, Newsreader headlines, Geist Mono ranks/scores.

**Deploy note:** production is Vercel project **`hoops-intel` only** (`prj_uOMNFwlueYPsY5viw9Wxc3RqDn2S` → https://hoopsintel.net/). Do **not** deploy or relink `hoops-intel-1` or `hoops-intel-2`.

[Mobile Desk](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_desk.webp)
[Mobile Tonight](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_tonight.webp)
[Mobile Injuries](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_injuries.webp)
[Mobile Pick Em](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_pickem.webp)
[mobile_desk_tonight_injuries_pickem.mp4](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_desk_tonight_injuries_pickem.mp4)

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (299 tests)
- [x] Vercel Preview looks correct for UI changes
- [x] New secrets documented in `.env.example` / `README.md` if applicable (none)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c67090-ae48-4627-b405-8662b7d2c66c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

