### PR TITLE
PT desk labels, history/refs sitemap lastmod, ops-readiness defaults

### DIFF
--- a/.github/workflows/ops-readiness-check.yml
+++ b/.github/workflows/ops-readiness-check.yml
@@ -31,13 +31,16 @@ jobs:
           body=$(curl -fsSL --max-time 15 "$OPS_READINESS_URL")
           missing=$(echo "$body" | node -e "
             const d = JSON.parse(require('fs').readFileSync(0,'utf8'));
-            const gaps = [];
-            if (!d.stripe?.checkoutReady) gaps.push('stripe checkout');
-            if (!d.stripe?.webhookReady) gaps.push('stripe webhook');
-            if (!d.push?.notifyAuthReady) gaps.push('push notify');
-            if (!d.supabase?.serverReady) gaps.push('supabase server');
-            if (!d.emailDigest?.resendReady) gaps.push('resend');
-            if (!d.llm?.anthropicSeriesIntelReady) gaps.push('anthropic');
+            const gaps = Array.isArray(d.gaps)
+              ? d.gaps
+              : [
+                  !d.stripe?.checkoutReady && 'stripe checkout',
+                  !d.stripe?.webhookReady && 'stripe webhook',
+                  !d.push?.notifyAuthReady && 'push notify',
+                  !d.supabase?.serverReady && 'supabase server',
+                  !d.emailDigest?.resendReady && 'resend',
+                  !d.llm?.anthropicSeriesIntelReady && 'anthropic',
+                ].filter(Boolean);
             console.log(gaps.join(', '));
           ")
           if [ -n "$missing" ]; then

--- a/PRODUCTION-OPS.md
+++ b/PRODUCTION-OPS.md
@@ -38,6 +38,8 @@ Required keys are listed in `scripts/ops-preflight.mjs`. Client-side: `VITE_*` p
 
 Verify live: https://hoopsintel.net/api/ops-readiness
 
+`APP_BASE_URL` defaults to `https://hoopsintel.net` and `PUSH_API_URL` defaults to `https://hoopsintel.net/api/push-notify` in checkout, portal, and `/api/ops-readiness`. Set them explicitly in Vercel anyway. Stripe, VAPID keys, Supabase, Resend, and Anthropic have no safe defaults — those flags stay false until secrets land.
+
 ### 3. Stripe Pro
 
 - Production webhook → `https://hoopsintel.net/api/stripe-webhook`
@@ -65,7 +67,7 @@ If none are set, the workflow runs `npm run social:preview` (dry-run) and exits 
 ### 5. Vercel hygiene
 
 - Confirm `hoopsintel.net` DNS → Vercel production project **hoops-intel**
-- Archive duplicate projects `hoops-intel-1` and `hoops-intel-2`
+- Do not recreate deleted clones `hoops-intel-1` / `hoops-intel-2`
 
 ## Ship ritual (every production deploy)
 

--- a/api/ops-readiness.ts
+++ b/api/ops-readiness.ts
@@ -2,6 +2,10 @@
 
 export const config = { runtime: "edge" };
 
+const CANONICAL_APP_BASE = "https://hoopsintel.net";
+const CANONICAL_PUSH_API = "https://hoopsintel.net/api/push-notify";
+const CANONICAL_VAPID_SUBJECT = "mailto:admin@hoopsintel.net";
+
 function configured(v: string | undefined): boolean {
   return Boolean(v && String(v).length > 0);
 }
@@ -18,6 +22,23 @@ export default async function handler(req: Request): Promise<Response> {
     configured(process.env.STRIPE_PRICE_ANNUAL);
 
   const vapidPair = configured(process.env.VAPID_PUBLIC_KEY) && configured(process.env.VAPID_PRIVATE_KEY);
+  const notifyAuthReady = configured(process.env.PUSH_API_SECRET) && vapidPair;
+  const supabaseReady = configured(process.env.SUPABASE_URL) && configured(process.env.SUPABASE_SERVICE_KEY);
+  const resendReady = configured(process.env.RESEND_API_KEY);
+  const anthropicReady = configured(process.env.ANTHROPIC_API_KEY);
+
+  // Match runtime defaults in create-checkout / create-portal-session / push-notify.
+  const appBaseConfigured = configured(process.env.APP_BASE_URL ?? CANONICAL_APP_BASE);
+  const apiUrlConfigured = configured(process.env.PUSH_API_URL ?? CANONICAL_PUSH_API);
+  const vapidSubjectConfigured = configured(process.env.VAPID_SUBJECT ?? CANONICAL_VAPID_SUBJECT);
+
+  const gaps: string[] = [];
+  if (!stripeCheckout) gaps.push("stripe checkout");
+  if (!configured(process.env.STRIPE_WEBHOOK_SECRET)) gaps.push("stripe webhook");
+  if (!notifyAuthReady) gaps.push("push notify");
+  if (!supabaseReady) gaps.push("supabase server");
+  if (!resendReady) gaps.push("resend");
+  if (!anthropicReady) gaps.push("anthropic");
 
   const body = {
     stripe: {
@@ -25,33 +46,34 @@ export default async function handler(req: Request): Promise<Response> {
       webhookReady: configured(process.env.STRIPE_WEBHOOK_SECRET),
     },
     billingUrls: {
-      appBaseConfigured: configured(process.env.APP_BASE_URL),
+      appBaseConfigured,
     },
     push: {
       vapidKeyPairReady: vapidPair,
-      vapidSubjectConfigured: configured(process.env.VAPID_SUBJECT),
-      notifyAuthReady: configured(process.env.PUSH_API_SECRET) && vapidPair,
+      vapidSubjectConfigured,
+      notifyAuthReady,
     },
     supabase: {
-      serverReady: configured(process.env.SUPABASE_URL) && configured(process.env.SUPABASE_SERVICE_KEY),
+      serverReady: supabaseReady,
     },
     creatorQueue: {
       adminConfigured: configured(process.env.GUEST_PULSE_ADMIN_SECRET),
     },
     emailDigest: {
-      resendReady: configured(process.env.RESEND_API_KEY),
-      intakeInboxReady:
-        configured(process.env.RESEND_API_KEY) && configured(process.env.CONTACT_INBOUND_EMAIL),
+      resendReady,
+      intakeInboxReady: resendReady && configured(process.env.CONTACT_INBOUND_EMAIL),
     },
     pushDispatch: {
-      apiUrlConfigured: configured(process.env.PUSH_API_URL),
+      apiUrlConfigured,
     },
     llm: {
-      anthropicSeriesIntelReady: configured(process.env.ANTHROPIC_API_KEY),
+      anthropicSeriesIntelReady: anthropicReady,
     },
+    gaps,
     hints: [
       "Client env (VITE_*) is not inspected here — set Stripe publishable + VITE_VAPID_PUBLIC_KEY in Vercel.",
       "Cron workflows need GitHub repository secrets mirrored from production.",
+      `APP_BASE_URL defaults to ${CANONICAL_APP_BASE}; PUSH_API_URL defaults to ${CANONICAL_PUSH_API}.`,
     ],
   };
 

--- a/client/src/__tests__/pacificTime.test.ts
+++ b/client/src/__tests__/pacificTime.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { editionHourLabel, editionPublishLabel, formatPacificTime } from "../lib/pacificTime";
+import { formatContentDate } from "../lib/contentDate";
+
+describe("pacificTime", () => {
+  it("labels the 13:03 UTC edition window as 5:03 AM PT in PST", () => {
+    expect(editionPublishLabel(new Date("2026-01-15T13:03:00Z"))).toBe("5:03 AM PT");
+    expect(editionHourLabel(new Date("2026-01-15T13:00:00Z"))).toBe("5 AM PT");
+  });
+
+  it("labels the 13:03 UTC edition window as 6:03 AM PT in PDT", () => {
+    expect(editionPublishLabel(new Date("2026-09-02T13:03:00Z"))).toBe("6:03 AM PT");
+    expect(editionHourLabel(new Date("2026-09-02T13:00:00Z"))).toBe("6 AM PT");
+  });
+
+  it("never emits a hardcoded PST or PDT suffix", () => {
+    expect(formatPacificTime(new Date("2026-09-02T13:03:00Z"))).toMatch(/ PT$/);
+    expect(formatPacificTime(new Date("2026-09-02T13:03:00Z"))).not.toMatch(/PST|PDT/);
+  });
+});
+
+describe("formatContentDate", () => {
+  it("pretty-prints ISO generatedDate and leaves display strings alone", () => {
+    expect(formatContentDate("2026-09-02")).toBe("September 2, 2026");
+    expect(formatContentDate("June 9, 2026")).toBe("June 9, 2026");
+  });
+});

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -18,6 +18,7 @@ import { BrandLockup } from "./enhanced/EnhancedUi";
 import { ENHANCED_ACCENT } from "../lib/enhancedDesk";
 import { pulseEdition } from "../lib/pulseData";
 import { compactEditionDate } from "../lib/enhancedDesk";
+import { editionHourLabel } from "../lib/pacificTime";
 
 export type SiteHeaderProps = {
   /** Secondary line under brand (e.g. ARCHIVE, DAILY INTELLIGENCE). */
@@ -81,7 +82,7 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
     if (result.ok) {
       setSubscribed(true);
       setShowModal(false);
-      toast("Subscribed — morning digest at 5 AM PST");
+      toast(`Subscribed — morning digest at ${editionHourLabel()}`);
     } else {
       setApiError(result.error);
     }
@@ -133,7 +134,7 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
             <div className="mb-4 space-y-2">
               <p className="text-xs font-semibold text-white">Email digest</p>
               <p className="text-xs leading-relaxed" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
-                Morning edition at 5 AM PST.
+                Morning edition at {editionHourLabel()}.
               </p>
             </div>
             <div className="mb-4 space-y-2">

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -16,6 +16,7 @@ import {
   shortInjuryLine,
   tickerWireText,
 } from "../../lib/enhancedDesk";
+import { editionPublishLabel } from "../../lib/pacificTime";
 import { EnhancedButton, InjuryChip, SectionHeader, StatCard } from "./EnhancedUi";
 
 function PulseRow({
@@ -108,7 +109,7 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
             <p className="text-xs md:text-xs max-md:mobile-readable max-md:text-[var(--hi-text-secondary,#8b9bb0)]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
               <span className="hidden md:inline">By Will Henderson · Hoops Intel · {editionUpdatedLabel()}</span>
               <span className="md:hidden">
-                Will Henderson · 5:03 AM PT
+                Will Henderson · {editionPublishLabel()}
                 {hasTonightSlate() ? "" : " · no games tonight"}
               </span>
             </p>

--- a/client/src/lib/contentDate.ts
+++ b/client/src/lib/contentDate.ts
@@ -1,0 +1,12 @@
+/** Display helper for generatedDate fields that may be ISO or a long US date. */
+export function formatContentDate(value: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+  if (!m) return value;
+  const d = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+  return d.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/client/src/lib/dataTrust.ts
+++ b/client/src/lib/dataTrust.ts
@@ -1,7 +1,8 @@
+import { editionPublishLabel } from "./pacificTime";
 import { pulseEdition } from "./pulseData";
 
-/** Morning edition publish window (matches GitHub Actions daily update). */
-export const EDITION_PUBLISH_LABEL = "5:03 AM PST";
+/** Morning edition publish window (13:00 UTC cron, labeled in America/Los_Angeles). */
+export const EDITION_PUBLISH_LABEL = editionPublishLabel();
 
 export function editionUpdatedLabel(): string {
   return `Updated ${EDITION_PUBLISH_LABEL} · ${pulseEdition.date}`;

--- a/client/src/lib/enhancedDesk.ts
+++ b/client/src/lib/enhancedDesk.ts
@@ -1,6 +1,7 @@
 import { gamePreviews, injuryUpdates, narrative, pulseEdition, pulseIndex, tickerItems, westStandings } from "./pulseData";
 import { contextualAskChips } from "./askShortcuts";
 import { activeEditionContext, editionContextDeskLabel, type EditionContext } from "./deskMode";
+import { editionPublishLabel } from "./pacificTime";
 
 export const ENHANCED_ACCENT = "#1EC8F5";
 export const CAMP_OPEN_ISO = "2026-10-03";
@@ -102,8 +103,8 @@ export function deskEyebrow(ctx: EditionContext = activeEditionContext()): strin
   return editionContextDeskLabel(ctx).toUpperCase();
 }
 
-export function editionUpdatedLabel(display = pulseEdition.date): string {
-  return `Updated 5:03 AM PT`;
+export function editionUpdatedLabel(_display = pulseEdition.date): string {
+  return `Updated ${editionPublishLabel()}`;
 }
 
 export function compactEditionDate(display = pulseEdition.date): string {

--- a/client/src/lib/pacificTime.ts
+++ b/client/src/lib/pacificTime.ts
@@ -1,0 +1,43 @@
+/** Pacific wall-clock helpers. Actions crons are fixed UTC; labels must follow DST. */
+
+export const PACIFIC_TZ = "America/Los_Angeles";
+
+/** `daily-update.yml` cron `0 13 * * *` — 5:00 AM PST / 6:00 AM PDT. */
+export const EDITION_CRON_UTC_HOUR = 13;
+export const EDITION_PUBLISH_MINUTE = 3;
+
+export function formatPacificTime(date: Date, includeMinutes = true): string {
+  const time = date.toLocaleTimeString("en-US", {
+    timeZone: PACIFIC_TZ,
+    hour: "numeric",
+    ...(includeMinutes ? { minute: "2-digit" as const } : {}),
+  });
+  return `${time} PT`;
+}
+
+/** Instant the morning edition is treated as published on `now`'s UTC calendar day. */
+export function editionPublishAt(now = new Date()): Date {
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      EDITION_CRON_UTC_HOUR,
+      EDITION_PUBLISH_MINUTE,
+      0,
+    ),
+  );
+}
+
+/** e.g. "6:03 AM PT" during PDT, "5:03 AM PT" during PST. */
+export function editionPublishLabel(now = new Date()): string {
+  return formatPacificTime(editionPublishAt(now));
+}
+
+/** e.g. "6 AM PT" during PDT — digest/edition hour without minutes. */
+export function editionHourLabel(now = new Date()): string {
+  const at = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), EDITION_CRON_UTC_HOUR, 0, 0),
+  );
+  return formatPacificTime(at, false);
+}

--- a/client/src/pages/HistoryEngine.tsx
+++ b/client/src/pages/HistoryEngine.tsx
@@ -1,6 +1,7 @@
 // Historical Context Engine — Past Meets Present
 
 import ToolPageLayout from "../components/ToolPageLayout";
+import { formatContentDate } from "../lib/contentDate";
 import { historyData } from "../lib/historyData";
 import type { HistoricalComparison, MilestoneWatch as MilestoneWatchType } from "../lib/historyData";
 
@@ -188,7 +189,7 @@ export default function HistoryEngine() {
             Past Meets Present
           </h1>
           <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {data.generatedDate} — Connecting today's performances to NBA history
+            {formatContentDate(data.generatedDate)} — Connecting today's performances to NBA history
           </p>
         </div>
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -63,6 +63,7 @@ import PickEmHomeBanner from "../components/PickEmHomeBanner";
 import { isOffseasonDesk, offseasonPrimaryCta, editionContextDeskLabel } from "../lib/deskMode";
 import { FOOTER_QUICK_LINKS } from "../lib/siteNav";
 import { liveScoresTrustLabel } from "../lib/dataTrust";
+import { editionHourLabel } from "../lib/pacificTime";
 import { lineMovementForMatchup, spreadMoved } from "../lib/lineMovement";
 import { formatLineMovementBadge } from "../lib/spreadMovement";
 import EnhancedDesk, { EnhancedTicker } from "../components/enhanced/EnhancedDesk";
@@ -1754,7 +1755,7 @@ function Footer() {
     setSubmitting(false);
     if (result.ok) {
       setSubscribed(true);
-      toast("Subscribed — morning digest at 5 AM PST");
+      toast(`Subscribed — morning digest at ${editionHourLabel()}`);
     } else {
       setApiError(result.error);
     }
@@ -1787,7 +1788,7 @@ function Footer() {
           <div>
             <div className="section-label mb-2">DAILY DIGEST</div>
             <p className="text-xs mb-3" style={{ color: "rgba(255,255,255,0.4)" }}>
-              Get the morning edition in your inbox at 5 AM PST
+              Get the morning edition in your inbox at {editionHourLabel()}
             </p>
             {subscribed ? (
               <div className="text-xs px-3 py-2 rounded" style={{ background: "rgba(16,185,129,0.1)", color: "#10B981" }}>

--- a/client/src/pages/Pro.tsx
+++ b/client/src/pages/Pro.tsx
@@ -41,7 +41,7 @@ const FEATURES = [
   },
   {
     title: "Early morning delivery",
-    body: "Edition at 6 AM PST when push/digest is configured — ahead of the public desk drop.",
+    body: "Edition at 6 AM PT when push/digest is configured — ahead of the public desk drop.",
   },
   {
     title: "Pick ’Em accountability",

--- a/client/src/pages/RefReports.tsx
+++ b/client/src/pages/RefReports.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import ToolPageLayout from "../components/ToolPageLayout";
+import { formatContentDate } from "../lib/contentDate";
 import { refData } from "../lib/refData";
 import type { RefereeProfile, TonightRefAssignment } from "../lib/refData";
 
@@ -209,7 +210,7 @@ export default function RefReports() {
             Know the Whistle
           </h1>
           <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {data.generatedDate} — Tonight's officiating crews and their tendencies
+            {formatContentDate(data.generatedDate)} — Tonight's officiating crews and their tendencies
           </p>
         </div>
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -128,13 +128,13 @@
   </url>
   <url>
     <loc>https://hoopsintel.net/history</loc>
-    <lastmod>2026-06-09</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/refs</loc>
-    <lastmod>2026-06-09</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/scripts/generate-history.mjs
+++ b/scripts/generate-history.mjs
@@ -4,11 +4,12 @@
 // Run daily after generate-edition.mjs completes
 
 import { claudeGenerate } from "./lib/claude-client.mjs";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { toDisplayDate } from "./lib/daily-dates.mjs";
+import { toDisplayDate, toISODate } from "./lib/daily-dates.mjs";
 import { writeGeneratedFile } from "./lib/write-generated-file.mjs";
+import { stampGeneratedDate } from "./lib/stamp-generated-date.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -78,7 +79,7 @@ export interface HistoryData {
   narrative: string;
 }
 
-export const historyData: HistoryData = { ... };
+export const historyData: HistoryData = { generatedDate: "${toISODate(0)}", ... };
 \`\`\`
 
 ## Instructions
@@ -91,6 +92,7 @@ export const historyData: HistoryData = { ... };
 7. Be historically accurate — use real NBA records, real seasons, real stats
 8. Update milestones and streaks based on latest game results
 9. Verdicts should be thoughtful: "On pace to surpass", "Falling short", or "Matching stride"
+10. Set generatedDate to ISO YYYY-MM-DD (${toISODate(0)})
 
 Output ONLY the complete TypeScript file. No markdown fences, no explanation. The file MUST end with \`};\` closing export const historyData.`;
 
@@ -111,6 +113,7 @@ Output ONLY the complete TypeScript file. No markdown fences, no explanation. Th
     throw new Error(`historyData.ts failed validation: ${result.reason}`);
   }
 
+  writeFileSync(outPath, stampGeneratedDate(readFileSync(outPath, "utf8"), toISODate(0)), "utf8");
   console.log(`✅ Wrote ${outPath}`);
 }
 

--- a/scripts/generate-refs.mjs
+++ b/scripts/generate-refs.mjs
@@ -4,11 +4,12 @@
 // Run daily after generate-edition.mjs completes
 
 import { claudeGenerate } from "./lib/claude-client.mjs";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import { toDisplayDate } from "./lib/daily-dates.mjs";
+import { toDisplayDate, toISODate } from "./lib/daily-dates.mjs";
 import { writeGeneratedFile } from "./lib/write-generated-file.mjs";
+import { stampGeneratedDate } from "./lib/stamp-generated-date.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -78,7 +79,7 @@ export interface RefData {
   weeklyTrend: string;
 }
 
-export const refData: RefData = { ... };
+export const refData: RefData = { generatedDate: "${toISODate(0)}", ... };
 \`\`\`
 
 ## Instructions
@@ -94,6 +95,7 @@ export const refData: RefData = { ... };
 10. Pace impact should range from -2.0 to +2.5
 11. Write a weekly trend summary noting patterns in this week's assignments
 12. Keep ref numbers accurate where possible (Tony Brothers #25, Scott Foster #48, etc.)
+13. Set generatedDate to ISO YYYY-MM-DD (${toISODate(0)})
 
 Output ONLY the complete TypeScript file. No markdown fences, no explanation. The file MUST end with \`};\` closing export const refData.`;
 
@@ -114,6 +116,7 @@ Output ONLY the complete TypeScript file. No markdown fences, no explanation. Th
     throw new Error(`Generated refData.ts failed validation: ${result.reason}`);
   }
 
+  writeFileSync(outPath, stampGeneratedDate(readFileSync(outPath, "utf8"), toISODate(0)), "utf8");
   console.log(`✅ Wrote ${outPath}`);
 }
 

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -249,6 +249,9 @@ export function lastmodForLoc(loc, ctx) {
     "/print-edition",
     "/betting-intel",
     "/compare-players",
+    // Daily-pipeline pages: lastmod follows the edition when generators freeze.
+    "/history",
+    "/refs",
   ]);
   const contentDate = contentDatesLastmod(STATIC_ROUTE_SOURCES[loc]);
   const sourceDate = sourcesLastmod(STATIC_ROUTE_SOURCES[loc]);

--- a/scripts/lib/stamp-generated-date.mjs
+++ b/scripts/lib/stamp-generated-date.mjs
@@ -7,8 +7,8 @@ export function stampGeneratedDate(fileText, iso) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
     throw new Error(`stampGeneratedDate: invalid ISO date: ${iso}`);
   }
-  if (/\bgeneratedDate:\s*"\d{4}-\d{2}-\d{2}"/.test(fileText)) {
-    return fileText.replace(/\bgeneratedDate:\s*"\d{4}-\d{2}-\d{2}"/, `generatedDate: "${iso}"`);
+  if (/\bgeneratedDate:\s*(?:"[^"]*"|'[^']*')/.test(fileText)) {
+    return fileText.replace(/\bgeneratedDate:\s*(?:"[^"]*"|'[^']*')/, `generatedDate: "${iso}"`);
   }
   return fileText.replace(
     /(export const \w[\w]*\s*(?::\s*\w[\w]*)?\s*=\s*\{)/,

--- a/scripts/tests/sitemap-lastmod.test.mjs
+++ b/scripts/tests/sitemap-lastmod.test.mjs
@@ -91,6 +91,25 @@ test("stampGeneratedDate upserts ISO generatedDate without rewriting date", () =
   assert.equal(stampGeneratedDate(stamped, "2026-08-26").includes('generatedDate: "2026-08-26"'), true);
 });
 
+test("stampGeneratedDate replaces display-string generatedDate instead of duplicating", () => {
+  const src = `export const historyData: HistoryData = {\n  generatedDate: "June 9, 2026",\n};\n`;
+  const stamped = stampGeneratedDate(src, "2026-09-02");
+  assert.equal([...stamped.matchAll(/generatedDate:/g)].length, 1);
+  assert.match(stamped, /generatedDate: "2026-09-02"/);
+  assert.doesNotMatch(stamped, /June 9, 2026/);
+});
+
+test("history and refs lastmod advance with the daily edition when content is frozen", () => {
+  const historyIso = extractExportedTimestamp(readFileSync(join(ROOT, "client/src/lib/historyData.ts"), "utf8"));
+  const refsIso = extractExportedTimestamp(readFileSync(join(ROOT, "client/src/lib/refData.ts"), "utf8"));
+  const later = (...dates) => dates.filter(Boolean).sort().at(-1);
+  const ctx = { buildDay: "2026-12-01", editionIso: "2026-09-02" };
+  assert.equal(lastmodForLoc("/history", ctx), later(historyIso, ctx.editionIso));
+  assert.equal(lastmodForLoc("/refs", ctx), later(refsIso, ctx.editionIso));
+  assert.equal(lastmodForLoc("/history", ctx), "2026-09-02");
+  assert.equal(lastmodForLoc("/refs", ctx), "2026-09-02");
+});
+
 test("Pulse Index players get higher sitemap priority; others stay default", () => {
   assert.deepEqual(playerSitemapMeta({ inPulse: true }), { priority: "0.65", changefreq: "daily" });
   assert.deepEqual(playerSitemapMeta({ inPulse: false }), { priority: "0.5", changefreq: "weekly" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Kyle: ship the remaining ops/desk updates against current `main`. Deploy only to Vercel project **hoops-intel**. Clones stay deleted. `scores-refresh` and `injury-check` stay skipped through September.

### 1. PST vs PDT on the live desk — fixed

Hypothesis (hardcoded PST label) was correct, and the Enhanced desk’s “PT” still hardcoded the PST hour.

Daily edition cron is `0 13 * * *` (13:00 UTC year-round) = 5:00 AM PST / **6:00 AM PDT**. “Updated 5:03 AM PST” was an hour off in September.

- Shared `America/Los_Angeles` helper; user-facing suffix is **PT**
- Wired desk byline, DataTrust badge, digest toast/copy, and Pro early-delivery copy
- PDT now shows `6:03 AM PT` / `6 AM PT`; PST still `5:03 AM PT` / `5 AM PT`

### 2. Sitemap lastmod on `/history` and `/refs` (#358) — actually fixed

#358 is already closed (site-review closer) but production lastmod was still `2026-06-09`. Root cause: `generatedDate: "June 9, 2026"` parses to that day, and `stampGeneratedDate` only replaced ISO strings.

- `lastmodForLoc` now ties `/history` and `/refs` to `max(contentDate, editionIso)`
- `stampGeneratedDate` replaces any `generatedDate` string (no duplicate field)
- History/refs generators stamp ISO `generatedDate` after write
- Committed `public/sitemap.xml` lastmod is `2026-09-02` for those two routes only

Leave #358 closed; comment after this lands.

### 3. Ops-readiness (#129) — cheap false-positives only

Live `/api/ops-readiness` was all-false. Closer is not broken; Stripe / VAPID keys / Supabase / Resend / Anthropic are real production gaps and **stay open**.

Cheap/safe code fixes that match existing runtime defaults:

- `APP_BASE_URL` → `https://hoopsintel.net`
- `PUSH_API_URL` → `https://hoopsintel.net/api/push-notify`
- `VAPID_SUBJECT` → `mailto:admin@hoopsintel.net` (already defaulted in `push-notify.ts`)
- API now returns `gaps[]` for the workflow closer

**Do not close #129.** Secrets still missing.

### Out of scope (as requested)

- Did not recreate `hoops-intel-1` / `hoops-intel-2`
- Did not re-enable scores-refresh or injury-check crons
- GitHub homepage still `hoops-intel.vercel.app` — no write API in this environment

## Checklist

- [x] `npm run test:unit` for new Pacific-time tests (full suite in CI)
- [x] Sitemap lastmod tests (`node --test scripts/tests/sitemap-lastmod.test.mjs`)
- [x] `npm run typecheck:api`
- [ ] CI green on this PR
- [ ] Vercel Preview / production deploy to **hoops-intel** only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c67090-ae48-4627-b405-8662b7d2c66c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c67090-ae48-4627-b405-8662b7d2c66c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace PST labels with computed PT, add ops-readiness gaps and sitemap lastmod
> - Adds `pacificTime.ts` with `America/Los_Angeles` formatting that converts the fixed 13:03 UTC edition schedule to 5:03 AM PT (PST) or 6:03 AM PT (PDT); applies it across [SiteHeader.tsx](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-6c9e909f1a2593ba81efaaa649dda03642303b13148d47db86f2fe7d9b1917c6), [EnhancedDesk.tsx](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-0ee83f87c4980e1ca40078106d29e71029551935a8c56c5d5b5a60befb22430f), [Home.tsx](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-89afd9d1dc263b0fb25b7de782e8da5905de63d47c483bc69807c1449c19be01), [Pro.tsx](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-f35378611e3d36ab6ad35cd4ad5f6da92c1de09442dfbb43278bfb86a2cacbcd), and the `dataTrust`/`enhancedDesk` label utilities
> - Adds `formatContentDate` to [contentDate.ts](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-8e70109a9a65ddccb81d5e8357886eb9e799d3bf14efe95d3949b3cffcfe6c4f) to convert ISO date strings to long US dates while passing non-ISO strings through; used in [HistoryEngine.tsx](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-b89acaeb24ce404f72916c4dcd9a588432cd6806222cd34f387509d55df788e3) and [RefReports.tsx](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-ee013be2f3534a2b2627d63bfdcecf53a8614d6049ae9d3b4906da5fdf74d7b2)
> - Extends [generate-sitemap.mjs](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-8d21738aa38c071a755376f824cbe53bfdc27028e61004c33d98cac9d7ee7a9c) `lastmodForLoc` to use the edition date for `/history` and `/refs` when content is frozen
> - Updates [api/ops-readiness.ts](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-24451fc81df6219a4d4e5a3409a19ea888dfd9c4e7130078d8716e40c874aabd) to treat undefined `APP_BASE_URL`, `PUSH_API_URL`, and `VAPID_SUBJECT` as configured with canonical defaults, and returns a `gaps` array listing unready Stripe, push, Supabase, Resend, and Anthropic capabilities
> - Risk: [stamp-generated-date.mjs](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-53a8a051fb393ad225e1048df9d2a6ad69fe3bf9c21ab851b57ab4ea5e1725c0) contains a literal `+` token before the `return` statement, making the module syntactically invalid; this prevents [generate-history.mjs](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-ab7d36610606fe04068a9629ce653bda1cb05b3101750947c8f2ac95f99eafc5) and [generate-refs.mjs](https://github.com/hondoentertainment/hoops-intel/pull/365/files#diff-3d5304cf3ea1d581274119d1a2d6f9b8b5997e25d2d926f05c570333124ce6c1) from loading the helper and failing before generation completes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fb91cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->