### PR TITLE
Mobile type, image srcset, and overlap fixes

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -53,7 +53,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="apple-touch-icon" href="/assets/logo.png" />
-    <link rel="preload" as="image" href="/assets/hero-bg.webp" />
+    <link rel="preload" as="image" href="/assets/brand-diamond.svg" />
     <link rel="alternate" type="application/rss+xml" title="Hoops Intel RSS" href="/feed.xml" />
     <link rel="preconnect" href="https://site.api.espn.com" crossorigin />
     <link rel="dns-prefetch" href="https://site.api.espn.com" />

--- a/client/src/__tests__/playerAvatar.test.tsx
+++ b/client/src/__tests__/playerAvatar.test.tsx
@@ -43,7 +43,8 @@ describe("PlayerAvatar", () => {
     render(<PlayerAvatar name="LeBron James" team="LAL" />);
     const img = screen.getByAltText("LeBron James") as HTMLImageElement;
     expect(img.tagName).toBe("IMG");
-    expect(img.src).toContain("/1966.png");
+    expect(img.src).toContain("1966.png");
+    expect(img.src).toContain("combiner");
     expect(img.getAttribute("srcset")).toContain("64w");
     expect(img.getAttribute("sizes")).toBe("40px");
     expect(headshotSrcSetForName("LeBron James")).toContain("combiner");

--- a/client/src/__tests__/playerAvatar.test.tsx
+++ b/client/src/__tests__/playerAvatar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import PlayerAvatar, { normalizePlayerName, headshotUrlForName } from "../components/PlayerAvatar";
+import PlayerAvatar, { normalizePlayerName, headshotUrlForName, headshotSrcSetForName } from "../components/PlayerAvatar";
 
 vi.mock("../lib/playerHeadshotData", () => ({
   playerHeadshotIds: { "lebron james": 1966, "nikola jokic": 3112335 },
@@ -44,6 +44,9 @@ describe("PlayerAvatar", () => {
     const img = screen.getByAltText("LeBron James") as HTMLImageElement;
     expect(img.tagName).toBe("IMG");
     expect(img.src).toContain("/1966.png");
+    expect(img.getAttribute("srcset")).toContain("64w");
+    expect(img.getAttribute("sizes")).toBe("40px");
+    expect(headshotSrcSetForName("LeBron James")).toContain("combiner");
   });
 
   it("falls back to a labeled initials crest for unknown players", () => {

--- a/client/src/__tests__/teamLogo.test.tsx
+++ b/client/src/__tests__/teamLogo.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/react";
 import TeamLogo from "../components/TeamLogo";
 import {
   teamLogoUrl,
+  teamLogoSrcSet,
+  teamLogoUrlSized,
   normalizeTeam,
   getTeamColor,
   getTeamName,
@@ -45,9 +47,20 @@ describe("team identity helpers", () => {
 });
 
 describe("TeamLogo", () => {
+  it("offers combiner srcset so phones skip the 500px mark", () => {
+    const set = teamLogoSrcSet("LAL");
+    expect(set).toContain("40w");
+    expect(set).toContain("80w");
+    expect(teamLogoUrlSized("LAL", 40)).toContain("w=40");
+    expect(teamLogoUrlSized("LAL", 40)).toContain("/i/teamlogos/nba/500/lal.png");
+  });
+
   it("renders an accessible image with the full team name", () => {
     render(<TeamLogo team="LAL" />);
-    expect(screen.getByAltText("Los Angeles Lakers")).toBeInTheDocument();
+    const img = screen.getByAltText("Los Angeles Lakers") as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute("srcset")).toContain("40w");
+    expect(img.getAttribute("sizes")).toBe("24px");
   });
 
   it("falls back to a labeled crest for unknown teams", () => {

--- a/client/src/__tests__/teamLogo.test.tsx
+++ b/client/src/__tests__/teamLogo.test.tsx
@@ -59,6 +59,8 @@ describe("TeamLogo", () => {
     render(<TeamLogo team="LAL" />);
     const img = screen.getByAltText("Los Angeles Lakers") as HTMLImageElement;
     expect(img).toBeInTheDocument();
+    expect(img.getAttribute("src")).toContain("combiner");
+    expect(img.getAttribute("src")).toContain("w=48");
     expect(img.getAttribute("srcset")).toContain("40w");
     expect(img.getAttribute("sizes")).toBe("24px");
   });

--- a/client/src/components/MobileBottomNav.tsx
+++ b/client/src/components/MobileBottomNav.tsx
@@ -17,6 +17,8 @@ export default function MobileBottomNav() {
       className="mobile-bottom-nav fixed bottom-0 left-0 right-0 z-50 md:hidden border-t"
       style={{
         paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))",
+        paddingLeft: "env(safe-area-inset-left)",
+        paddingRight: "env(safe-area-inset-right)",
         background: "var(--hi-surface,#0c1522)",
         borderColor: "var(--hi-border,#1e2c40)",
       }}
@@ -30,7 +32,7 @@ export default function MobileBottomNav() {
               key={link.href}
               href={link.href}
               aria-current={active ? "page" : undefined}
-              className="mobile-bottom-nav-item relative min-h-[48px] flex flex-col items-center justify-center gap-0.5 text-[10px] tracking-wide active:scale-[0.97] transition-transform"
+              className="mobile-bottom-nav-item relative min-h-12 flex flex-col items-center justify-center gap-1 text-[11px] leading-none tracking-wide active:scale-[0.97] transition-transform"
               style={{
                 color: active ? ENHANCED_ACCENT : "var(--hi-text-secondary,#8b9bb0)",
                 fontWeight: active ? 600 : 500,

--- a/client/src/components/PlayerAvatar.tsx
+++ b/client/src/components/PlayerAvatar.tsx
@@ -23,6 +23,12 @@ export function headshotUrlForName(name: string): string | null {
   return id ? `https://a.espncdn.com/i/headshots/nba/players/full/${id}.png` : null;
 }
 
+export function headshotUrlSized(name: string, px: number): string | null {
+  const full = headshotUrlForName(name);
+  if (!full) return null;
+  return espnCombinerUrl(full.replace("https://a.espncdn.com", ""), px);
+}
+
 export function headshotSrcSetForName(name: string): string | null {
   const full = headshotUrlForName(name);
   if (!full) return null;
@@ -53,6 +59,7 @@ interface PlayerAvatarProps {
 export default function PlayerAvatar({ name, team, size = 40, className = "" }: PlayerAvatarProps) {
   const [failed, setFailed] = useState(false);
   const url = headshotUrlForName(name);
+  const src = headshotUrlSized(name, Math.min(256, Math.max(64, size * 2))) ?? url;
   const srcSet = headshotSrcSetForName(name);
 
   if (!url || failed) {
@@ -80,7 +87,7 @@ export default function PlayerAvatar({ name, team, size = 40, className = "" }: 
 
   return (
     <img
-      src={url}
+      src={src ?? undefined}
       srcSet={srcSet ?? undefined}
       sizes={`${size}px`}
       alt={name}
@@ -90,7 +97,7 @@ export default function PlayerAvatar({ name, team, size = 40, className = "" }: 
       loading="lazy"
       decoding="async"
       onError={() => setFailed(true)}
-      className={`shrink-0 rounded-full object-cover object-top max-w-full ${className}`}
+      className={`shrink-0 rounded-full object-cover object-top overflow-hidden max-w-full ${className}`}
       style={{ width: size, height: size, maxWidth: size, maxHeight: size, background: "rgba(255,255,255,0.06)" }}
     />
   );

--- a/client/src/components/PlayerAvatar.tsx
+++ b/client/src/components/PlayerAvatar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { playerHeadshotIds } from "../lib/playerHeadshotData";
-import { getTeamColor, readableTextOn } from "../lib/teamColors";
+import { espnCombinerUrl, getTeamColor, readableTextOn } from "../lib/teamColors";
 
 /**
  * Normalize a display name to a stable lookup key. MUST stay identical to the
@@ -21,6 +21,13 @@ export function normalizePlayerName(name: string): string {
 export function headshotUrlForName(name: string): string | null {
   const id = playerHeadshotIds[normalizePlayerName(name)];
   return id ? `https://a.espncdn.com/i/headshots/nba/players/full/${id}.png` : null;
+}
+
+export function headshotSrcSetForName(name: string): string | null {
+  const full = headshotUrlForName(name);
+  if (!full) return null;
+  const path = full.replace("https://a.espncdn.com", "");
+  return `${espnCombinerUrl(path, 64)} 64w, ${espnCombinerUrl(path, 128)} 128w, ${espnCombinerUrl(path, 256)} 256w, ${full} 600w`;
 }
 
 function initials(name: string): string {
@@ -46,6 +53,7 @@ interface PlayerAvatarProps {
 export default function PlayerAvatar({ name, team, size = 40, className = "" }: PlayerAvatarProps) {
   const [failed, setFailed] = useState(false);
   const url = headshotUrlForName(name);
+  const srcSet = headshotSrcSetForName(name);
 
   if (!url || failed) {
     const bg = team ? getTeamColor(team) : "#1E3A5F";
@@ -73,6 +81,8 @@ export default function PlayerAvatar({ name, team, size = 40, className = "" }: 
   return (
     <img
       src={url}
+      srcSet={srcSet ?? undefined}
+      sizes={`${size}px`}
       alt={name}
       title={name}
       width={size}
@@ -80,8 +90,8 @@ export default function PlayerAvatar({ name, team, size = 40, className = "" }: 
       loading="lazy"
       decoding="async"
       onError={() => setFailed(true)}
-      className={`shrink-0 rounded-full object-cover ${className}`}
-      style={{ width: size, height: size, background: "rgba(255,255,255,0.06)" }}
+      className={`shrink-0 rounded-full object-cover object-top max-w-full ${className}`}
+      style={{ width: size, height: size, maxWidth: size, maxHeight: size, background: "rgba(255,255,255,0.06)" }}
     />
   );
 }

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -547,6 +547,7 @@ export default function SiteHeader({
           background: "var(--hi-header-bg, rgba(5, 13, 26, 0.95))",
           borderColor: "var(--hi-border-soft, rgba(255,255,255,0.08))",
           backdropFilter: "blur(20px)",
+          paddingTop: "env(safe-area-inset-top)",
         }}
       >
         <div className="container max-md:px-4">
@@ -760,7 +761,7 @@ export default function SiteHeader({
             ref={mobilePanelRef}
             role="navigation"
             aria-label="Sections"
-            className="absolute top-14 left-0 right-0 max-h-[min(70vh,28rem)] overflow-y-auto pb-[env(safe-area-inset-bottom)] border-t border-white/10 shadow-xl"
+            className="absolute top-[calc(3.5rem+env(safe-area-inset-top))] left-0 right-0 max-h-[min(70vh,28rem)] overflow-y-auto pb-[env(safe-area-inset-bottom)] border-t border-white/10 shadow-xl"
             style={{ background: "var(--hi-mobile-sheet, #081018)" }}
           >
             <div className="container py-3 flex flex-col gap-1">

--- a/client/src/components/TeamLogo.tsx
+++ b/client/src/components/TeamLogo.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   teamLogoUrl,
+  teamLogoUrlSized,
   teamLogoSrcSet,
   getTeamColor,
   getTeamName,
@@ -24,6 +25,7 @@ export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoPr
   const [failed, setFailed] = useState(false);
   const abbr = normalizeTeam(team);
   const url = teamLogoUrl(team);
+  const src = teamLogoUrlSized(team, Math.min(160, Math.max(40, size * 2))) ?? url;
   const srcSet = teamLogoSrcSet(team);
   const name = getTeamName(team);
 
@@ -52,7 +54,7 @@ export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoPr
 
   return (
     <img
-      src={url}
+      src={src ?? undefined}
       srcSet={srcSet ?? undefined}
       sizes={`${size}px`}
       alt={name}
@@ -62,7 +64,7 @@ export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoPr
       loading="lazy"
       decoding="async"
       onError={() => setFailed(true)}
-      className={`shrink-0 object-contain max-w-full ${className}`}
+      className={`shrink-0 object-contain object-center overflow-hidden max-w-full ${className}`}
       style={{ width: size, height: size, maxWidth: size, maxHeight: size }}
     />
   );

--- a/client/src/components/TeamLogo.tsx
+++ b/client/src/components/TeamLogo.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   teamLogoUrl,
+  teamLogoSrcSet,
   getTeamColor,
   getTeamName,
   normalizeTeam,
@@ -23,6 +24,7 @@ export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoPr
   const [failed, setFailed] = useState(false);
   const abbr = normalizeTeam(team);
   const url = teamLogoUrl(team);
+  const srcSet = teamLogoSrcSet(team);
   const name = getTeamName(team);
 
   if (!url || failed) {
@@ -51,6 +53,8 @@ export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoPr
   return (
     <img
       src={url}
+      srcSet={srcSet ?? undefined}
+      sizes={`${size}px`}
       alt={name}
       title={name}
       width={size}
@@ -58,8 +62,8 @@ export default function TeamLogo({ team, size = 24, className = "" }: TeamLogoPr
       loading="lazy"
       decoding="async"
       onError={() => setFailed(true)}
-      className={`shrink-0 object-contain ${className}`}
-      style={{ width: size, height: size }}
+      className={`shrink-0 object-contain max-w-full ${className}`}
+      style={{ width: size, height: size, maxWidth: size, maxHeight: size }}
     />
   );
 }

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -33,7 +33,7 @@ function PulseRow({
   return (
     <a
       href={`/player/${slugify(player)}`}
-      className="enhanced-card grid grid-cols-[1.75rem_minmax(0,1fr)_3.5rem] items-start gap-x-3 px-3 py-3 md:px-4 w-full min-w-0 overflow-hidden hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
+      className="enhanced-card grid grid-cols-[1.75rem_minmax(0,1fr)_4rem] items-start gap-x-3 px-3 py-3 md:px-4 w-full min-w-0 overflow-hidden hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
     >
       <p className="mono-data pulse-score font-bold text-lg md:text-xl self-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
         {padRank(rank)}

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -33,31 +33,31 @@ function PulseRow({
   return (
     <a
       href={`/player/${slugify(player)}`}
-      className="enhanced-card flex items-center gap-3 md:gap-4 px-3 py-3 md:px-4 w-full min-w-0 overflow-hidden hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
+      className="enhanced-card grid grid-cols-[1.75rem_minmax(0,1fr)_3.5rem] items-start gap-x-3 px-3 py-3 md:px-4 w-full min-w-0 overflow-hidden hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
     >
-      <p className="mono-data font-bold text-lg md:text-xl shrink-0 w-7 md:w-auto" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+      <p className="mono-data pulse-score font-bold text-lg md:text-xl self-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
         {padRank(rank)}
       </p>
-      <div className="flex-1 min-w-0 overflow-hidden">
+      <div className="min-w-0 overflow-hidden">
         <div className="flex items-baseline gap-2 min-w-0">
-          <span className="text-sm font-semibold text-[var(--hi-text,#f3f6fa)] truncate">{player}</span>
-          <span className="text-[11px] font-bold tracking-[0.6px] shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+          <span className="text-base font-semibold leading-5 text-[var(--hi-text,#f3f6fa)] truncate">{player}</span>
+          <span className="text-xs font-bold tracking-[0.6px] shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
             {team}
           </span>
         </div>
-        <p className="text-[11px] mt-0.5 truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <p className="text-sm leading-5 mt-0.5 truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
           {compact ? compactPulseStats(keyStats) : keyStats}
         </p>
-        <p className={`editorial-body text-xs leading-4 mt-0.5 text-[var(--hi-text,#f3f6fa)] ${compact ? "line-clamp-1" : "line-clamp-2"}`}>
+        <p className={`editorial-body mobile-readable mt-1 text-[var(--hi-text,#f3f6fa)] ${compact ? "line-clamp-2" : "line-clamp-2"}`}>
           {note}
         </p>
       </div>
-      <div className="flex flex-col items-end gap-0.5 shrink-0 w-14 md:w-[72px] text-right">
-        <span className="text-[11px] font-bold" style={{ color: mark.color }}>
+      <div className="flex flex-col items-end gap-0.5 min-w-0 text-right">
+        <span className="text-xs font-bold leading-none" style={{ color: mark.color }}>
           {mark.mark}
         </span>
-        <span className="mono-data font-bold text-[22px] leading-none text-[var(--hi-text,#f3f6fa)]">{formatPulseScore(indexScore)}</span>
-        <span className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <span className="mono-data pulse-score font-bold text-[22px] text-[var(--hi-text,#f3f6fa)]">{formatPulseScore(indexScore)}</span>
+        <span className="text-xs leading-4" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
           {teamRecord}
         </span>
       </div>
@@ -102,10 +102,10 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
             <p className="enhanced-kicker">
               {deskEyebrow()} · {pulseEdition.date.toUpperCase()}
             </p>
-            <h1 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[30px] leading-[34px] md:text-[30px] max-md:text-2xl max-md:leading-7">
+            <h1 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[30px] leading-[34px] max-md:text-[1.5rem] max-md:leading-8">
               {narrative.headline}
             </h1>
-            <p className="text-xs max-md:text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+            <p className="text-xs md:text-xs max-md:mobile-readable max-md:text-[var(--hi-text-secondary,#8b9bb0)]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
               <span className="hidden md:inline">By Will Henderson · Hoops Intel · {editionUpdatedLabel()}</span>
               <span className="md:hidden">
                 Will Henderson · 5:03 AM PT

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -157,7 +157,7 @@ export function GamePreviewCard({
         </p>
       </div>
       <div className="flex flex-col gap-1 min-w-0">
-        <p className="mono-data pulse-score font-bold text-[22px] md:text-[26px] text-[var(--hi-text,#f3f6fa)]">
+        <p className="mono-data font-bold text-[22px] md:text-[26px] leading-7 text-[var(--hi-text,#f3f6fa)] break-words">
           {away} <span className="text-sm font-normal" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>@</span> {home}
         </p>
         {network ? (

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -40,17 +40,17 @@ export function SectionHeader({
   actionHref?: string;
 }) {
   return (
-    <div className="flex items-end gap-3 w-full min-w-0">
+    <div className="flex flex-col items-start gap-1 md:flex-row md:items-end md:gap-3 w-full min-w-0">
       <div className="flex-1 min-w-0">
         <p className="enhanced-kicker">{eyebrow}</p>
-        <h2 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[28px] leading-8 max-md:text-2xl max-md:leading-7 break-words">
+        <h2 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[28px] leading-8 max-md:text-[1.5rem] max-md:leading-8">
           {title}
         </h2>
       </div>
       {action && actionHref ? (
         <a
           href={actionHref}
-          className="text-xs font-medium shrink-0 inline-flex items-end min-h-11 pb-1"
+          className="text-sm font-medium shrink-0 inline-flex items-end min-h-11 pb-1"
           style={{ color: ENHANCED_ACCENT }}
         >
           {action}
@@ -77,7 +77,7 @@ export function StatCard({
       <p className="mono-data font-bold leading-9 text-[32px] max-md:text-[28px] max-md:leading-8 break-words" style={{ color: ENHANCED_ACCENT }}>
         {value}
       </p>
-      <p className="text-xs leading-4" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+      <p className="text-sm leading-5 max-md:mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
         {sub}
       </p>
     </div>
@@ -152,21 +152,21 @@ export function GamePreviewCard({
       <div className="flex items-center gap-2 min-w-0">
         <p className="enhanced-kicker">{status}</p>
         <span className="flex-1 min-w-0" />
-        <p className="text-[11px] shrink-0 text-right" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <p className="text-sm shrink-0 text-right leading-5" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
           {when}
         </p>
       </div>
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 min-w-0">
-        <p className="mono-data font-bold text-[22px] md:text-[26px] text-[var(--hi-text,#f3f6fa)]">
+      <div className="flex flex-col gap-1 min-w-0">
+        <p className="mono-data pulse-score font-bold text-[22px] md:text-[26px] text-[var(--hi-text,#f3f6fa)]">
           {away} <span className="text-sm font-normal" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>@</span> {home}
         </p>
         {network ? (
-          <p className="text-[11px] font-semibold tracking-[0.8px] ml-auto" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          <p className="text-sm font-semibold tracking-[0.8px] leading-5" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
             {network}
           </p>
         ) : null}
       </div>
-      <p className="editorial-body text-xs leading-4 text-[var(--hi-text,#f3f6fa)]">{note}</p>
+      <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)]">{note}</p>
     </div>
   );
 }

--- a/client/src/lib/teamColors.ts
+++ b/client/src/lib/teamColors.ts
@@ -40,6 +40,26 @@ export function teamLogoUrl(team: string): string | null {
   return slug ? `https://a.espncdn.com/i/teamlogos/nba/500/${slug}.png` : null;
 }
 
+/** ESPN combiner resize so phones do not download the 500px mark. */
+export function espnCombinerUrl(cdnPath: string, px: number): string {
+  const w = Math.max(16, Math.round(px));
+  return `https://a.espncdn.com/combiner/i?img=${cdnPath}&w=${w}&h=${w}`;
+}
+
+export function teamLogoUrlSized(team: string, px: number): string | null {
+  const slug = ESPN_LOGO_SLUGS[normalizeTeam(team)];
+  return slug ? espnCombinerUrl(`/i/teamlogos/nba/500/${slug}.png`, px) : null;
+}
+
+export function teamLogoSrcSet(team: string): string | null {
+  const full = teamLogoUrl(team);
+  if (!full) return null;
+  const s40 = teamLogoUrlSized(team, 40);
+  const s80 = teamLogoUrlSized(team, 80);
+  const s160 = teamLogoUrlSized(team, 160);
+  return `${s40} 40w, ${s80} 80w, ${s160} 160w, ${full} 500w`;
+}
+
 const TEAM_NAMES: Record<string, string> = {
   ATL: "Atlanta Hawks", BOS: "Boston Celtics", BRK: "Brooklyn Nets",
   CHA: "Charlotte Hornets", CHI: "Chicago Bulls", CLE: "Cleveland Cavaliers",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1613,7 +1613,25 @@ function StandingsSection() {
   const renderConference = (title: string, standings: any[]) => (
     <div>
       <h3 className="display-heading text-white text-lg mb-3">{title}</h3>
-      <div className="glass-card rounded-lg overflow-x-auto">
+      <div className="md:hidden enhanced-card divide-y" style={{ borderColor: "var(--hi-border,#1e2c40)" }}>
+        {sortedStandings(standings).map((team: any) => (
+          <a
+            key={`m-${team.team}`}
+            href={`/team/${team.team.toLowerCase()}`}
+            className="flex items-center gap-3 px-3 py-2.5 min-h-12 min-w-0"
+          >
+            <span className="mono-data pulse-score w-6 text-sm" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+              {team.rank}
+            </span>
+            <TeamLogo team={team.team} size={24} />
+            <span className="text-base font-semibold leading-5 truncate">{team.team}</span>
+            <span className="mono-data pulse-score ml-auto text-sm">
+              {team.wins}-{team.losses}
+            </span>
+          </a>
+        ))}
+      </div>
+      <div className="hidden md:block glass-card rounded-lg overflow-x-auto">
         <table className="w-full min-w-[620px] text-xs">
           <thead>
             <tr style={{ background: "rgba(255,255,255,0.04)" }}>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1574,6 +1574,16 @@ function RookieAndFantasySection() {
 function StandingsSection() {
   const [sortKey, setSortKey] = useState<string>("rank");
   const [sortAsc, setSortAsc] = useState(true);
+  const [desktopTable, setDesktopTable] = useState(() =>
+    typeof window.matchMedia === "function" ? window.matchMedia("(min-width: 768px)").matches : false,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const apply = () => setDesktopTable(mq.matches);
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, []);
 
   const handleSort = (key: string) => {
     if (sortKey === key) { setSortAsc(!sortAsc); }
@@ -1613,7 +1623,8 @@ function StandingsSection() {
   const renderConference = (title: string, standings: any[]) => (
     <div>
       <h3 className="display-heading text-white text-lg mb-3">{title}</h3>
-      <div className="hidden md:block glass-card rounded-lg overflow-x-auto">
+      {desktopTable ? (
+      <div className="glass-card rounded-lg overflow-x-auto">
         <table className="w-full min-w-[620px] text-xs">
           <thead>
             <tr style={{ background: "rgba(255,255,255,0.04)" }}>
@@ -1681,7 +1692,8 @@ function StandingsSection() {
           </div>
         )}
       </div>
-      <div className="md:hidden enhanced-card divide-y" style={{ borderColor: "var(--hi-border,#1e2c40)" }}>
+      ) : (
+      <div className="enhanced-card divide-y" style={{ borderColor: "var(--hi-border,#1e2c40)" }}>
         {sortedStandings(standings).map((team: any) => (
           <a
             key={`m-${team.team}`}
@@ -1699,6 +1711,7 @@ function StandingsSection() {
           </a>
         ))}
       </div>
+      )}
     </div>
   );
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1613,24 +1613,6 @@ function StandingsSection() {
   const renderConference = (title: string, standings: any[]) => (
     <div>
       <h3 className="display-heading text-white text-lg mb-3">{title}</h3>
-      <div className="md:hidden enhanced-card divide-y" style={{ borderColor: "var(--hi-border,#1e2c40)" }}>
-        {sortedStandings(standings).map((team: any) => (
-          <a
-            key={`m-${team.team}`}
-            href={`/team/${team.team.toLowerCase()}`}
-            className="flex items-center gap-3 px-3 py-2.5 min-h-12 min-w-0"
-          >
-            <span className="mono-data pulse-score w-6 text-sm" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
-              {team.rank}
-            </span>
-            <TeamLogo team={team.team} size={24} />
-            <span className="text-base font-semibold leading-5 truncate">{team.team}</span>
-            <span className="mono-data pulse-score ml-auto text-sm">
-              {team.wins}-{team.losses}
-            </span>
-          </a>
-        ))}
-      </div>
       <div className="hidden md:block glass-card rounded-lg overflow-x-auto">
         <table className="w-full min-w-[620px] text-xs">
           <thead>
@@ -1698,6 +1680,24 @@ function StandingsSection() {
             <span className="cursor-help" title="Seeds 7–10 play a mini-tournament for the final two playoff spots in each conference">7-10: <span style={{ color: "#F59E0B" }}>Play-In Tournament</span></span>
           </div>
         )}
+      </div>
+      <div className="md:hidden enhanced-card divide-y" style={{ borderColor: "var(--hi-border,#1e2c40)" }}>
+        {sortedStandings(standings).map((team: any) => (
+          <a
+            key={`m-${team.team}`}
+            href={`/team/${team.team.toLowerCase()}`}
+            className="flex items-center gap-3 px-3 py-2.5 min-h-12 min-w-0"
+          >
+            <span className="mono-data pulse-score w-6 text-sm" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+              {team.rank}
+            </span>
+            <TeamLogo team={team.team} size={24} />
+            <span className="text-base font-semibold leading-5 truncate">{team.team}</span>
+            <span className="mono-data pulse-score ml-auto text-sm">
+              {team.wins}-{team.losses}
+            </span>
+          </a>
+        ))}
       </div>
     </div>
   );

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -340,7 +340,7 @@ export default function InjuryReport() {
           </button>
         </div>
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          <p className="mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
             {shortDate} · {editionContextDeskLabel().toLowerCase()} · {tallies.dtd} day-to-day · {tallies.probable}{" "}
             probable · {tallies.out} out
           </p>
@@ -359,15 +359,15 @@ export default function InjuryReport() {
                 className="enhanced-card flex flex-col sm:flex-row sm:items-center gap-2.5 sm:gap-4 p-3.5 min-w-0 overflow-hidden"
               >
                 <div className="w-full sm:w-[220px] shrink-0 min-w-0">
-                  <p className="text-[15px] font-semibold text-[var(--hi-text,#f3f6fa)] truncate">{injury.player}</p>
-                  <p className="text-[11px] font-bold tracking-[0.6px]" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+                  <p className="text-base font-semibold leading-6 text-[var(--hi-text,#f3f6fa)] truncate">{injury.player}</p>
+                  <p className="text-sm font-bold tracking-[0.6px] leading-5" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
                     {injury.team}
                   </p>
                 </div>
                 <InjuryChip status={injury.status} />
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13px] font-medium text-[var(--hi-text,#f3f6fa)]">{injury.injury}</p>
-                  <p className="editorial-body text-xs leading-[17px] mt-1" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+                  <p className="text-base font-medium leading-6 text-[var(--hi-text,#f3f6fa)]">{injury.injury}</p>
+                  <p className="editorial-body mobile-readable mt-1" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
                     {injury.timeline}
                   </p>
                 </div>

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -364,7 +364,9 @@ export default function InjuryReport() {
                     {injury.team}
                   </p>
                 </div>
-                <InjuryChip status={injury.status} />
+                <div className="self-start">
+                  <InjuryChip status={injury.status} />
+                </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-base font-medium leading-6 text-[var(--hi-text,#f3f6fa)]">{injury.injury}</p>
                   <p className="editorial-body mobile-readable mt-1" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -328,12 +328,12 @@ export default function InjuryReport() {
     <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
       <SiteHeader />
       <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
-        <div className="flex items-end justify-between gap-3 min-w-0">
+        <div className="flex flex-col gap-1 md:flex-row md:items-end md:justify-between min-w-0">
           <SectionHeader eyebrow="INJURY WIRE" title="Full report" />
           <button
             type="button"
             onClick={nextClub}
-            className="text-xs font-medium min-h-11 shrink-0 inline-flex items-end pb-1"
+            className="text-sm font-medium min-h-11 shrink-0 inline-flex items-end pb-1 self-start"
             style={{ color: "var(--hi-accent,#1ec8f5)" }}
           >
             {club === "all" ? "Filter · all clubs" : `Filter · ${club}`}

--- a/client/src/pages/PickEm.tsx
+++ b/client/src/pages/PickEm.tsx
@@ -521,8 +521,8 @@ function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
           actionHref="/pick-em#season-board"
         />
         <div className="enhanced-card flex flex-col gap-2.5 p-[22px] max-md:p-4">
-          <p className="editorial-heading text-2xl text-[var(--hi-text,#f3f6fa)]">No picks yet.</p>
-          <p className="editorial-body text-sm leading-5 text-[var(--hi-text,#f3f6fa)] max-w-3xl">
+          <p className="editorial-heading text-2xl max-md:text-[1.5rem] max-md:leading-8 text-[var(--hi-text,#f3f6fa)]">No picks yet.</p>
+          <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)] max-w-3xl">
             Nothing on tonight’s schedule, so the board is closed. Game and bracket picks count toward the
             season board when the first tip lands. Lock picks to see how you stack up against the desk.
           </p>

--- a/client/src/pages/Tonight.tsx
+++ b/client/src/pages/Tonight.tsx
@@ -53,15 +53,15 @@ export default function Tonight() {
           </div>
         ) : (
           <div className="enhanced-card flex flex-col gap-2 p-5">
-            <p className="editorial-heading text-[22px] leading-[26px] text-[var(--hi-text,#f3f6fa)]">
+            <p className="editorial-heading text-[1.375rem] leading-8 text-[var(--hi-text,#f3f6fa)]">
               The dead period still has the floor.
             </p>
-            <p className="editorial-body text-sm leading-5 text-[var(--hi-text,#f3f6fa)]">
+            <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)]">
               Nothing on tonight’s schedule. Preseason opens October 3
               {campDays > 0 ? ` — ${campDays === 1 ? "one day" : `${campDays} days`}` : ""}. Rotation battles
               and minutes caps move to Lineups until the first tip.
             </p>
-            <p className="text-xs leading-[18px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+            <p className="mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
               Scores is not a standalone route — recaps live on the desk when games exist.
             </p>
             <div className="pt-1">
@@ -80,7 +80,7 @@ export default function Tonight() {
               action="Add to Pulse →"
               actionHref="/my-pulse"
             />
-            <p className="text-xs -mt-2" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+            <p className="mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
               Editorial camp-open watch list — not a live ESPN slate and not tonight’s scores.
             </p>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -197,11 +197,30 @@ html.light .section-label {
   font-family: "Newsreader", Georgia, "Times New Roman", serif;
   font-weight: 700;
   letter-spacing: -0.01em;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .editorial-body {
   font-family: "Newsreader", Georgia, "Times New Roman", serif;
   font-weight: 400;
+}
+
+.mobile-readable {
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.pulse-score {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  line-height: 1.15;
+}
+
+@media (max-width: 767px) {
+  .editorial-heading {
+    line-height: 1.28;
+  }
 }
 
 .enhanced-kicker {

--- a/e2e/visual-smoke.spec.ts
+++ b/e2e/visual-smoke.spec.ts
@@ -7,7 +7,7 @@ import { test, expect, type Page } from "@playwright/test";
 // <img>; when it isn't, TeamLogo's onError swaps each to a crest. Either way a
 // team mark is present and no broken <img> is left mounted.
 
-const ESPN_LOGO = /https:\/\/a\.espncdn\.com\/i\/teamlogos\/nba\/500\/[a-z]+\.png/;
+const ESPN_LOGO = /https:\/\/a\.espncdn\.com\/(?:combiner\/i\?img=\/)?i\/teamlogos\/nba\/500\/[a-z]+\.png/;
 
 function collectPageErrors(page: Page): string[] {
   const errors: string[] = [];
@@ -27,9 +27,10 @@ test("team marks resolve as a real logo or a crest — never a broken image", as
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
   // Standings render team marks regardless of season/slate. A mark is either a
-  // loaded logo <img> or its crest fallback (role=img span).
-  const marks = page.locator('img[src*="a.espncdn.com/i/teamlogos"], span[role="img"]');
-  await expect(marks.first()).toBeVisible({ timeout: 10_000 });
+  // loaded logo <img> or its crest fallback (role=img span). Mobile standings
+  // keep a compact list that is display:none on desktop — only assert visible.
+  const marks = page.locator('img[src*="teamlogos"], span[role="img"]');
+  await expect(marks.filter({ visible: true }).first()).toBeVisible({ timeout: 10_000 });
 
   // Let any failed logo images run their onError → crest swap.
   await page.waitForTimeout(800);
@@ -40,9 +41,10 @@ test("team marks resolve as a real logo or a crest — never a broken image", as
     .evaluateAll((els) => els.filter((e) => (e as HTMLImageElement).complete && (e as HTMLImageElement).naturalWidth === 0).length);
   expect(broken, "broken team-logo <img> still mounted").toBe(0);
 
-  // Any logo that did stay mounted must carry a well-formed ESPN logo URL.
+  // Any logo that did stay mounted must carry a well-formed ESPN logo URL
+  // (direct 500px mark or combiner resize).
   const srcs = await page
-    .locator('img[src*="a.espncdn.com/i/teamlogos"]')
+    .locator('img[src*="teamlogos"]')
     .evaluateAll((els) => els.map((e) => (e as HTMLImageElement).src));
   for (const src of srcs) expect(src).toMatch(ESPN_LOGO);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up on the same mobile pass as #361 (already merged). Kyle’s extra constraints: mobile-appropriate images, readable type, and no font overlap.

**Images**
- `TeamLogo` and `PlayerAvatar` ship `srcset` + `sizes` via the ESPN combiner, and `src` is a retina-sized combiner URL so phones do not fall back to the 500px mark.
- Logos/headshots stay in a fixed box (`object-contain` / `object-cover object-top`) so they do not stretch or collide with text.
- Desk standings mount **one** view: compact list on phones, full table from 768px up. Phones do not download the hidden desktop table marks.
- Removed the unused `hero-bg.webp` preload (Enhanced desk does not paint it).

**Type**
- Body copy on Desk / Tonight / Injuries / Pick ’Em is 16px with 1.45 line-height.
- Headlines wrap at ~24px instead of shrinking; Geist Mono ranks/scores stay tabular and on one line.

**Overlap**
- Pulse rows are a 3-column grid (rank | copy | score) so names cannot sit on scores.
- Section actions stack under titles on phones.
- Header uses `safe-area-inset-top`; tab bar uses left/right/bottom safe areas.
- Injury chips stay inline (`self-start`) instead of stretching into full-width bars.
- Smoke test asserts a **visible** team mark and accepts combiner URLs (hidden mobile marks were failing Playwright).

**Deploy note:** production is Vercel project **`hoops-intel` only**. Do **not** deploy `hoops-intel-1` or `hoops-intel-2`.

## Mobile proof (390×844)

No type-on-type on Desk, Tonight, Injuries, or Pick ’Em. Standings compact list included.

[Desk at 390px — headline wraps, Pulse rank/name/score do not collide, tab bar clear](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_no_overlap_desk.png)
[Tonight at 390px — empty slate and camp cards, no overflow](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_no_overlap_tonight.png)
[Injuries at 390px — chips stay inline, cards stack without collision](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_no_overlap_injuries.png)
[Pick ](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_no_overlap_pickem.png)
[Desk standings at 390px — compact list, 24px combiner logos, no 620px table overflow](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_no_overlap_standings.png)

## Checklist

- [x] `npm run build` — unit tests 300 passed locally
- [x] `npm run test:unit` passes
- [ ] Vercel Preview looks correct for UI changes
- [x] New secrets documented (none)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c67090-ae48-4627-b405-8662b7d2c66c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add responsive ESPN image srcsets and mobile layout fixes
> - `PlayerAvatar` and `TeamLogo` now build sized ESPN combiner URLs with `srcset` and `sizes`, reducing bandwidth on small screens. New helpers `headshotSrcSetForName`, `headshotUrlSized`, `teamLogoSrcSet`, and `teamLogoUrlSized` live in [PlayerAvatar.tsx](https://github.com/hondoentertainment/hoops-intel/pull/362/files#diff-a6f86c78ef77d4d8ead18798b4ddcbe97d0a93c977aeb6bf17967253f24030b1) and [teamColors.ts](https://github.com/hondoentertainment/hoops-intel/pull/362/files#diff-b4b1be0b644914edea3b1d717425732b5fbd4ed6d689a90865219f6d4f7bf8bb)
> - `MobileBottomNav` and `SiteHeader` add `env(safe-area-inset-*)` padding to respect device notches and rounded corners
> - Standings in [Home.tsx](https://github.com/hondoentertainment/hoops-intel/pull/362/files#diff-89afd9d1dc263b0fb25b7de782e8da5905de63d47c483bc69807c1449c19be01) render a compact linked card list below 768px via a `matchMedia` listener, falling back to the full table on desktop
> - Typography and layout adjustments across `EnhancedDesk`, `EnhancedUi`, `InjuryReport`, `PickEm`, and `Tonight` use new `.mobile-readable` and `.pulse-score` classes from [index.css](https://github.com/hondoentertainment/hoops-intel/pull/362/files#diff-065f34d6861b830db5472fba3f56f0815fb9777d8b481e34e6927c845810e1df)
> - Risk: the visual smoke test in [visual-smoke.spec.ts](https://github.com/hondoentertainment/hoops-intel/pull/362/files#diff-b83fd932f50f318603fe2a8e40cfa843104c30b8a696051a13ff6772e230b8b9) was relaxed to accept combiner-resized logo URLs and generic `teamlogos` locators; verify no other e2e tests assert on exact ESPN image URLs or table-only standings markup
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a95b6b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->