### PR TITLE
Camp Desk UI polish — Figma AI Pass Sep 2026

### DIFF
--- a/client/src/__tests__/campDesk.test.ts
+++ b/client/src/__tests__/campDesk.test.ts
@@ -6,6 +6,7 @@ import {
   campIntelCards,
   campRosterBattles,
   campScheduleStatus,
+  campShortDate,
   campStorylines,
   campUnresolved,
   isCampDesk,
@@ -45,6 +46,8 @@ describe("campDesk", () => {
     expect(status.headline).toMatch(/camp-week/i);
     expect(status.sub).toMatch(/not tonight/i);
     expect(status.games[0]).toMatchObject({ away: "MIA", home: "TOR" });
+    expect(status.games.length).toBeGreaterThanOrEqual(3);
+    expect(campShortDate("2026-10-03")).toBe("Oct 3");
     expect(campScheduleMeta.label).toMatch(/not tonight/i);
     expect(campScheduleGames.some((g) => g.away === "NYK" && g.home === "BOS" && g.dateIso === "2026-10-03")).toBe(
       false,
@@ -63,7 +66,19 @@ describe("Tonight empty slate", () => {
     const tonight = readFileSync(join(srcDir, "pages/Tonight.tsx"), "utf8");
     expect(tonight).not.toContain("CAMP_OPENER");
     expect(tonight).toContain("Open camp intel");
-    expect(tonight).toContain("No games tonight");
+    expect(tonight).toContain("Waiting on Oct 3");
+    expect(tonight).toContain("never invent tip-offs");
     expect(tonight).not.toMatch(/away:\s*"NYK"[\s\S]*home:\s*"BOS"/);
+  });
+});
+
+describe("Camp Desk Figma pass", () => {
+  it("labels the ESPN slate not-tonight and keeps Tonight empty honest", () => {
+    const desk = readFileSync(join(srcDir, "components/enhanced/EnhancedDesk.tsx"), "utf8");
+    expect(desk).toContain("NOT TONIGHT");
+    expect(desk).toContain("EMPTY · HONEST");
+    expect(desk).toContain("No invented tip-offs");
+    expect(desk).toContain("Pulse of the camp");
+    expect(desk).not.toContain("CAMP_OPENER");
   });
 });

--- a/client/src/__tests__/enhancedDesk.test.ts
+++ b/client/src/__tests__/enhancedDesk.test.ts
@@ -5,12 +5,15 @@ import {
   deskAskChips,
   formatPulseScore,
   hasTonightSlate,
+  headerDateLabel,
   heroStats,
   injuryChipTone,
   injuryCounts,
+  lastNameOf,
   mobileHeroStats,
   padRank,
   pulseTrendMark,
+  seasonChipLabel,
   shortInjuryLine,
 } from "../lib/enhancedDesk";
 import { gamePreviews, pulseIndex } from "../lib/pulseData";
@@ -27,7 +30,9 @@ describe("enhancedDesk", () => {
   it("derives hero stats from live edition data, not invented scores", () => {
     const cards = heroStats();
     expect(cards[0]?.kicker).toBe("PULSE LEADER");
-    expect(cards[0]?.value).toBe(formatPulseScore(pulseIndex[0]!.indexScore));
+    expect(cards[0]?.value).toBe(lastNameOf(pulseIndex[0]!.player));
+    expect(cards[0]?.sub).toContain(formatPulseScore(pulseIndex[0]!.indexScore));
+    expect(cards.some((c) => c.kicker === "CAMP OPENS")).toBe(true);
     expect(cards.some((c) => c.kicker === "WEST NO. 1")).toBe(false);
     expect(cards.some((c) => c.kicker === "UNRESOLVED")).toBe(true);
     expect(hasTonightSlate()).toBe(gamePreviews.length > 0);
@@ -37,7 +42,7 @@ describe("enhancedDesk", () => {
     const counts = injuryCounts();
     expect(counts.all).toBeGreaterThan(0);
     expect(counts.dtd + counts.probable + counts.out + counts.questionable).toBe(counts.all);
-    expect(injuryChipTone("Day-to-Day")).toBe("danger");
+    expect(injuryChipTone("Day-to-Day")).toBe("warn");
     expect(injuryChipTone("Probable")).toBe("success");
     expect(shortInjuryLine("Right knee soreness (chronic management)")).toMatch(/knee/i);
   });
@@ -55,7 +60,9 @@ describe("enhancedDesk", () => {
 
   it("uses closed-slate Ask chips when there are no games", () => {
     const chips = deskAskChips();
-    expect(chips).toContain("Which rotation battles matter before camp?");
+    expect(chips).toContain("Who leads Camp Pulse?");
     expect(daysUntilIso("2026-10-03", new Date("2026-09-01T12:00:00"))).toBe(32);
+    expect(seasonChipLabel("preseason")).toBe("PRESEASON");
+    expect(headerDateLabel("September 9, 2026")).toBe("Sep 9, 2026");
   });
 });

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -14,8 +14,8 @@ import {
   readRecentSearches,
   POPULAR_SEARCH_DESTINATIONS,
 } from "../lib/searchHistory";
-import { BrandLockup } from "./enhanced/EnhancedUi";
-import { ENHANCED_ACCENT } from "../lib/enhancedDesk";
+import { BrandLockup, SeasonChip } from "./enhanced/EnhancedUi";
+import { ENHANCED_ACCENT, headerDateLabel, seasonChipLabel } from "../lib/enhancedDesk";
 import { pulseEdition } from "../lib/pulseData";
 import { compactEditionDate } from "../lib/enhancedDesk";
 import { editionHourLabel } from "../lib/pacificTime";
@@ -496,6 +496,7 @@ export default function SiteHeader({
   const { theme, toggleTheme } = useTheme();
   const { toast } = useToast();
   const [locationPath] = useLocation();
+  const seasonChip = seasonChipLabel();
   const mobilePanelRef = useRef<HTMLDivElement>(null);
   useBodyScrollLock(mobileOpen);
   useFocusTrap(mobileOpen, mobilePanelRef);
@@ -628,12 +629,21 @@ export default function SiteHeader({
             </nav>
 
             <div className="flex items-center gap-0.5 sm:gap-2 shrink-0">
+              {seasonChip ? <SeasonChip>{seasonChip}</SeasonChip> : null}
               <span
-                className="mono-data text-[11px] md:hidden px-1"
-                style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}
+                className="hidden md:inline text-[11px] font-medium whitespace-nowrap"
+                style={{ color: "var(--hi-text-secondary,#8594a8)" }}
               >
-                {compactEditionDate(editionBadge ?? pulseEdition.date)}
+                {headerDateLabel(editionBadge ?? pulseEdition.date)}
               </span>
+              {!seasonChip ? (
+                <span
+                  className="mono-data text-[11px] md:hidden px-1"
+                  style={{ color: "var(--hi-text-secondary,#8594a8)" }}
+                >
+                  {compactEditionDate(editionBadge ?? pulseEdition.date)}
+                </span>
+              ) : null}
               {toolbarExtra}
               <button
                 type="button"
@@ -737,10 +747,10 @@ export default function SiteHeader({
                 </button>
               )}
 
-              {editionBadge ? (
+              {editionBadge && !seasonChip ? (
                 <div
                   className="hidden sm:block px-2 sm:px-3 py-1 rounded text-[10px] sm:text-xs font-medium whitespace-nowrap"
-                  style={{ background: "rgba(14,165,233,0.15)", color: "#0EA5E9", border: "1px solid rgba(14,165,233,0.3)" }}
+                  style={{ background: "rgba(30,200,245,0.14)", color: ENHANCED_ACCENT, border: "1px solid rgba(30,200,245,0.28)" }}
                 >
                   {editionBadge}
                 </div>

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -747,14 +747,6 @@ export default function SiteHeader({
                 </button>
               )}
 
-              {editionBadge && !seasonChip ? (
-                <div
-                  className="hidden sm:block px-2 sm:px-3 py-1 rounded text-[10px] sm:text-xs font-medium whitespace-nowrap"
-                  style={{ background: "rgba(30,200,245,0.14)", color: ENHANCED_ACCENT, border: "1px solid rgba(30,200,245,0.28)" }}
-                >
-                  {editionBadge}
-                </div>
-              ) : null}
             </div>
           </div>
         </div>

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -5,6 +5,7 @@ import { isFinalsActive, finalistTeams } from "../../lib/playoffData";
 import {
   campIntelCards,
   campScheduleStatus,
+  campShortDate,
   isCampDesk,
   type CampCard,
   type CampScheduleRow,
@@ -13,8 +14,8 @@ import {
   compactPulseStats,
   deskAskChips,
   deskEyebrow,
-  editionUpdatedLabel,
   formatPulseScore,
+  formatPulseTenths,
   hasTonightSlate,
   heroStats,
   mobileHeroStats,
@@ -24,7 +25,15 @@ import {
   tickerWireText,
 } from "../../lib/enhancedDesk";
 import { editionPublishLabel } from "../../lib/pacificTime";
-import { EnhancedButton, InjuryChip, SectionHeader, StatCard } from "./EnhancedUi";
+import {
+  DeskInset,
+  DeskPanel,
+  EnhancedButton,
+  InjuryChip,
+  SectionHeader,
+  StatCard,
+  StatusPill,
+} from "./EnhancedUi";
 
 function PulseRow({
   rank,
@@ -48,24 +57,22 @@ function PulseRow({
       </p>
       <div className="min-w-0 overflow-hidden">
         <div className="flex items-baseline gap-2 min-w-0">
-          <span className="text-base font-semibold leading-5 text-[var(--hi-text,#f3f6fa)] truncate">{player}</span>
+          <span className="text-base font-semibold leading-5 text-[var(--hi-text,#f2f5fa)] truncate">{player}</span>
           <span className="text-xs font-bold tracking-[0.6px] shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
             {team}
           </span>
         </div>
-        <p className="text-sm leading-5 mt-0.5 truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <p className="text-sm leading-5 mt-0.5 truncate" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
           {compact ? compactPulseStats(keyStats) : keyStats}
         </p>
-        <p className={`editorial-body mobile-readable mt-1 text-[var(--hi-text,#f3f6fa)] ${compact ? "line-clamp-2" : "line-clamp-2"}`}>
-          {note}
-        </p>
+        <p className="editorial-body mobile-readable mt-1 text-[var(--hi-text,#f2f5fa)] line-clamp-2">{note}</p>
       </div>
       <div className="flex flex-col items-end gap-0.5 min-w-0 text-right">
         <span className="text-xs font-bold leading-none" style={{ color: mark.color }}>
           {mark.mark}
         </span>
-        <span className="mono-data pulse-score font-bold text-[22px] text-[var(--hi-text,#f3f6fa)]">{formatPulseScore(indexScore)}</span>
-        <span className="text-xs leading-4" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <span className="mono-data pulse-score font-bold text-[22px] text-[var(--hi-text,#f2f5fa)]">{formatPulseScore(indexScore)}</span>
+        <span className="text-xs leading-4" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
           {teamRecord}
         </span>
       </div>
@@ -73,42 +80,56 @@ function PulseRow({
   );
 }
 
-function CampIntelCard({ card }: { card: CampCard }) {
+function CompactPulseRow({
+  rank,
+  player,
+  team,
+  indexScore,
+}: Pick<(typeof pulseIndex)[number], "rank" | "player" | "team" | "indexScore">) {
   return (
     <a
-      href={card.href}
-      className="enhanced-card flex flex-col gap-1.5 p-3.5 max-md:p-3 min-w-0 overflow-hidden hover:border-[var(--hi-accent,#1ec8f5)]/40 transition-colors"
+      href={`/player/${slugify(player)}`}
+      className="desk-inset flex items-center gap-3 px-3 py-2.5 min-h-11 min-w-0 overflow-hidden"
     >
-      <div className="flex items-center gap-2 min-w-0">
-        <p className="enhanced-kicker truncate">{card.kicker}</p>
-        {card.team ? (
-          <span className="text-[11px] font-bold shrink-0" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
-            {card.team}
-          </span>
-        ) : null}
-      </div>
-      <p className="text-sm font-semibold leading-5 text-[var(--hi-text,#f3f6fa)] line-clamp-2">{card.title}</p>
-      <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)] line-clamp-3">{card.body}</p>
+      <span className="mono-data text-xs font-bold shrink-0 w-4" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+        {rank}
+      </span>
+      <span className="flex-1 min-w-0 text-[13px] font-medium text-[var(--hi-text,#f2f5fa)] truncate">{player}</span>
+      <span className="text-[11px] font-medium shrink-0" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+        {team}
+      </span>
+      <span className="mono-data text-sm font-bold shrink-0 pulse-score" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+        {formatPulseTenths(indexScore)}
+      </span>
     </a>
   );
 }
 
-function CampScheduleRow({ game, label }: { game: CampScheduleRow; label: string }) {
+function CampIntelRow({ card }: { card: CampCard }) {
+  const kicker = card.team ? `${card.kicker} · ${card.team}` : card.kicker;
   return (
-    <div className="enhanced-card flex flex-col gap-1 px-3.5 py-3 min-w-0 overflow-hidden">
-      <p className="enhanced-kicker">{label}</p>
-      <p className="mono-data font-bold text-[20px] leading-6 text-[var(--hi-text,#f3f6fa)] break-words">
-        {game.away}{" "}
-        <span className="text-sm font-normal" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-          @
-        </span>{" "}
-        {game.home}
+    <DeskInset href={card.href} className="flex flex-col gap-1 p-3">
+      <p className="text-[10px] font-semibold tracking-[0.8px] uppercase" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+        {kicker}
       </p>
-      <p className="text-sm leading-5 truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-        {game.when}
-        {game.tv ? ` · ${game.tv}` : ""}
+      <p className="text-sm font-semibold leading-[17px] text-[var(--hi-text,#f2f5fa)] line-clamp-2">{card.title}</p>
+      <p className="text-xs leading-[18px] line-clamp-2" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+        {card.body}
       </p>
-    </div>
+    </DeskInset>
+  );
+}
+
+function CampSlateCard({ game }: { game: CampScheduleRow }) {
+  const dateLabel = game.dateIso ? campShortDate(game.dateIso) : game.when.split(" ")[0] ?? game.when;
+  return (
+    <DeskInset className="flex flex-col gap-1.5 p-2.5 w-[152px] shrink-0">
+      <p className="text-[11px] font-semibold text-[var(--hi-text,#f2f5fa)]">{dateLabel}</p>
+      <p className="text-[11px] truncate" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+        {game.away} @ {game.home}
+      </p>
+      <StatusPill tone="warn">NOT TONIGHT</StatusPill>
+    </DeskInset>
   );
 }
 
@@ -116,11 +137,11 @@ export function EnhancedTicker() {
   return (
     <div
       className="hidden md:flex items-center gap-4 px-4 md:px-7 py-2 overflow-hidden"
-      style={{ background: "var(--hi-surface-2,#121c2c)" }}
+      style={{ background: "var(--hi-surface-2,#12171f)" }}
       aria-label="Edition wire"
     >
       <p className="enhanced-kicker shrink-0">{deskEyebrow()}</p>
-      <p className="text-xs truncate" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+      <p className="text-xs truncate" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
         {tickerWireText()}
       </p>
     </div>
@@ -144,175 +165,183 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
   const intel = campIntelCards(3);
   const mobileIntel = intel.slice(0, 2);
   const schedule = campScheduleStatus();
-  const scheduleLabel = schedule.kind === "tonight" ? "TONIGHT" : "ESPN · NOT TONIGHT";
 
   return (
-    <div className="px-4 md:px-7 py-4 md:py-5">
-      <div className="flex flex-col lg:flex-row gap-6 items-start">
-        <div className="flex-1 min-w-0 flex flex-col gap-3.5">
-          <div id="today-desk" className="flex flex-col gap-2">
-            <p className="enhanced-kicker">
-              {deskEyebrow()} · {pulseEdition.date.toUpperCase()}
-            </p>
-            <h1 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[30px] leading-[34px] max-md:text-[1.5rem] max-md:leading-8">
-              {narrative.headline}
-            </h1>
-            <p className="text-xs md:text-xs max-md:mobile-readable max-md:text-[var(--hi-text-secondary,#8b9bb0)]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-              <span className="hidden md:inline">By Will Henderson · Hoops Intel · {editionUpdatedLabel()}</span>
-              <span className="md:hidden">
-                Will Henderson · {editionPublishLabel()}
-                {hasTonightSlate() ? "" : " · no games tonight"}
-              </span>
-            </p>
+    <div className="px-4 md:px-7 py-6 md:py-6">
+      <div className="flex flex-col gap-[22px]">
+        <div id="today-desk" className="flex flex-col gap-2.5 max-w-[980px] min-w-0">
+          <p className="enhanced-kicker">
+            {deskEyebrow()} · {pulseEdition.date.toUpperCase()}
+          </p>
+          <h1 className="hidden md:block editorial-heading text-[var(--hi-text,#f2f5fa)] text-[26px] leading-[34px]">
+            {narrative.headline}
+          </h1>
+          <h1 className="md:hidden editorial-heading text-[var(--hi-text,#f2f5fa)] text-[1.5rem] leading-8">
+            {campMode ? pulseEdition.date : narrative.headline}
+          </h1>
+          <p className="text-xs max-md:mobile-readable" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            <span className="hidden md:inline">Will Henderson · updated {editionPublishLabel()}</span>
+            <span className="md:hidden">
+              {campMode
+                ? `Camp opens Oct 3. Tonight stays empty.`
+                : `Will Henderson · ${editionPublishLabel()}${hasTonightSlate() ? "" : " · no games tonight"}`}
+            </span>
+          </p>
+          {!campMode ? (
             <div className="flex flex-wrap gap-2 items-center">
-              <EnhancedButton href={campMode ? "#camp-intel" : "#pulse-index"}>
-                {campMode ? "Camp intel" : "Read the brief"}
-              </EnhancedButton>
+              <EnhancedButton href="#pulse-index">Read the brief</EnhancedButton>
               <EnhancedButton href="/my-pulse" variant="ghost">
                 {showMyPulse ? "My Pulse" : "Set My Pulse"}
               </EnhancedButton>
             </div>
-          </div>
-
-          <div className="hidden md:grid grid-cols-2 xl:grid-cols-4 gap-2.5">
-            {desktopStats.map((card) => (
-              <StatCard key={card.kicker} {...card} />
-            ))}
-          </div>
-          <div className="grid grid-cols-2 gap-2 md:hidden">
-            {mobileStats.map((card) => (
-              <StatCard key={card.kicker} {...card} />
-            ))}
-          </div>
-
-          {campMode ? (
-            <div id="camp-intel" className="flex flex-col gap-2">
-              <SectionHeader
-                eyebrow="CAMP INTEL"
-                title="Before the slate"
-                action="Lineups →"
-                actionHref="/lineups"
-              />
-              <p className="mobile-readable hidden md:block" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-                Roster battles, unresolved extensions, and Pulse of the camp — grounded in this edition, not invented games.
-              </p>
-              <div className="hidden md:grid grid-cols-1 md:grid-cols-3 gap-2.5">
-                {intel.map((card) => (
-                  <CampIntelCard key={`${card.kicker}-${card.title}`} card={card} />
-                ))}
-              </div>
-              <div className="grid grid-cols-1 gap-2 md:hidden">
-                {mobileIntel.map((card) => (
-                  <CampIntelCard key={`${card.kicker}-${card.title}`} card={card} />
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          <div id="pulse-index" className="hidden md:block">
-            <SectionHeader
-              eyebrow={campMode ? "CAMP PULSE" : "HOMEPAGE MODULE"}
-              title={campMode ? "Pulse of the camp" : "Pulse Index"}
-              action="How Pulse works →"
-              actionHref="/pulse-methodology"
-            />
-          </div>
-          <div className="md:hidden">
-            <SectionHeader
-              eyebrow="PULSE INDEX"
-              title={campMode ? "Camp Pulse" : "Today's board"}
-              action="Full →"
-              actionHref="/pulse-history"
-            />
-          </div>
-
-          <div className="hidden md:flex flex-col gap-2">
-            {desktopPulse.map((row) => (
-              <PulseRow key={row.rank} {...row} />
-            ))}
-          </div>
-          <div className="flex flex-col gap-2 md:hidden">
-            {mobilePulse.map((row) => (
-              <PulseRow key={row.rank} {...row} compact />
-            ))}
-          </div>
-
-          {campMode && schedule.kind !== "empty" ? (
-            <div id="camp-schedule" className="flex flex-col gap-2">
-              <SectionHeader
-                eyebrow="SCHEDULE"
-                title={schedule.headline}
-                action="Tonight →"
-                actionHref="/tonight"
-              />
-              <p className="mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-                {schedule.sub}
-              </p>
-              <div className="hidden md:grid grid-cols-1 md:grid-cols-3 gap-2.5">
-                {schedule.games.map((game) => (
-                  <CampScheduleRow key={`${game.away}-${game.home}-${game.when}`} game={game} label={scheduleLabel} />
-                ))}
-              </div>
-              <div className="grid grid-cols-1 gap-2 md:hidden">
-                {schedule.games.slice(0, 2).map((game) => (
-                  <CampScheduleRow key={`${game.away}-${game.home}-${game.when}`} game={game} label={scheduleLabel} />
-                ))}
-              </div>
-            </div>
           ) : null}
         </div>
 
-        <aside id="injuries" className="hidden md:flex w-full lg:w-[320px] shrink-0 flex-col gap-4">
-          <SectionHeader
-            eyebrow={campMode ? "CAMP WATCH" : "INJURY WIRE"}
-            title={campMode ? "Last known" : "Desk tags"}
-            action="Full report →"
-            actionHref="/injuries"
-          />
-          {campMode ? (
-            <p className="text-xs leading-5" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-              Editorial tags from today’s edition. The live injury cron stays dark through September.
-            </p>
-          ) : null}
-          <div className="flex flex-col gap-2">
-            {railInjuries.map((injury) => (
-              <a
-                key={injury.player}
-                href={`/player/${slugify(injury.player)}`}
-                className="enhanced-card flex flex-col gap-1 p-2.5"
-              >
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-xs font-semibold text-[var(--hi-text,#f3f6fa)]">{injury.player}</span>
-                  <span className="text-[11px] font-bold" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
-                    {injury.team}
-                  </span>
-                  <InjuryChip status={injury.status} />
+        <div className="hidden md:grid grid-cols-3 gap-3 max-w-[936px]">
+          {desktopStats.slice(0, 3).map((card) => (
+            <StatCard key={card.kicker} {...card} />
+          ))}
+        </div>
+        <div className="grid grid-cols-2 gap-2 md:hidden">
+          {mobileStats.map((card) => (
+            <StatCard key={card.kicker} {...card} />
+          ))}
+        </div>
+
+        <div className="flex flex-col lg:flex-row gap-5 items-start">
+          <div className="flex-1 min-w-0 flex flex-col gap-4">
+            {campMode ? (
+              <DeskPanel id="camp-intel" kicker="Before the slate" hint="Camp intel · storylines before tip-offs return">
+                <div className="hidden md:flex flex-col gap-3">
+                  {intel.map((card) => (
+                    <CampIntelRow key={`${card.kicker}-${card.title}`} card={card} />
+                  ))}
                 </div>
-                <p className="text-[11px]" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-                  {shortInjuryLine(injury.injury)}
-                </p>
-              </a>
-            ))}
+                <div className="flex flex-col gap-2 md:hidden">
+                  {mobileIntel.map((card) => (
+                    <CampIntelRow key={`${card.kicker}-${card.title}`} card={card} />
+                  ))}
+                </div>
+              </DeskPanel>
+            ) : null}
+
+            {campMode ? (
+              <DeskPanel id="pulse-index" kicker="Pulse of the camp">
+                <div className="hidden md:flex flex-col gap-3">
+                  {desktopPulse.map((row) => (
+                    <CompactPulseRow key={row.rank} rank={row.rank} player={row.player} team={row.team} indexScore={row.indexScore} />
+                  ))}
+                </div>
+                <div className="flex flex-col gap-2 md:hidden">
+                  {mobilePulse.map((row) => (
+                    <CompactPulseRow key={row.rank} rank={row.rank} player={row.player} team={row.team} indexScore={row.indexScore} />
+                  ))}
+                </div>
+              </DeskPanel>
+            ) : (
+              <>
+                <div id="pulse-index" className="hidden md:block">
+                  <SectionHeader eyebrow="HOMEPAGE MODULE" title="Pulse Index" action="How Pulse works →" actionHref="/pulse-methodology" />
+                </div>
+                <div className="md:hidden">
+                  <SectionHeader eyebrow="PULSE INDEX" title="Today's board" action="Full →" actionHref="/pulse-history" />
+                </div>
+                <div className="hidden md:flex flex-col gap-2">
+                  {desktopPulse.map((row) => (
+                    <PulseRow key={row.rank} {...row} />
+                  ))}
+                </div>
+                <div className="flex flex-col gap-2 md:hidden">
+                  {mobilePulse.map((row) => (
+                    <PulseRow key={row.rank} {...row} compact />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {campMode && schedule.kind !== "empty" ? (
+              <DeskPanel id="camp-schedule" kicker="ESPN camp-week slate" hint={schedule.sub} className="hidden md:flex">
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {schedule.games.map((game) => (
+                    <CampSlateCard key={`${game.away}-${game.home}-${game.when}`} game={game} />
+                  ))}
+                </div>
+              </DeskPanel>
+            ) : null}
           </div>
 
-          <div className="enhanced-card flex flex-col gap-2 p-3.5">
-            <p className="enhanced-kicker">Ask Hoops Intel</p>
-            <p className="editorial-body text-xs leading-4 text-[var(--hi-text,#f3f6fa)]">
-              Shortcuts open the assistant with today’s edition context.
-            </p>
-            {chips.map((chip) => (
-              <button
-                key={chip}
-                type="button"
-                className="text-left text-[11px] font-medium px-2.5 py-2 rounded-md min-h-11"
-                style={{ background: "var(--hi-surface-2,#121c2c)", color: "var(--hi-text,#f3f6fa)" }}
-                onClick={() => dispatchAskPrompt(chip)}
-              >
-                {chip}
-              </button>
-            ))}
-          </div>
-        </aside>
+          <aside id="injuries" className="hidden md:flex w-full lg:w-[420px] shrink-0 flex-col gap-4">
+            <DeskPanel kicker={campMode ? "Camp Watch" : "Injury Wire"} hint={campMode ? "Last known" : "Desk tags"}>
+              <div className="flex flex-col gap-2.5">
+                {railInjuries.map((injury) => (
+                  <a
+                    key={injury.player}
+                    href={`/player/${slugify(injury.player)}`}
+                    className="desk-inset flex items-center gap-2 px-2.5 py-2 min-h-11 min-w-0"
+                  >
+                    <span className="flex-1 min-w-0 text-xs font-medium text-[var(--hi-text,#f2f5fa)] truncate">
+                      {injury.player}
+                    </span>
+                    <span className="text-[11px] font-medium shrink-0" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+                      {injury.team}
+                    </span>
+                    <InjuryChip status={injury.status} />
+                  </a>
+                ))}
+              </div>
+              {campMode ? (
+                <p className="sr-only">
+                  Editorial tags from today’s edition. The live injury cron stays dark through September. {railInjuries.map((i) => shortInjuryLine(i.injury)).join("; ")}
+                </p>
+              ) : null}
+            </DeskPanel>
+
+            {campMode ? (
+              <DeskPanel kicker="Tonight">
+                <DeskInset className="flex flex-col items-center justify-center gap-2 p-[18px] text-center">
+                  <p className="text-sm font-semibold text-[var(--hi-text,#f2f5fa)]">Slate clear</p>
+                  <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+                    No invented tip-offs. Camp opens Oct 3.
+                  </p>
+                  <StatusPill tone="accent">EMPTY · HONEST</StatusPill>
+                </DeskInset>
+              </DeskPanel>
+            ) : null}
+
+            <DeskPanel kicker="Ask Hoops Intel" hint="Shortcuts into the desk AI">
+              {chips.map((chip) => (
+                <button
+                  key={chip}
+                  type="button"
+                  className="desk-inset text-left text-xs font-normal px-2.5 py-2 min-h-11 w-full text-[var(--hi-text,#f2f5fa)]"
+                  onClick={() => dispatchAskPrompt(chip)}
+                >
+                  {chip}
+                </button>
+              ))}
+              <EnhancedButton href="/ask">Ask Hoops Intel</EnhancedButton>
+            </DeskPanel>
+          </aside>
+
+          {campMode ? (
+            <div className="md:hidden w-full flex flex-col gap-3">
+              <DeskPanel kicker="Tonight">
+                <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+                  Slate clear · not tonight
+                </p>
+              </DeskPanel>
+              {schedule.kind !== "empty" ? (
+                <DeskPanel kicker="ESPN camp-week slate" hint={schedule.sub}>
+                  <div className="flex gap-2 overflow-x-auto pb-1">
+                    {schedule.games.slice(0, 3).map((game) => (
+                      <CampSlateCard key={`${game.away}-${game.home}-${game.when}`} game={game} />
+                    ))}
+                  </div>
+                </DeskPanel>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -319,7 +319,7 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
                   {chip}
                 </button>
               ))}
-              <EnhancedButton href="/ask">Ask Hoops Intel</EnhancedButton>
+              <EnhancedButton href="/ask" className="w-full">Ask Hoops Intel</EnhancedButton>
             </DeskPanel>
           </aside>
 

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -19,13 +19,96 @@ export function BrandLockup({ compact = false }: { compact?: boolean }) {
     <a href="/" className="flex items-center gap-2.5 min-w-0 py-1">
       <BrandMark size={compact ? 12 : 14} />
       <span
-        className="font-bold tracking-[1.2px] text-[var(--hi-text,#f3f6fa)] truncate"
-        style={{ fontSize: compact ? 12 : 13, letterSpacing: compact ? "0.8px" : "1.2px" }}
+        className="font-bold truncate"
+        style={{
+          fontSize: compact ? 12 : 13,
+          letterSpacing: compact ? "0.8px" : "1px",
+          color: ENHANCED_ACCENT,
+        }}
       >
         HOOPS INTEL
       </span>
     </a>
   );
+}
+
+export function SeasonChip({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className="desk-chip uppercase"
+      style={{ background: "rgba(31,199,245,0.14)", color: ENHANCED_ACCENT }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function StatusPill({
+  tone,
+  children,
+}: {
+  tone: "accent" | "warn" | "success" | "danger";
+  children: ReactNode;
+}) {
+  const styles = {
+    accent: { background: "rgba(31,199,245,0.14)", color: ENHANCED_ACCENT },
+    warn: { background: "rgba(242,184,56,0.14)", color: "var(--hi-warn,#f2b838)" },
+    success: { background: "rgba(64,209,140,0.14)", color: "var(--hi-success,#40d18c)" },
+    danger: { background: "rgba(255,77,106,0.14)", color: "var(--hi-danger,#ff4d6a)" },
+  }[tone];
+  return (
+    <span className="desk-chip" style={styles}>
+      {children}
+    </span>
+  );
+}
+
+export function DeskPanel({
+  kicker,
+  hint,
+  children,
+  id,
+  className = "",
+}: {
+  kicker: string;
+  hint?: string;
+  children: ReactNode;
+  id?: string;
+  className?: string;
+}) {
+  return (
+    <section id={id} className={`enhanced-card flex flex-col gap-3 p-4 min-w-0 overflow-hidden ${className}`}>
+      <div className="min-w-0">
+        <p className="enhanced-kicker">{kicker}</p>
+        {hint ? (
+          <p className="text-xs leading-5 mt-1.5" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            {hint}
+          </p>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function DeskInset({
+  children,
+  className = "",
+  href,
+}: {
+  children: ReactNode;
+  className?: string;
+  href?: string;
+}) {
+  const cls = `desk-inset min-w-0 overflow-hidden ${className}`;
+  if (href) {
+    return (
+      <a href={href} className={`${cls} block transition-colors hover:bg-white/[0.04]`}>
+        {children}
+      </a>
+    );
+  }
+  return <div className={cls}>{children}</div>;
 }
 
 export function SectionHeader({
@@ -43,7 +126,7 @@ export function SectionHeader({
     <div className="flex flex-col items-start gap-1 md:flex-row md:items-end md:gap-3 w-full min-w-0">
       <div className="flex-1 min-w-0">
         <p className="enhanced-kicker">{eyebrow}</p>
-        <h2 className="editorial-heading text-[var(--hi-text,#f3f6fa)] text-[28px] leading-8 max-md:text-[1.5rem] max-md:leading-8">
+        <h2 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[28px] leading-8 max-md:text-[1.5rem] max-md:leading-8">
           {title}
         </h2>
       </div>
@@ -70,14 +153,15 @@ export function StatCard({
   sub: string;
 }) {
   return (
-    <div className="enhanced-card flex flex-col gap-1.5 px-4 py-3.5 max-md:px-3 max-md:py-3 min-w-0 overflow-hidden">
-      <p className="text-[10px] font-semibold tracking-[1.2px] uppercase" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+    <div className="enhanced-card flex flex-col gap-1 p-4 max-md:p-3 min-w-0 overflow-hidden">
+      <p
+        className="text-[10px] font-semibold tracking-[0.8px] uppercase"
+        style={{ color: "var(--hi-text-secondary,#8594a8)" }}
+      >
         {kicker}
       </p>
-      <p className="mono-data font-bold leading-9 text-[32px] max-md:text-[28px] max-md:leading-8 break-words" style={{ color: ENHANCED_ACCENT }}>
-        {value}
-      </p>
-      <p className="text-sm leading-5 max-md:mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+      <p className="font-bold text-lg leading-[22px] text-[var(--hi-text,#f2f5fa)] break-words">{value}</p>
+      <p className="text-xs leading-[15px] truncate" style={{ color: ENHANCED_ACCENT }}>
         {sub}
       </p>
     </div>
@@ -85,17 +169,7 @@ export function StatCard({
 }
 
 export function InjuryChip({ status }: { status: string }) {
-  const tone = injuryChipTone(status);
-  const bg = tone === "success" ? "var(--hi-success,#3ddc97)" : tone === "danger" ? "var(--hi-danger,#ff4d6a)" : "#F59E0B";
-  const color = tone === "success" ? "var(--hi-bg-page,#050d1a)" : "#F3F6FA";
-  return (
-    <span
-      className="inline-flex items-center justify-center px-2 py-[3px] rounded text-[10px] font-semibold tracking-[0.5px] uppercase shrink-0"
-      style={{ background: bg, color }}
-    >
-      {injuryStatusLabel(status)}
-    </span>
-  );
+  return <StatusPill tone={injuryChipTone(status)}>{injuryStatusLabel(status)}</StatusPill>;
 }
 
 export function EnhancedButton({
@@ -112,11 +186,11 @@ export function EnhancedButton({
   type?: "button" | "submit";
 }) {
   const className =
-    "inline-flex items-center justify-center px-4 py-[9px] rounded-md text-[13px] font-semibold min-h-11 transition-opacity hover:opacity-90";
+    "inline-flex items-center justify-center px-3.5 py-2.5 rounded-[10px] text-[13px] font-semibold min-h-11 transition-opacity hover:opacity-90";
   const style =
     variant === "primary"
-      ? { background: ENHANCED_ACCENT, color: "#050d1a" }
-      : { background: "transparent", color: "var(--hi-text,#f3f6fa)", border: "1px solid var(--hi-border,#1e2c40)" };
+      ? { background: ENHANCED_ACCENT, color: "#0a0d12" }
+      : { background: "transparent", color: "var(--hi-text,#f2f5fa)", border: "1px solid var(--hi-border,#293342)" };
 
   if (href) {
     return (
@@ -152,21 +226,25 @@ export function GamePreviewCard({
       <div className="flex items-center gap-2 min-w-0">
         <p className="enhanced-kicker">{status}</p>
         <span className="flex-1 min-w-0" />
-        <p className="text-sm shrink-0 text-right leading-5" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+        <p className="text-sm shrink-0 text-right leading-5" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
           {when}
         </p>
       </div>
       <div className="flex flex-col gap-1 min-w-0">
-        <p className="mono-data font-bold text-[22px] md:text-[26px] leading-7 text-[var(--hi-text,#f3f6fa)] break-words">
-          {away} <span className="text-sm font-normal" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>@</span> {home}
+        <p className="mono-data font-bold text-[22px] md:text-[26px] leading-7 text-[var(--hi-text,#f2f5fa)] break-words">
+          {away}{" "}
+          <span className="text-sm font-normal" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            @
+          </span>{" "}
+          {home}
         </p>
         {network ? (
-          <p className="text-sm font-semibold tracking-[0.8px] leading-5" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
+          <p className="text-sm font-semibold tracking-[0.8px] leading-5" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
             {network}
           </p>
         ) : null}
       </div>
-      <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)]">{note}</p>
+      <p className="editorial-body mobile-readable text-[var(--hi-text,#f2f5fa)]">{note}</p>
     </div>
   );
 }

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -178,15 +178,17 @@ export function EnhancedButton({
   variant = "primary",
   onClick,
   type = "button",
+  className = "",
 }: {
   href?: string;
   children: ReactNode;
   variant?: "primary" | "ghost";
   onClick?: () => void;
   type?: "button" | "submit";
+  className?: string;
 }) {
-  const className =
-    "inline-flex items-center justify-center px-3.5 py-2.5 rounded-[10px] text-[13px] font-semibold min-h-11 transition-opacity hover:opacity-90";
+  const cls =
+    `inline-flex items-center justify-center px-3.5 py-2.5 rounded-[10px] text-[13px] font-semibold min-h-11 transition-opacity hover:opacity-90 ${className}`;
   const style =
     variant === "primary"
       ? { background: ENHANCED_ACCENT, color: "#0a0d12" }
@@ -194,13 +196,13 @@ export function EnhancedButton({
 
   if (href) {
     return (
-      <a href={href} className={className} style={style}>
+      <a href={href} className={cls} style={style}>
         {children}
       </a>
     );
   }
   return (
-    <button type={type} onClick={onClick} className={className} style={style}>
+    <button type={type} onClick={onClick} className={cls} style={style}>
       {children}
     </button>
   );

--- a/client/src/lib/campDesk.ts
+++ b/client/src/lib/campDesk.ts
@@ -19,7 +19,17 @@ export type CampScheduleRow = {
   when: string;
   tv: string;
   note: string;
+  dateIso?: string;
 };
+
+export function campShortDate(dateIso: string): string {
+  const parts = dateIso.split("-");
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  if (!month || !day || !months[month - 1]) return dateIso;
+  return `${months[month - 1]} ${day}`;
+}
 
 export type CampScheduleStatus = {
   kind: "tonight" | "espn-upcoming" | "empty";
@@ -182,13 +192,14 @@ export function campScheduleStatus(): CampScheduleStatus {
     return {
       kind: "espn-upcoming",
       headline: "ESPN camp-week slate",
-      sub: "Not tonight. First tips when camp opens — pulled from ESPN, not invented.",
-      games: campScheduleGames.slice(0, 3).map((game) => ({
+      sub: "Oct 3 openers · labeled not tonight",
+      games: campScheduleGames.slice(0, 5).map((game) => ({
         away: game.away,
         home: game.home,
         when: game.when,
         tv: game.tv,
         note: game.venue || "ESPN camp-week listing",
+        dateIso: game.dateIso,
       })),
     };
   }
@@ -203,8 +214,8 @@ export function campScheduleStatus(): CampScheduleStatus {
 
 export function campAskChips(): string[] {
   return [
-    "Which rotation battles matter before camp?",
-    "Who is unresolved heading into October?",
-    "When does training camp open?",
+    "Who leads Camp Pulse?",
+    "When does camp open?",
+    "Any unresolved injuries?",
   ];
 }

--- a/client/src/lib/enhancedDesk.ts
+++ b/client/src/lib/enhancedDesk.ts
@@ -71,13 +71,53 @@ export function injuryStatusKey(status: string): string {
 
 export function injuryChipTone(status: string): "danger" | "success" | "warn" {
   const key = injuryStatusKey(status);
-  if (key === "out" || key === "day-to-day" || key === "doubtful") return "danger";
+  if (key === "out") return "danger";
   if (key === "probable") return "success";
   return "warn";
 }
 
 export function injuryStatusLabel(status: string): string {
-  return status.replace(/-/g, "-").toUpperCase();
+  if (injuryStatusKey(status) === "day-to-day") return "Day-to-Day";
+  if (!status) return status;
+  return status
+    .split(/[-_\s]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("-");
+}
+
+export function lastNameOf(name: string): string {
+  return name.split(" ").slice(-1)[0] ?? name;
+}
+
+export function formatPulseTenths(score: number): string {
+  return score.toFixed(1);
+}
+
+export function seasonChipLabel(ctx: EditionContext = activeEditionContext()): string | null {
+  switch (ctx) {
+    case "preseason":
+      return "PRESEASON";
+    case "playoffs":
+      return "PLAYOFFS";
+    case "finals":
+      return "FINALS";
+    case "draft":
+      return "DRAFT";
+    case "free-agency":
+      return "FREE AGENCY";
+    case "summer-league":
+      return "SUMMER";
+    case "dead-period":
+      return "OFFSEASON";
+    default:
+      return null;
+  }
+}
+
+export function headerDateLabel(display = pulseEdition.date): string {
+  const parsed = parseEditionDisplayDate(display);
+  if (!parsed) return display;
+  return parsed.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
 export function injuryCounts(rows = injuryUpdates) {
@@ -135,20 +175,20 @@ export function heroStats(): HeroStat[] {
   const west1 = westStandings[0];
   const campDays = daysUntilIso(CAMP_OPEN_ISO);
   const murray = murrayStandoff();
-  const lastName = leader?.player.split(" ").slice(-1)[0] ?? "—";
+  const lastName = leader ? lastNameOf(leader.player) : "—";
 
   const cards: HeroStat[] = [];
   if (leader) {
     cards.push({
       kicker: "PULSE LEADER",
-      value: formatPulseScore(leader.indexScore),
-      sub: `${lastName} · ${leader.team}`,
+      value: lastName,
+      sub: `${leader.team} · ${formatPulseScore(leader.indexScore)}`,
     });
   }
   cards.push({
-    kicker: "PRESEASON",
+    kicker: "CAMP OPENS",
     value: campDays > 0 ? `${campDays} days` : campDays === 0 ? "Today" : "Open",
-    sub: "Camp opens October 3",
+    sub: "October 3",
   });
 
   // Empty slates stay a camp desk — last season's W-L is not tonight's scoreboard.
@@ -157,8 +197,8 @@ export function heroStats(): HeroStat[] {
     if (unresolved.length > 0) {
       cards.push({
         kicker: "UNRESOLVED",
-        value: String(unresolved.length),
-        sub: unresolved.map((row) => row.player.split(" ").slice(-1)[0]).join(" · "),
+        value: `${unresolved.length} ${unresolved.length === 1 ? "issue" : "issues"}`,
+        sub: unresolved.map((row) => lastNameOf(row.player)).join(" · "),
       });
     } else if (murray) {
       cards.push({ kicker: "MURRAY", value: murray.value, sub: murray.sub });
@@ -182,23 +222,23 @@ export function heroStats(): HeroStat[] {
 export function mobileHeroStats(): HeroStat[] {
   const all = heroStats();
   const pulse = all.find((c) => c.kicker === "PULSE LEADER");
-  const camp = all.find((c) => c.kicker === "PRESEASON");
+  const camp = all.find((c) => c.kicker === "CAMP OPENS" || c.kicker === "PRESEASON");
   return [
     pulse
-      ? { kicker: "PULSE", value: pulse.value, sub: pulse.sub.replace(/Wembanyama/, "Wemby") }
+      ? { kicker: "PULSE", value: pulse.value.replace(/Wembanyama/, "Wemby"), sub: pulse.sub }
       : { kicker: "PULSE", value: "—", sub: "Board idle" },
     camp
-      ? { kicker: "CAMP", value: camp.value.replace(/ days$/, "d"), sub: "Opens Oct 3" }
-      : { kicker: "CAMP", value: "—", sub: "Opens Oct 3" },
+      ? { kicker: "CAMP", value: camp.value.replace(/ days$/, "d"), sub: camp.sub }
+      : { kicker: "CAMP", value: "—", sub: "October 3" },
   ];
 }
 
 export function deskAskChips(): string[] {
   if (gamePreviews.length === 0) {
     return [
-      "Which rotation battles matter before camp?",
-      "Who is unresolved heading into October?",
-      "When does training camp open?",
+      "Who leads Camp Pulse?",
+      "When does camp open?",
+      "Any unresolved injuries?",
     ];
   }
   return contextualAskChips().slice(0, 3);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -61,6 +61,8 @@ import { rationaleToBullets, pulseLeadLine } from "../lib/pulseRationale";
 import { shouldShowLiveScorebar, scorebarGamesToShow } from "../lib/scorebarVisibility";
 import PickEmHomeBanner from "../components/PickEmHomeBanner";
 import { isOffseasonDesk, offseasonPrimaryCta, editionContextDeskLabel } from "../lib/deskMode";
+import { isCampDesk } from "../lib/campDesk";
+import { hasTonightSlate } from "../lib/enhancedDesk";
 import { FOOTER_QUICK_LINKS } from "../lib/siteNav";
 import { liveScoresTrustLabel } from "../lib/dataTrust";
 import { editionHourLabel } from "../lib/pacificTime";
@@ -1899,7 +1901,7 @@ export default function Home() {
     <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
       <SiteHeader editionBadge={pulseEdition.date} />
       <RivalTonightBanner />
-      <EnhancedTicker />
+      {isCampDesk() && !hasTonightSlate() ? null : <EnhancedTicker />}
       <main id="main-content" tabIndex={-1}>
         <EnhancedDesk showMyPulse={showMyPulse} />
         <LiveScorebar />

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -267,7 +267,7 @@ function FilterButton({
       className="flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-semibold transition-all"
       style={
         active
-          ? { background: "#0EA5E9", color: "#fff" }
+          ? { background: "var(--hi-accent,#1ec8f5)", color: "#0a0d12" }
           : {
               background: "rgba(255,255,255,0.05)",
               color: "rgba(255,255,255,0.5)",

--- a/client/src/pages/PickEm.tsx
+++ b/client/src/pages/PickEm.tsx
@@ -521,15 +521,15 @@ function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
           actionHref="/pick-em#season-board"
         />
         <div className="enhanced-card flex flex-col gap-2.5 p-[22px] max-md:p-4">
-          <p className="editorial-heading text-2xl max-md:text-[1.5rem] max-md:leading-8 text-[var(--hi-text,#f3f6fa)]">No picks yet.</p>
-          <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)] max-w-3xl">
-            Nothing on tonight’s schedule, so the board is closed. Game and bracket picks count toward the
-            season board when the first tip lands. Lock picks to see how you stack up against the desk.
+          <p className="editorial-heading text-2xl max-md:text-[1.5rem] max-md:leading-8 text-[var(--hi-text,#f2f5fa)]">Board closed.</p>
+          <p className="editorial-body mobile-readable text-[var(--hi-text,#f2f5fa)] max-w-3xl">
+            Nothing on tonight’s ESPN slate, so Pick ’Em stays locked. We never invent tip-offs for camp week.
+            Game and bracket picks count toward the season board when the first tip lands.
           </p>
           <div className="flex flex-wrap gap-2 pt-1">
-            <EnhancedButton href="/tonight">Open Pick &apos;Em</EnhancedButton>
-            <EnhancedButton href="/archive" variant="ghost">
-              View archive
+            <EnhancedButton href="/tonight">Open Tonight</EnhancedButton>
+            <EnhancedButton href="/#camp-intel" variant="ghost">
+              Camp intel
             </EnhancedButton>
           </div>
         </div>

--- a/client/src/pages/Tonight.tsx
+++ b/client/src/pages/Tonight.tsx
@@ -1,5 +1,5 @@
 import SiteHeader from "../components/SiteHeader";
-import { EnhancedButton, GamePreviewCard, SectionHeader, StatCard } from "../components/enhanced/EnhancedUi";
+import { DeskPanel, EnhancedButton, GamePreviewCard, SectionHeader, StatCard, StatusPill } from "../components/enhanced/EnhancedUi";
 import { daysUntilIso, CAMP_OPEN_ISO, hasTonightSlate } from "../lib/enhancedDesk";
 import { campIntelCards, campScheduleStatus } from "../lib/campDesk";
 import { gamePreviews, pulseEdition } from "../lib/pulseData";
@@ -14,13 +14,17 @@ export default function Tonight() {
   return (
     <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
       <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
-        <SectionHeader
-          eyebrow="TONIGHT'S SLATE"
-          title={slateOpen ? `${gamePreviews.length} games tonight` : "No games tonight"}
-          action="Watch guide →"
-          actionHref="/watch-guide"
-        />
+      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-6 flex flex-col gap-5 outline-none">
+        <div className="flex flex-col gap-2 min-w-0">
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[30px] leading-[34px] max-md:text-[1.5rem] max-md:leading-8">
+            Tonight
+          </h1>
+          <p className="mobile-readable max-w-2xl" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            {slateOpen
+              ? `${gamePreviews.length} games on the ESPN board.`
+              : "No games on the board. Preseason desk stays honest — we never invent tip-offs."}
+          </p>
+        </div>
 
         {slateOpen ? (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
@@ -50,26 +54,13 @@ export default function Tonight() {
             ))}
           </div>
         ) : (
-          <div className="enhanced-card flex flex-col gap-2 p-5 max-md:p-4">
-            <p className="editorial-heading text-[1.375rem] leading-8 text-[var(--hi-text,#f3f6fa)]">
-              The slate is empty. The desk is not.
+          <div className="enhanced-card flex flex-col items-center justify-center text-center gap-2 px-6 py-12 max-md:px-4 max-md:py-10">
+            <p className="font-semibold text-lg leading-6 text-[var(--hi-text,#f2f5fa)]">Waiting on Oct 3</p>
+            <p className="text-sm max-w-md" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+              Camp openers land on ESPN schedule · not tonight
+              {campDays > 0 ? ` · ${campDays === 1 ? "one day" : `${campDays} days`} out` : ""}.
             </p>
-            <p className="editorial-body mobile-readable text-[var(--hi-text,#f3f6fa)]">
-              Nothing on tonight’s ESPN schedule. Training camp opens October 3
-              {campDays > 0 ? ` — ${campDays === 1 ? "one day" : `${campDays} days`}` : ""}.
-              Roster battles, cuts, and Pulse of the camp live on the morning desk — not as invented matchups here.
-            </p>
-            <p className="mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-              {schedule.kind === "espn-upcoming"
-                ? schedule.sub
-                : "Scores is not a standalone route — recaps land on the desk when games exist."}
-            </p>
-            <div className="flex flex-wrap gap-2 pt-1">
-              <EnhancedButton href="/#camp-intel">Open camp intel</EnhancedButton>
-              <EnhancedButton href="/lineups" variant="ghost">
-                Rotation battles
-              </EnhancedButton>
-            </div>
+            <StatusPill tone="warn">NOT TONIGHT</StatusPill>
           </div>
         )}
 
@@ -87,6 +78,22 @@ export default function Tonight() {
                   <StatCard kicker={card.kicker} value={card.team ?? card.kicker} sub={card.title} />
                 </a>
               ))}
+            </div>
+            {schedule.kind === "espn-upcoming" ? (
+              <DeskPanel kicker="ESPN camp-week slate" hint={schedule.sub}>
+                <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+                  {schedule.games
+                    .slice(0, 3)
+                    .map((game) => `${game.away} @ ${game.home}`)
+                    .join(" · ")}
+                </p>
+              </DeskPanel>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <EnhancedButton href="/#camp-intel">Open camp intel</EnhancedButton>
+              <EnhancedButton href="/lineups" variant="ghost">
+                Rotation battles
+              </EnhancedButton>
             </div>
           </>
         ) : null}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -4,7 +4,7 @@
 /* ═══════════════════════════════════════════════════════════
    HOOPS INTEL — Global Styles
    Design: Dark Intelligence Dashboard
-   Colors: Navy #050D1A, Electric Blue #0EA5E9, Emerald #10B981,
+   Colors: Navy #050D1A, Accent #1EC8F5, Emerald #10B981,
            Rose #F43F5E, Amber #F59E0B
    Fonts: Barlow Condensed (headers), DM Sans (body), JetBrains Mono (stats)
    ═══════════════════════════════════════════════════════════ */
@@ -30,13 +30,14 @@ html.dark {
   --hi-muted: rgba(255, 255, 255, 0.72);
   --hi-muted-sub: rgba(255, 255, 255, 0.68);
   --hi-accent: #1ec8f5;
-  --hi-surface: #0c1522;
-  --hi-surface-2: #121c2c;
-  --hi-border: #1e2c40;
-  --hi-text: #f3f6fa;
-  --hi-text-secondary: #8b9bb0;
-  --hi-success: #3ddc97;
+  --hi-surface: #171c26;
+  --hi-surface-2: #12171f;
+  --hi-border: #293342;
+  --hi-text: #f2f5fa;
+  --hi-text-secondary: #8594a8;
+  --hi-success: #40d18c;
   --hi-danger: #ff4d6a;
+  --hi-warn: #f2b838;
 }
 
 html.light {
@@ -56,6 +57,7 @@ html.light {
   --hi-text-secondary: #475569;
   --hi-success: #059669;
   --hi-danger: #e11d48;
+  --hi-warn: #b45309;
 }
 
 .sr-only {
@@ -241,16 +243,34 @@ html.light .section-label {
 .enhanced-kicker {
   font-family: "DM Sans", sans-serif;
   font-weight: 600;
-  font-size: 10px;
-  letter-spacing: 1.4px;
+  font-size: 11px;
+  letter-spacing: 1.1px;
   text-transform: uppercase;
   color: var(--hi-accent, #1ec8f5);
 }
 
 .enhanced-card {
-  background: var(--hi-surface, #0c1522);
-  border: 1px solid var(--hi-border, #1e2c40);
+  background: var(--hi-surface, #171c26);
+  border: 1px solid var(--hi-border, #293342);
+  border-radius: 14px;
+}
+
+.desk-inset {
+  background: var(--hi-surface-2, #12171f);
   border-radius: 10px;
+}
+
+.desk-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 /* Container */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Figma **Camp Desk · AI Pass Sep 2026** (`tXhGJnS7Ol1Dg0jb9I0C6L`, Home · Live-aligned plus Tonight / mobile frames) on the live Vite/React desk — not a Next.js rewrite. Visual upgrade only; September honesty is unchanged.

- Accent token `#1EC8F5`, 14px desk panels, inset rows, pill chips
- Name-first stats strip (Pulse leader / Camp opens / Unresolved) from live edition data
- Stacked **Before the slate** intel, compact **Pulse of the camp** rows, ESPN camp-week cards labeled **NOT TONIGHT**
- Rail: Camp Watch pills, Tonight **Slate clear / EMPTY · HONEST**, Ask shortcuts + full-width cyan CTA
- Header: cyan lockup, **PRESEASON** chip, a single compact date (Codex P2: removed the leftover `editionBadge` chip that would duplicate the date in regular season)
- Tonight empty: **Waiting on Oct 3** + not-tonight badge (no invented tip-offs)
- Pick ’Em closed board and Injury chips use the same desk language
- Mobile: tighter mast, Camp Pulse, Tonight empty, no font overlap (`truncate` / `min-w-0` / 44px targets)

[Desktop Desk above the fold](https://cursor.com/agents/bc-fdaf86a5-8199-4482-a247-d77a592963bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_desktop_above_fold.webp)
[Tonight empty state](https://cursor.com/agents/bc-fdaf86a5-8199-4482-a247-d77a592963bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftonight_empty_state.webp)
[camp_desk_figma_walkthrough.mp4](https://cursor.com/agents/bc-fdaf86a5-8199-4482-a247-d77a592963bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamp_desk_figma_walkthrough.mp4)

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (315/315)
- [x] Local preview verified (Desk / Tonight / Injuries / Pick ’Em, desktop + 390px)
- [x] New secrets documented in `.env.example` / `README.md` if applicable (N/A — no env/secret changes)

## Residual gaps

- Header still keeps Search / Pro / theme / account (product chrome the Figma nav omits)
- Injury Wire and Pick ’Em are token/chip aligned, not full dedicated Figma page rebuilds (those frames were not separate nodes in the shared file; used attached mocks + Home system)
- Standings / Full Edition / footer below the desk are unchanged
- Scores/injury crons stay dark through September
- Stack is Vite + React (existing app), not Next.js


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdaf86a5-8199-4482-a247-d77a592963bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdaf86a5-8199-4482-a247-d77a592963bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rework Camp Desk UI with camp-mode `EnhancedDesk`, new chip/inset components, and honest empty-slate copy
> - Adds a camp-mode layout to `EnhancedDesk` that renders camp intel rows, compact Camp Pulse rows, a dated ESPN camp-week slate labeled NOT TONIGHT, and an honest empty-Tonight panel instead of invented tip-offs
> - Introduces reusable `SeasonChip`, `StatusPill`, `DeskPanel`, and `DeskInset` components in [EnhancedUi.tsx](https://github.com/hondoentertainment/hoops-intel/pull/379/files#diff-935c3e3d041a7d90a9914e6db9da66d38f8ba4c1ac87ad1e4f455ca38a69c383), plus `campShortDate`, `seasonChipLabel`, `headerDateLabel`, and `formatPulseTenths` utilities in [enhancedDesk.ts](https://github.com/hondoentertainment/hoops-intel/pull/379/files#diff-d5abf09a43f791161633225a5653610ec762bc5a24df5b4b651e9c35d9530071) and [campDesk.ts](https://github.com/hondoentertainment/hoops-intel/pull/379/files#diff-7d707d197da8614ffd8a699428308f25198d178e52972e905fce1a917b70a39a)
> - Reworks the [Tonight.tsx](https://github.com/hondoentertainment/hoops-intel/pull/379/files#diff-21ab0eee2637b89b6034854bcd179ed8378af5432dcb9f693966ab4a715c4371) empty slate to show a "Waiting on Oct 3" card with a NOT TONIGHT pill and a separate upcoming-ESPN-schedule panel
> - Updates the dark/light theme color variables in [index.css](https://github.com/hondoentertainment/hoops-intel/pull/379/files#diff-065f34d6861b830db5472fba3f56f0815fb9777d8b481e34e6927c845810e1df) with revised surfaces, borders, text colors, and a new warning tone
> - Behavioral Change: `injuryChipTone` now maps Day-to-Day and doubtful to `warn` instead of `danger`; `campScheduleStatus` returns up to 5 dated games (was 3 undated); closed-slate Ask chips and Pick 'Em copy replaced with camp-focused prompts — callers relying on the old rotation-battle or October-resolution prompts will see different text
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef38a6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->