### PR TITLE
Tighten Projections team count after #376 Codex review

### DIFF
--- a/scripts/generate-projections.mjs
+++ b/scripts/generate-projections.mjs
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { validateOutput } from "./lib/validate-output.mjs";
+import { canonicalNbaAbbrev, isEspnSyncedTeamAbbrev } from "./lib/content-quality-constants.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -189,8 +190,16 @@ function stripFences(text) {
     .trim();
 }
 
-function countProjectedTeams(source) {
-  return (source.match(/conference:\s*"(?:east|west)"/g) || []).length;
+/** Count distinct NBA teams, not the `conference: "east" | "west"` interface. */
+export function countProjectedTeams(source) {
+  const abbrs = new Set();
+  const re = /team:\s*"([A-Z]{3})"\s*,\s*conference:\s*"(?:east|west)"/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    const abbr = match[1];
+    if (isEspnSyncedTeamAbbrev(abbr)) abbrs.add(canonicalNbaAbbrev(abbr));
+  }
+  return abbrs.size;
 }
 
 async function generateOnce(client, prompt, attempt) {
@@ -241,6 +250,9 @@ async function main() {
   const client = new Anthropic();
   const prompt = buildPrompt(weekLabel, pulseContext);
   const previous = existsSync(OUT_PATH) ? readFileSync(OUT_PATH, "utf8") : null;
+  const restorePrevious = () => {
+    if (previous !== null) writeFileSync(OUT_PATH, previous, "utf8");
+  };
 
   let lastError = null;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
@@ -249,6 +261,7 @@ async function main() {
       const result = await generateOnce(client, prompt, attempt);
       responseText = result.text;
     } catch (err) {
+      restorePrevious();
       console.error("❌ Claude API error:", err.message);
       process.exit(1);
     }
@@ -256,6 +269,7 @@ async function main() {
     try {
       writeFileSync(OUT_PATH, responseText, "utf8");
     } catch (err) {
+      restorePrevious();
       console.error("❌ Failed to write output:", err.message);
       process.exit(1);
     }
@@ -280,12 +294,14 @@ async function main() {
     }
   }
 
-  if (previous) writeFileSync(OUT_PATH, previous, "utf8");
+  restorePrevious();
   console.error(`❌ Projections generation failed after ${MAX_ATTEMPTS} attempts: ${lastError}`);
   process.exit(1);
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-projections.mjs
+++ b/scripts/generate-projections.mjs
@@ -193,11 +193,12 @@ function stripFences(text) {
 /** Count distinct NBA teams, not the `conference: "east" | "west"` interface. */
 export function countProjectedTeams(source) {
   const abbrs = new Set();
-  const re = /team:\s*"([A-Z]{3})"\s*,\s*conference:\s*"(?:east|west)"/g;
-  let match;
-  while ((match = re.exec(source)) !== null) {
-    const abbr = match[1];
-    if (isEspnSyncedTeamAbbrev(abbr)) abbrs.add(canonicalNbaAbbrev(abbr));
+  const objects = source.match(/\{[^{}]*\}/g) || [];
+  for (const obj of objects) {
+    const team = obj.match(/(?:(?<![A-Za-z])team|"team")\s*:\s*"([A-Z]{3})"/);
+    const conf = obj.match(/(?:(?<![A-Za-z])conference|"conference")\s*:\s*"(?:east|west)"/);
+    if (!team || !conf) continue;
+    if (isEspnSyncedTeamAbbrev(team[1])) abbrs.add(canonicalNbaAbbrev(team[1]));
   }
   return abbrs.size;
 }

--- a/scripts/tests/validate-output.test.mjs
+++ b/scripts/tests/validate-output.test.mjs
@@ -103,6 +103,17 @@ test("countProjectedTeams accepts 30 distinct team rows", () => {
   assert.equal(countProjectedTeams(src), 30);
 });
 
+test("countProjectedTeams is independent of property order and quoting", () => {
+  const src = `
+export const projectionsData = { teams: [
+  { conference: "east", currentWins: 50, team: "NYK" },
+  { "team": "BOS", currentWins: 48, "conference": "east" },
+  { team: "OKC", currentWins: 64, conference: "west" },
+] };
+`;
+  assert.equal(countProjectedTeams(src), 3);
+});
+
 test("committed projectionsData.ts still counts as a full 30-team slate", () => {
   const file = readFileSync(new URL("../../client/src/lib/projectionsData.ts", import.meta.url), "utf8");
   assert.equal(countProjectedTeams(file), 30);

--- a/scripts/tests/validate-output.test.mjs
+++ b/scripts/tests/validate-output.test.mjs
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { hasCompleteModuleEnding, validateOutput } from "../lib/validate-output.mjs";
+import { countProjectedTeams } from "../generate-projections.mjs";
 
 test("hasCompleteModuleEnding accepts closed object / export endings", () => {
   assert.equal(hasCompleteModuleEnding("};"), true);
@@ -66,4 +67,43 @@ test("weekly runner gives Projections the same extra timeout as Trade Simulator"
     src,
     /name:\s*"Projections"[\s\S]{0,160}timeoutMs:\s*480_000/,
   );
+});
+
+const INTERFACE_AND_RISER = `
+export interface TeamProjection {
+  team: string;
+  conference: "east" | "west";
+}
+export const projectionsData = {
+  biggestRiser: { team: "HOU", change: "+1" },
+  teams: [
+`;
+
+function teamRow(abbr, conference = "west") {
+  return `    { team: "${abbr}", conference: "${conference}", currentWins: 1 },`;
+}
+
+test("countProjectedTeams ignores the interface union, riser fields, and bogus abbrevs", () => {
+  const twentyNine = Array.from({ length: 29 }, (_, i) =>
+    teamRow(["ATL", "BOS", "BKN", "CHA", "CHI", "CLE", "DAL", "DEN", "DET", "GSW",
+      "HOU", "IND", "LAC", "LAL", "MEM", "MIA", "MIL", "MIN", "NOP", "NYK",
+      "OKC", "ORL", "PHI", "PHX", "POR", "SAC", "SAS", "TOR", "UTA"][i]),
+  ).join("\n");
+  const src = `${INTERFACE_AND_RISER}\n${twentyNine}\n${teamRow("SAN")}\n  ],\n};\n`;
+  assert.equal(countProjectedTeams(src), 29);
+});
+
+test("countProjectedTeams accepts 30 distinct team rows", () => {
+  const thirty = ["ATL", "BOS", "BKN", "CHA", "CHI", "CLE", "DAL", "DEN", "DET", "GSW",
+    "HOU", "IND", "LAC", "LAL", "MEM", "MIA", "MIL", "MIN", "NOP", "NYK",
+    "OKC", "ORL", "PHI", "PHX", "POR", "SAC", "SAS", "TOR", "UTA", "WAS"]
+    .map((abbr, i) => teamRow(abbr, i < 15 ? "east" : "west"))
+    .join("\n");
+  const src = `${INTERFACE_AND_RISER}\n${thirty}\n  ],\n};\n`;
+  assert.equal(countProjectedTeams(src), 30);
+});
+
+test("committed projectionsData.ts still counts as a full 30-team slate", () => {
+  const file = readFileSync(new URL("../../client/src/lib/projectionsData.ts", import.meta.url), "utf8");
+  assert.equal(countProjectedTeams(file), 30);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #376. That PR merged at `9bff985` before the Codex review commit landed, so these hardenings never reached `main`.

**P1 (from #376 review):** `countProjectedTeams` treated the interface line `conference: "east" | "west"` as a team. It now counts distinct canonical NBA teams from objects that have both a `team` abbrev and an east/west `conference` field.

**P2 (from #376 review):** Restore the previous file if a retry `generateOnce` throws after a bad first write.

**P2 (this PR):** Counting is order-independent — conference-first, intervening properties, and quoted keys all count. A complete 30-team module in a different serialization is no longer rejected as incomplete.

Tests in `scripts/tests/validate-output.test.mjs` cover the 29-vs-30 case and mixed property order.

## Checklist

- [x] Targeted `node --test scripts/tests/validate-output.test.mjs` (10/10)
- [x] No UI / secrets changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e43d7f68-7fa9-4d6a-a06e-c3f49ac93374?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e43d7f68-7fa9-4d6a-a06e-c3f49ac93374&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

