### PR TITLE
Unclip header menus and lift Ask above the tab bar

### DIFF
--- a/client/src/__tests__/mobileChrome.test.ts
+++ b/client/src/__tests__/mobileChrome.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("mobile chrome", () => {
+  it("does not clip header popovers on the shared 56px row", () => {
+    const header = readFileSync(join(srcDir, "components/SiteHeader.tsx"), "utf8");
+    expect(header).toMatch(/h-14 min-h-\[56px\]"/);
+    expect(header).not.toMatch(/h-14 min-h-\[56px\] overflow-hidden/);
+  });
+
+  it("keeps Ask input and page padding on the shared tab-bar clearance", () => {
+    const ask = readFileSync(join(srcDir, "pages/AskAI.tsx"), "utf8");
+    const css = readFileSync(join(srcDir, "styles/index.css"), "utf8");
+    expect(css).toContain("--hi-tabbar-clearance");
+    expect(css).toMatch(/\.has-mobile-tabbar[\s\S]{0,80}var\(--hi-tabbar-clearance\)/);
+    expect(ask).toContain("var(--hi-tabbar-clearance)");
+  });
+});

--- a/client/src/__tests__/mobileChrome.test.ts
+++ b/client/src/__tests__/mobileChrome.test.ts
@@ -17,6 +17,7 @@ describe("mobile chrome", () => {
     const css = readFileSync(join(srcDir, "styles/index.css"), "utf8");
     expect(css).toContain("--hi-tabbar-clearance");
     expect(css).toMatch(/\.has-mobile-tabbar[\s\S]{0,80}var\(--hi-tabbar-clearance\)/);
-    expect(ask).toContain("var(--hi-tabbar-clearance)");
+    expect(ask).toContain("ask-page-composer");
+    expect(css).toContain(".ask-page-composer");
   });
 });

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -551,8 +551,8 @@ export default function SiteHeader({
         }}
       >
         <div className="container max-md:px-4">
-          <div className="flex items-center justify-between gap-2 h-14 min-h-[56px] overflow-hidden">
-            <div className="flex items-center gap-1 min-w-0">
+          <div className="flex items-center justify-between gap-2 h-14 min-h-[56px]">
+            <div className="flex items-center gap-1 min-w-0 overflow-x-clip">
               <button
                 type="button"
                 className="md:hidden min-h-11 min-w-11 flex items-center justify-center rounded-lg text-white hover:bg-white/10 focus-visible:outline focus-visible:outline-sky-500"

