### PR TITLE
Tie weekly tool sitemap lastmod to the daily edition

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -104,19 +104,19 @@
   </url>
   <url>
     <loc>https://hoopsintel.net/lineups</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/clutch</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/draft</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -128,13 +128,13 @@
   </url>
   <url>
     <loc>https://hoopsintel.net/tactics</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoopsintel.net/projections</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -158,7 +158,7 @@
   </url>
   <url>
     <loc>https://hoopsintel.net/community-pulse</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -182,7 +182,7 @@
   </url>
   <url>
     <loc>https://hoopsintel.net/trade-value</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.55</priority>
   </url>
@@ -206,7 +206,7 @@
   </url>
   <url>
     <loc>https://hoopsintel.net/trade-simulator</loc>
-    <lastmod>2026-08-31</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -260,6 +260,17 @@ export function lastmodForLoc(loc, ctx) {
     "/podcast-companion",
     "/embed-stats",
     "/widgets/analytics",
+    // Weekly tools: generatedDate freezes on the last successful weekly run
+    // (currently 2026-08-31). Follow the edition so lastmod tracks real desk
+    // freshness without inventing lineup/clutch/tactics copy.
+    "/lineups",
+    "/clutch",
+    "/tactics",
+    "/draft",
+    "/projections",
+    "/community-pulse",
+    "/trade-value",
+    "/trade-simulator",
   ]);
   const contentDate = contentDatesLastmod(STATIC_ROUTE_SOURCES[loc]);
   const sourceDate = sourcesLastmod(STATIC_ROUTE_SOURCES[loc]);

--- a/scripts/tests/sitemap-lastmod.test.mjs
+++ b/scripts/tests/sitemap-lastmod.test.mjs
@@ -132,6 +132,26 @@ test("history and refs lastmod advance with the daily edition when content is fr
   assert.equal(lastmodForLoc("/refs", ctx), "2026-09-02");
 });
 
+test("weekly tool pages lastmod advance with the daily edition when content is frozen", () => {
+  const later = (...dates) => dates.filter(Boolean).sort().at(-1);
+  const ctx = { buildDay: "2026-12-01", editionIso: "2026-09-02" };
+  const frozenTools = [
+    ["/lineups", "client/src/lib/lineupData.ts"],
+    ["/clutch", "client/src/lib/clutchData.ts"],
+    ["/tactics", "client/src/lib/tacticsData.ts"],
+    ["/draft", "client/src/lib/draftData.ts"],
+    ["/projections", "client/src/lib/projectionsData.ts"],
+    ["/community-pulse", "client/src/lib/communityPulseData.ts"],
+    ["/trade-value", "client/src/lib/tradeValueData.ts"],
+    ["/trade-simulator", "client/src/lib/tradeSimData.ts"],
+  ];
+  for (const [path, rel] of frozenTools) {
+    const contentIso = extractExportedTimestamp(readFileSync(join(ROOT, rel), "utf8"));
+    assert.equal(lastmodForLoc(path, ctx), later(contentIso, ctx.editionIso), path);
+    assert.equal(lastmodForLoc(path, ctx), "2026-09-02", path);
+  }
+});
+
 test("Pulse Index players get higher sitemap priority; others stay default", () => {
   assert.deepEqual(playerSitemapMeta({ inPulse: true }), { priority: "0.65", changefreq: "daily" });
   assert.deepEqual(playerSitemapMeta({ inPulse: false }), { priority: "0.5", changefreq: "weekly" });
@@ -175,7 +195,14 @@ test("committed sitemap includes publisher 200 routes and edition-stamped lastmo
   const editionIso = extractExportedTimestamp(readFileSync(join(ROOT, "client/src/lib/pulseData.ts"), "utf8"));
   assert.ok(editionIso, "pulseEdition.date should parse to an ISO day");
   assert.doesNotMatch(xml, /<loc>https:\/\/hoopsintel\.net\/account<\/loc>/);
-  for (const path of ["/podcast-companion", "/embed-stats", "/widgets/analytics"]) {
+  for (const path of [
+    "/podcast-companion",
+    "/embed-stats",
+    "/widgets/analytics",
+    "/lineups",
+    "/clutch",
+    "/tactics",
+  ]) {
     const escaped = path.replace(/\//g, "\\/");
     const block = xml.match(
       new RegExp(`<url>\\s*<loc>https:\\/\\/hoopsintel\\.net${escaped}<\\/loc>\\s*<lastmod>([^<]+)<\\/lastmod>`),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Weekly tool URLs (`/lineups`, `/clutch`, `/tactics`, `/draft`, `/projections`, `/community-pulse`, `/trade-value`, `/trade-simulator`) were stuck at `lastmod` `2026-08-31` — the last successful weekly generation. Sitemap lastmod now follows the daily edition when those generators freeze, matching the existing history/refs/podcast rule. No lineup/clutch/tactics copy was invented.

Verified locally: `node --test scripts/tests/sitemap-lastmod.test.mjs` — 21/21 pass. `validate-generated-structure.mjs` OK. Committed `public/sitemap.xml` only changes those eight lastmods to `2026-09-09` (current edition). Unrelated URLs were left alone.

Also attempted (ops, not in this PR): set the GitHub repo homepage from `https://hoops-intel.vercel.app` to `https://hoopsintel.net`. The GitHub App token used by this agent returns **403** (`Resource not accessible by integration`) on `gh repo edit` / `updateRepository`. Confirmed afterward: homepage is still `https://hoops-intel.vercel.app`. A maintainer can run:

```bash
gh repo edit hondoentertainment/hoops-intel --homepage https://hoopsintel.net
```

## Checklist

- [ ] `npm run build` passes locally — N/A for this lastmod-only change
- [x] Sitemap lastmod suite: `node --test scripts/tests/sitemap-lastmod.test.mjs` (21/21)
- [ ] Vercel Preview looks correct for UI changes — N/A
- [ ] New secrets documented in `.env.example` / `README.md` if applicable — N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a76b6ae-45df-4749-8a7e-8d1df79f1268?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a76b6ae-45df-4749-8a7e-8d1df79f1268&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tie 8 weekly tool routes to edition date in sitemap `lastmodForLoc` resolver
> Adds eight weekly tool routes (lineups, clutch, tactics, draft, projections, community pulse, trade value, trade simulator) to the set that tracks the daily edition date when resolving `lastmod` in [scripts/generate-sitemap.mjs](https://github.com/hondoentertainment/hoops-intel/pull/380/files#diff-8d21738aa38c071a755376f824cbe53bfdc27028e61004c33d98cac9d7ee7a9c). This ensures the sitemap reports a later date when the edition date is newer than frozen tool content. Behavioral Change: `lastmodForLoc` now returns the edition date for these routes when it is later than the content timestamp; committed [public/sitemap.xml](https://github.com/hondoentertainment/hoops-intel/pull/380/files#diff-bd4a35c26151469a9eaebf7c16024e40ceb05d52afe4aa08904081be72a40caf) is updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f6f3d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->