--- a/client/src/pages/AskAI.tsx
+++ b/client/src/pages/AskAI.tsx
@@ -84,7 +84,7 @@ export default function AskAI() {
           />
         </div>
 
-        <div className="sticky bottom-0 pb-[calc(4.5rem+env(safe-area-inset-bottom))] md:pb-0" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
+        <div className="sticky bottom-0 pb-[var(--hi-tabbar-clearance)] md:pb-0" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
           <ChatInput
             input={input}
             setInput={setInput}

--- a/client/src/pages/AskAI.tsx
+++ b/client/src/pages/AskAI.tsx
@@ -20,7 +20,7 @@ export default function AskAI() {
     <ToolPageLayout
       subtitle="ASK HOOPS INTEL"
       contentOnly
-      shellClassName="flex flex-col"
+      shellClassName="flex flex-col has-mobile-tabbar"
       showBreadcrumbs={false}
       showRelated={false}
     >
@@ -84,7 +84,7 @@ export default function AskAI() {
           />
         </div>
 
-        <div className="sticky bottom-0 pb-[var(--hi-tabbar-clearance)] md:pb-0" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
+        <div className="sticky bottom-0 ask-page-composer" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
           <ChatInput
             input={input}
             setInput={setInput}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -15,6 +15,11 @@
   box-sizing: border-box;
 }
 
+html {
+  /* Matches MobileBottomNav (~86px chrome + safe area). Keep Ask, toasts, and page padding in sync. */
+  --hi-tabbar-clearance: calc(5.75rem + env(safe-area-inset-bottom, 0px));
+}
+
 html.dark {
   --hi-bg-page: #050d1a;
   --hi-shell-text: rgba(255, 255, 255, 0.85);
@@ -85,7 +90,7 @@ body {
 
 /* Fixed phone tab bar — keep page content and empty states clear of it. */
 .has-mobile-tabbar {
-  padding-bottom: calc(5.75rem + env(safe-area-inset-bottom, 0px));
+  padding-bottom: var(--hi-tabbar-clearance);
 }
 
 @media (min-width: 768px) {
@@ -274,8 +279,8 @@ html.light .glass-card {
 
 /* Floating Ask AI panel — sit above mobile tab bar */
 .ask-chat-panel {
-  bottom: calc(3.5rem + env(safe-area-inset-bottom));
-  height: min(600px, calc(85vh - 3.5rem - env(safe-area-inset-bottom)));
+  bottom: var(--hi-tabbar-clearance);
+  height: min(600px, calc(85vh - var(--hi-tabbar-clearance)));
 }
 
 @media (min-width: 768px) {
@@ -485,7 +490,7 @@ html.light .glass-card {
 .back-to-top {
   position: fixed;
   right: 1rem;
-  bottom: calc(4.75rem + env(safe-area-inset-bottom));
+  bottom: var(--hi-tabbar-clearance);
   z-index: 45;
   display: flex;
   align-items: center;
@@ -579,7 +584,7 @@ html.light .desk-section-pill[data-active="true"] {
 
 .toast-stack {
   position: fixed;
-  bottom: calc(5.5rem + env(safe-area-inset-bottom));
+  bottom: var(--hi-tabbar-clearance);
   left: 50%;
   transform: translateX(-50%);
   z-index: 120;
@@ -627,7 +632,7 @@ html.light .desk-section-pill[data-active="true"] {
   position: fixed;
   left: 1rem;
   right: 1rem;
-  bottom: calc(5.25rem + env(safe-area-inset-bottom));
+  bottom: var(--hi-tabbar-clearance);
   z-index: 55;
   display: flex;
   flex-wrap: wrap;

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -93,6 +93,16 @@ body {
   padding-bottom: var(--hi-tabbar-clearance);
 }
 
+.ask-page-composer {
+  padding-bottom: var(--hi-tabbar-clearance);
+}
+
+@media (min-width: 768px) {
+  .ask-page-composer {
+    padding-bottom: 0;
+  }
+}
+
 @media (min-width: 768px) {
   .has-mobile-tabbar {
     padding-bottom: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Codex review on #361 (already merged): two leftovers from the taller mobile tab bar / compact header.

**P1 — header popovers**
- Removed `overflow-hidden` from the shared 56px header row so the desktop `More` menu and `NotificationBell` dialog are not clipped.
- Keep `overflow-x-clip` on the brand cluster only, so the wordmark can truncate without clipping popovers.

**P2 — Ask vs tab bar**
- Shared `--hi-tabbar-clearance` (`5.75rem` + safe area) for page padding, Ask composer, floating Ask panel, back-to-top, toasts, and the PWA prompt.
- `/ask` uses `.ask-page-composer` so the sticky input sits above the ~86px tab bar (the old `4.5rem` / 72px clearance was too short).

**Deploy note:** production is Vercel project **`hoops-intel` only**. Do **not** deploy `hoops-intel-1` or `hoops-intel-2`.

## Proof

[Desktop More menu fully visible below the header](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_more_menu_unclipped.png)
[Ask input on a 390px phone sits above the tab bar](https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_ask_input_above_tabbar.png)

## Checklist

- [x] `npm run test:unit` — 302 passed
- [ ] `npm run build` — CI
- [ ] Vercel Preview looks correct for UI changes
- [x] New secrets documented (none)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c67090-ae48-4627-b405-8662b7d2c66c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unclip header menus in `SiteHeader` and lift `AskAI` above the tab bar
> - Removes `overflow-hidden` from the main row in [SiteHeader.tsx](https://github.com/hondoentertainment/hoops-intel/pull/363/files#diff-6c9e909f1a2593ba81efaaa649dda03642303b13148d47db86f2fe7d9b1917c6) and applies `overflow-x-clip` to its left container to stop menus from clipping.
> - Positions the Ask page composer above the mobile tab bar by adding `has-mobile-tabbar` and the `.ask-page-composer` class in [AskAI.tsx](https://github.com/hondoentertainment/hoops-intel/pull/363/files#diff-c0cd7808add8614d17f4125a3615a8a75ed04ad66abc03519abd4d5087b43915).
> - Introduces the `--hi-tabbar-clearance` CSS variable in [index.css](https://github.com/hondoentertainment/hoops-intel/pull/363/files#diff-065f34d6861b830db5472fba3f56f0815fb9777d8b481e34e6927c845810e1df) to replace hardcoded bottom offsets across `.has-mobile-tabbar`, `.ask-chat-panel`, `.back-to-top`, `.toast-stack`, and `.pwa-install-prompt`.
> - Adds tests in [mobileChrome.test.ts](https://github.com/hondoentertainment/hoops-intel/pull/363/files#diff-14ad90d4a6bb9063a9c9f4a8ab180c5a047f9f14e234d94311612050fbd211b3) to verify the component classes and CSS variable usage.
> - Risk: Consolidating bottom offsets into `--hi-tabbar-clearance` for `.ask-chat-panel`, `.back-to-top`, `.toast-stack`, and `.pwa-install-prompt` changes exact pixel spacing for those elements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48b86d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->