### PR TITLE
Full-app editorial UX pass

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -119,7 +119,7 @@ function PageLoader() {
         <div className="flex items-center gap-3">
           <div
             className="w-8 h-8 rounded border-2 border-t-transparent animate-spin shrink-0"
-            style={{ borderColor: "#0EA5E9", borderTopColor: "transparent" }}
+            style={{ borderColor: "var(--hi-accent,#1ec8f5)", borderTopColor: "transparent" }}
             aria-hidden
           />
           <div className="text-sm font-medium" style={{ color: "rgba(255,255,255,0.7)" }}>
@@ -213,21 +213,24 @@ export default function App() {
             <Route path="/creator-queue" component={CreatorQueue} />
             <Route>
               <main id="main-content" tabIndex={-1} className="container py-20 text-center outline-none" lang="en">
-                <p className="section-label mb-3">NOT FOUND</p>
-                <h1 className="display-heading text-2xl font-bold text-white mb-4">404 — Page not found</h1>
-                <p className="text-sm mb-6" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
+                <p className="enhanced-kicker mb-3">Not found</p>
+                <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-3xl mb-4 max-md:text-[1.5rem]">
+                  404 — Page not found
+                </h1>
+                <p className="mobile-readable mb-6" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
                   That route is not part of Hoops Intel.
                 </p>
                 <div className="flex flex-wrap justify-center gap-x-6 gap-y-3 text-sm">
-                  <a href="/" className="text-sky-400 underline min-h-[44px] inline-flex items-center">
+                  <a href="/" className="underline min-h-11 inline-flex items-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
                     Today&apos;s desk
                   </a>
-                  <a href="/tools" className="text-sky-400 underline min-h-[44px] inline-flex items-center">
+                  <a href="/tools" className="underline min-h-11 inline-flex items-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
                     Tools
                   </a>
                   <button
                     type="button"
-                    className="text-sky-400 underline min-h-[44px] inline-flex items-center"
+                    className="underline min-h-11 inline-flex items-center"
+                    style={{ color: "var(--hi-accent,#1ec8f5)" }}
                     onClick={() => window.dispatchEvent(new Event("hi-open-search"))}
                   >
                     Open search

--- a/client/src/__tests__/campDesk.test.ts
+++ b/client/src/__tests__/campDesk.test.ts
@@ -66,8 +66,9 @@ describe("Tonight empty slate", () => {
     const tonight = readFileSync(join(srcDir, "pages/Tonight.tsx"), "utf8");
     expect(tonight).not.toContain("CAMP_OPENER");
     expect(tonight).toContain("Open camp intel");
-    expect(tonight).toContain("Waiting on Oct 3");
-    expect(tonight).toContain("never invent tip-offs");
+    expect(tonight).toContain("Waiting on ${openDate}");
+    expect(tonight).toContain("empty slate until real tip-offs");
+    expect(tonight).toContain("we never invent a slate");
     expect(tonight).not.toMatch(/away:\s*"NYK"[\s\S]*home:\s*"BOS"/);
   });
 });

--- a/client/src/__tests__/editorialUx.test.ts
+++ b/client/src/__tests__/editorialUx.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("editorial UX primitives", () => {
+  it("keeps the shared card language at 16px with the caliber accent", () => {
+    const css = readFileSync(join(srcDir, "styles/index.css"), "utf8");
+    expect(css).toContain("--hi-accent: #1ec8f5");
+    expect(css).toContain("--hi-card-radius: 16px");
+    expect(css).toMatch(/\.enhanced-card[\s\S]{0,200}var\(--hi-card-radius/);
+    expect(css).toMatch(/\.glass-card[\s\S]{0,200}var\(--hi-card-radius/);
+    expect(css).toContain(".desk-hairline");
+  });
+
+  it("exposes PageHero and EmptyState on the shared primitive module", () => {
+    const ui = readFileSync(join(srcDir, "components/enhanced/EnhancedUi.tsx"), "utf8");
+    expect(ui).toContain("export function PageHero");
+    expect(ui).toContain("export function EmptyState");
+    expect(ui).toContain("subtitle");
+  });
+
+  it("routes tool pages and the desk through the shared footer", () => {
+    const layout = readFileSync(join(srcDir, "components/ToolPageLayout.tsx"), "utf8");
+    const home = readFileSync(join(srcDir, "pages/Home.tsx"), "utf8");
+    const tonight = readFileSync(join(srcDir, "pages/Tonight.tsx"), "utf8");
+    expect(layout).toContain("SiteFooter");
+    expect(layout).toContain("PageHero");
+    expect(home).toContain("SiteFooter");
+    expect(tonight).toContain("EmptyState");
+    expect(tonight).toContain("Waiting on");
+    expect(tonight).toContain("empty slate until real tip-offs");
+    const header = readFileSync(join(srcDir, "components/SiteHeader.tsx"), "utf8");
+    expect(header).toContain("Daily NBA Intelligence");
+  });
+});

--- a/client/src/__tests__/enhancedDesk.test.ts
+++ b/client/src/__tests__/enhancedDesk.test.ts
@@ -15,6 +15,8 @@ import {
   pulseTrendMark,
   seasonChipLabel,
   shortInjuryLine,
+  campOpenDisplay,
+  deskKickerLine,
 } from "../lib/enhancedDesk";
 import { gamePreviews, pulseIndex } from "../lib/pulseData";
 
@@ -64,5 +66,7 @@ describe("enhancedDesk", () => {
     expect(daysUntilIso("2026-10-03", new Date("2026-09-01T12:00:00"))).toBe(32);
     expect(seasonChipLabel("preseason")).toBe("PRESEASON");
     expect(headerDateLabel("September 9, 2026")).toBe("Sep 9, 2026");
+    expect(campOpenDisplay("2026-10-03")).toBe("October 3");
+    expect(deskKickerLine("preseason")).toMatch(/PRESEASON DESK/);
   });
 });

--- a/client/src/components/Breadcrumbs.tsx
+++ b/client/src/components/Breadcrumbs.tsx
@@ -27,7 +27,11 @@ export default function Breadcrumbs({ items }: { items: Crumb[] }) {
                   {item.label}
                 </span>
               ) : (
-                <a href={item.href} className="truncate text-sky-400 hover:text-sky-300 transition-colors">
+                <a
+                  href={item.href}
+                  className="truncate min-h-11 inline-flex items-center hover:opacity-80"
+                  style={{ color: "var(--hi-accent,#1ec8f5)" }}
+                >
                   {item.label}
                 </a>
               )}

--- a/client/src/components/EditorialShell.tsx
+++ b/client/src/components/EditorialShell.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import SiteHeader, { type SiteHeaderProps } from "./SiteHeader";
+import SiteFooter from "./SiteFooter";
+
+export default function EditorialShell({
+  children,
+  header,
+  footer = true,
+  mainClassName = "",
+}: {
+  children: ReactNode;
+  header?: SiteHeaderProps;
+  footer?: boolean;
+  mainClassName?: string;
+}) {
+  return (
+    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#07090e)" }}>
+      <SiteHeader {...header} />
+      <main id="main-content" tabIndex={-1} className={`outline-none ${mainClassName}`.trim()}>
+        {children}
+      </main>
+      {footer ? <SiteFooter /> : null}
+    </div>
+  );
+}

--- a/client/src/components/SiteFooter.tsx
+++ b/client/src/components/SiteFooter.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { BrandLockup, EnhancedButton } from "./enhanced/EnhancedUi";
+import { ENHANCED_ACCENT } from "../lib/enhancedDesk";
+import { FOOTER_QUICK_LINKS } from "../lib/siteNav";
+import { pulseEdition } from "../lib/pulseData";
+import { subscribeDigestEmail, readDigestSignupHint } from "../lib/subscribeDigest";
+import { editionHourLabel } from "../lib/pacificTime";
+import { useToast } from "../contexts/ToastContext";
+
+function footerEmailOk(raw: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw.trim());
+}
+
+export default function SiteFooter() {
+  const { toast } = useToast();
+  const digestId = "footer-digest-email";
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [apiError, setApiError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [subscribed, setSubscribed] = useState(() => readDigestSignupHint());
+
+  const handleSubscribe = async () => {
+    if (!footerEmailOk(email)) {
+      setEmailError("Enter a valid email.");
+      return;
+    }
+    setEmailError("");
+    setApiError("");
+    setSubmitting(true);
+    const result = await subscribeDigestEmail(email);
+    setSubmitting(false);
+    if (result.ok) {
+      setSubscribed(true);
+      toast(`Subscribed — morning digest at ${editionHourLabel()}`);
+    } else {
+      setApiError(result.error);
+    }
+  };
+
+  const digestDescribedBy =
+    [emailError ? "footer-email-err" : "", apiError ? "footer-digest-api-err" : ""].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <footer className="py-10 mt-8 border-t" style={{ borderColor: "var(--hi-border-soft, rgba(255,255,255,0.06))" }}>
+      <div className="container">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
+          <div className="min-w-0">
+            <div className="mb-3">
+              <BrandLockup subtitle="Daily NBA intelligence" />
+            </div>
+            <p className="text-xs mb-3" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+              {pulseEdition.edition} · {pulseEdition.date}
+            </p>
+            <div className="flex flex-wrap gap-x-4 gap-y-2">
+              <a href="/archive" className="text-xs min-h-11 inline-flex items-center" style={{ color: ENHANCED_ACCENT }}>
+                Archive
+              </a>
+              <a href="/performance" className="text-xs min-h-11 inline-flex items-center" style={{ color: ENHANCED_ACCENT }}>
+                AI Performance
+              </a>
+              <a href="/feed.xml" className="text-xs min-h-11 inline-flex items-center" style={{ color: ENHANCED_ACCENT }}>
+                RSS Feed
+              </a>
+            </div>
+          </div>
+
+          <div className="min-w-0">
+            <p className="enhanced-kicker mb-2">Daily digest</p>
+            <p className="text-xs mb-3" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+              Morning edition in your inbox at {editionHourLabel()}
+            </p>
+            {subscribed ? (
+              <div className="text-xs px-3 py-2 rounded-[10px]" style={{ background: "rgba(64,209,140,0.12)", color: "var(--hi-success,#40d18c)" }}>
+                Subscribed to the daily digest
+              </div>
+            ) : (
+              <div className="space-y-1">
+                <label htmlFor={digestId} className="sr-only">
+                  Email for daily Hoops Intel digest
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <input
+                    id={digestId}
+                    type="email"
+                    autoComplete="email"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (emailError) setEmailError("");
+                      if (apiError) setApiError("");
+                    }}
+                    aria-invalid={emailError || apiError ? "true" : undefined}
+                    aria-describedby={digestDescribedBy}
+                    placeholder="you@domain.com"
+                    className="flex-1 min-w-[min(100%,12rem)] min-h-11 px-3 py-2 rounded-[10px] text-xs bg-[var(--hi-surface-2,#0e1218)] text-[var(--hi-text,#f2f5fa)] border outline-none"
+                    style={{ borderColor: "var(--hi-border,#252b36)" }}
+                  />
+                  <EnhancedButton onClick={() => void handleSubscribe()}>
+                    {submitting ? "Signing up…" : "Subscribe"}
+                  </EnhancedButton>
+                </div>
+                {emailError ? (
+                  <p id="footer-email-err" className="text-xs text-rose-400" role="alert">
+                    {emailError}
+                  </p>
+                ) : null}
+                {apiError ? (
+                  <p id="footer-digest-api-err" className="text-xs text-rose-400" role="alert">
+                    {apiError}
+                  </p>
+                ) : null}
+              </div>
+            )}
+          </div>
+
+          <div className="min-w-0">
+            <p className="enhanced-kicker mb-3">Explore</p>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+              {FOOTER_QUICK_LINKS.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className="text-xs min-h-11 inline-flex items-center hover:opacity-80"
+                  style={{ color: "var(--hi-text-secondary,#8594a8)" }}
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="desk-hairline mb-4" />
+        <p className="text-xs text-center" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+          © {new Date().getFullYear()} Hoops Intel · Not affiliated with the NBA · Data for entertainment purposes
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/client/src/components/SiteHeader.tsx
+++ b/client/src/components/SiteHeader.tsx
@@ -108,7 +108,7 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
           fill="none"
           stroke="currentColor"
           strokeWidth="2"
-          style={{ color: subscribed ? "#0EA5E9" : "rgba(255,255,255,0.5)" }}
+          style={{ color: subscribed ? ENHANCED_ACCENT : "var(--hi-text-secondary,#8594a8)" }}
           aria-hidden
         >
           <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
@@ -146,9 +146,9 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
                 href="/account#browser-push"
                 className="block w-full text-left px-3 py-2 rounded text-xs font-medium transition-colors min-h-[44px] flex items-center"
                 style={{
-                  background: "rgba(14,165,233,0.1)",
-                  color: "#0EA5E9",
-                  border: "1px solid rgba(14,165,233,0.2)",
+                  background: "rgba(30,200,245,0.1)",
+                  color: ENHANCED_ACCENT,
+                  border: "1px solid rgba(30,200,245,0.2)",
                 }}
               >
                 Set up browser push →
@@ -188,7 +188,7 @@ function NotificationBell({ idPrefix }: { idPrefix: string }) {
                     onClick={() => void handleSubscribe()}
                     disabled={submitting}
                     className="min-h-[44px] px-3 py-2 rounded text-xs font-semibold text-white sm:min-h-0 disabled:opacity-50"
-                    style={{ background: "#0EA5E9" }}
+                    style={{ background: ENHANCED_ACCENT, color: "#0a0d12" }}
                   >
                     {submitting ? "…" : "Subscribe"}
                   </button>
@@ -576,7 +576,12 @@ export default function SiteHeader({
               </button>
 
               <div className="flex items-center min-w-0 py-1">
-                <BrandLockup compact />
+                <span className="md:hidden">
+                  <BrandLockup compact />
+                </span>
+                <span className="hidden md:inline-flex min-w-0">
+                  <BrandLockup subtitle="Daily NBA Intelligence" />
+                </span>
               </div>
             </div>
 
@@ -617,7 +622,7 @@ export default function SiteHeader({
                       href={href}
                       className="block px-4 py-2.5 text-xs font-medium transition-colors hover:bg-white/5 hover:text-sky-400"
                       style={{
-                        color: navRouteMatches(href, locationPath) ? "#0EA5E9" : "rgba(255,255,255,0.75)",
+                        color: navRouteMatches(href, locationPath) ? ENHANCED_ACCENT : "var(--hi-text-secondary,#8594a8)",
                       }}
                       {...navAriaCurrent(href, locationPath)}
                     >
@@ -723,7 +728,7 @@ export default function SiteHeader({
                 <a
                   href="/account"
                   className="hidden md:flex items-center gap-1 min-h-11 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors hover:bg-white/10"
-                  style={{ background: "rgba(14,165,233,0.12)", color: "#7dd3fc", border: "1px solid rgba(14,165,233,0.25)" }}
+                  style={{ background: "rgba(30,200,245,0.12)", color: ENHANCED_ACCENT, border: "1px solid rgba(30,200,245,0.25)" }}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
                     <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
@@ -768,7 +773,12 @@ export default function SiteHeader({
             style={{ background: "var(--hi-mobile-sheet, #081018)" }}
           >
             <div className="container py-3 flex flex-col gap-1">
-              <a href="/" className="text-sm font-semibold text-sky-400 py-3 px-3 rounded-lg hover:bg-white/5" onClick={() => setMobileOpen(false)}>
+              <a
+                href="/"
+                className="text-sm font-semibold py-3 px-3 rounded-lg hover:bg-white/5 min-h-12 flex items-center"
+                style={{ color: ENHANCED_ACCENT }}
+                onClick={() => setMobileOpen(false)}
+              >
                 Today’s desk →
               </a>
               {mainNavLinks().map(({ label, href }) => {
@@ -779,7 +789,7 @@ export default function SiteHeader({
                     key={`m-${label}`}
                     href={href}
                     className="py-3 px-3 rounded-lg text-sm hover:bg-white/5 min-h-[48px] flex items-center"
-                    style={{ color: active ? "#38BDF8" : "rgba(255,255,255,0.85)" }}
+                    style={{ color: active ? ENHANCED_ACCENT : "var(--hi-text,#f2f5fa)" }}
                     aria-current={active ? "page" : undefined}
                     onClick={() => setMobileOpen(false)}
                   >

--- a/client/src/components/ToolPageLayout.tsx
+++ b/client/src/components/ToolPageLayout.tsx
@@ -1,7 +1,10 @@
 import { type ReactNode } from "react";
 import { useLocation } from "wouter";
 import SiteHeader from "./SiteHeader";
+import SiteFooter from "./SiteFooter";
 import Breadcrumbs, { type Crumb } from "./Breadcrumbs";
+import { DeskPanel, PageHero } from "./enhanced/EnhancedUi";
+import { ENHANCED_ACCENT } from "../lib/enhancedDesk";
 import { relatedToolsForHref } from "../lib/siteNav";
 
 const MAX_WIDTH: Record<string, string> = {
@@ -64,7 +67,7 @@ export default function ToolPageLayout({
     return (
       <div
         className={`min-h-screen ${shellClassName}`.trim()}
-        style={{ background: "var(--hi-bg-page, #050D1A)" }}
+        style={{ background: "var(--hi-bg-page, #07090e)" }}
       >
         <SiteHeader
           subtitle={subtitle}
@@ -75,14 +78,15 @@ export default function ToolPageLayout({
         <main id="main-content" tabIndex={-1} className="flex-1 flex flex-col min-h-0 outline-none">
           {children}
         </main>
+        <SiteFooter />
       </div>
     );
   }
 
   return (
     <div
-      className={`min-h-screen pb-8 has-mobile-tabbar ${shellClassName}`.trim()}
-      style={{ background: "var(--hi-bg-page, #050D1A)" }}
+      className={`min-h-screen has-mobile-tabbar ${shellClassName}`.trim()}
+      style={{ background: "var(--hi-bg-page, #07090e)" }}
     >
       <SiteHeader
         subtitle={subtitle}
@@ -92,47 +96,55 @@ export default function ToolPageLayout({
       />
       <main id="main-content" tabIndex={-1} className={`container py-8 mx-auto px-4 ${widthClass}`}>
         {showBreadcrumbs && <Breadcrumbs items={defaultCrumbs} />}
-        {(sectionLabel || title || description) && (
-          <header className="mb-8">
-            {sectionLabel && <p className="section-label mb-2">{sectionLabel}</p>}
-            {title && (
-              <h1 className="display-heading text-2xl sm:text-3xl mb-3" style={{ color: "var(--hi-heading,#fff)" }}>
-                {title}
-              </h1>
-            )}
-            {description && (
-              <p className="text-sm max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted,rgba(255,255,255,0.6))" }}>
+        {title ? (
+          <div className="mb-8">
+            <PageHero
+              kicker={sectionLabel || subtitle}
+              title={title}
+              description={description}
+            />
+          </div>
+        ) : sectionLabel || description ? (
+          <header className="mb-8 min-w-0">
+            {sectionLabel ? <p className="enhanced-kicker mb-2">{sectionLabel}</p> : null}
+            {description ? (
+              <p className="mobile-readable max-w-2xl" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
                 {description}
               </p>
-            )}
+            ) : null}
           </header>
-        )}
+        ) : null}
         <div className={related.length > 0 ? "grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_15rem] gap-8 items-start" : undefined}>
           <div className="min-w-0">{children}</div>
           {related.length > 0 && (
             <aside className="lg:sticky lg:top-20">
-              <div className="glass-card rounded-xl p-4">
-                <div className="section-label mb-3">RELATED TOOLS</div>
-                <ul className="space-y-2">
+              <DeskPanel kicker="Related tools">
+                <ul className="flex flex-col gap-1">
                   {related.map((tool) => (
                     <li key={tool.href}>
                       <a
                         href={tool.href}
-                        className="block text-xs font-medium text-sky-400 hover:text-sky-300 py-1.5"
+                        className="desk-inset flex items-center min-h-11 px-3 text-xs font-medium"
+                        style={{ color: ENHANCED_ACCENT }}
                       >
                         {tool.label} →
                       </a>
                     </li>
                   ))}
                 </ul>
-                <a href="/tools" className="inline-block mt-3 text-[11px] text-white/45 hover:text-sky-400">
+                <a
+                  href="/tools"
+                  className="inline-flex items-center min-h-11 text-[11px]"
+                  style={{ color: "var(--hi-text-secondary,#8594a8)" }}
+                >
                   All tools directory
                 </a>
-              </div>
+              </DeskPanel>
             </aside>
           )}
         </div>
       </main>
+      <SiteFooter />
     </div>
   );
 }

--- a/client/src/components/enhanced/EnhancedDesk.tsx
+++ b/client/src/components/enhanced/EnhancedDesk.tsx
@@ -14,6 +14,7 @@ import {
   compactPulseStats,
   deskAskChips,
   deskEyebrow,
+  deskKickerLine,
   formatPulseScore,
   formatPulseTenths,
   hasTonightSlate,
@@ -171,22 +172,23 @@ export default function EnhancedDesk({ showMyPulse }: { showMyPulse: boolean }) 
       <div className="flex flex-col gap-[22px]">
         <div id="today-desk" className="flex flex-col gap-2.5 max-w-[980px] min-w-0">
           <p className="enhanced-kicker">
-            {deskEyebrow()} · {pulseEdition.date.toUpperCase()}
+            {deskKickerLine()}
           </p>
-          <h1 className="hidden md:block editorial-heading text-[var(--hi-text,#f2f5fa)] text-[26px] leading-[34px]">
+          <h1 className="hidden md:block editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-[38px]">
             {narrative.headline}
           </h1>
           <h1 className="md:hidden editorial-heading text-[var(--hi-text,#f2f5fa)] text-[1.5rem] leading-8">
             {campMode ? pulseEdition.date : narrative.headline}
           </h1>
           <p className="text-xs max-md:mobile-readable" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
-            <span className="hidden md:inline">Will Henderson · updated {editionPublishLabel()}</span>
+            <span className="hidden md:inline">Will Henderson · Updated {editionPublishLabel()}</span>
             <span className="md:hidden">
               {campMode
                 ? `Camp opens Oct 3. Tonight stays empty.`
                 : `Will Henderson · ${editionPublishLabel()}${hasTonightSlate() ? "" : " · no games tonight"}`}
             </span>
           </p>
+          <div className="desk-hairline mt-1" />
           {!campMode ? (
             <div className="flex flex-wrap gap-2 items-center">
               <EnhancedButton href="#pulse-index">Read the brief</EnhancedButton>

--- a/client/src/components/enhanced/EnhancedUi.tsx
+++ b/client/src/components/enhanced/EnhancedUi.tsx
@@ -14,19 +14,39 @@ export function BrandMark({ size = 14 }: { size?: number }) {
   );
 }
 
-export function BrandLockup({ compact = false }: { compact?: boolean }) {
+export function BrandLockup({
+  compact = false,
+  subtitle,
+}: {
+  compact?: boolean;
+  subtitle?: string;
+}) {
   return (
     <a href="/" className="flex items-center gap-2.5 min-w-0 py-1">
       <BrandMark size={compact ? 12 : 14} />
-      <span
-        className="font-bold truncate"
-        style={{
-          fontSize: compact ? 12 : 13,
-          letterSpacing: compact ? "0.8px" : "1px",
-          color: ENHANCED_ACCENT,
-        }}
-      >
-        HOOPS INTEL
+      <span className="flex flex-col min-w-0 leading-none">
+        <span
+          className="font-bold truncate"
+          style={{
+            fontSize: compact ? 12 : 13,
+            letterSpacing: compact ? "0.8px" : "1px",
+            color: ENHANCED_ACCENT,
+          }}
+        >
+          HOOPS INTEL
+        </span>
+        {subtitle ? (
+          <span
+            className="truncate font-medium mt-0.5"
+            style={{
+              fontSize: compact ? 9 : 10,
+              color: "var(--hi-text-secondary,#8594a8)",
+              letterSpacing: "0.01em",
+            }}
+          >
+            {subtitle}
+          </span>
+        ) : null}
       </span>
     </a>
   );
@@ -255,6 +275,95 @@ export function EnhancedPageFrame({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
       {children}
+    </div>
+  );
+}
+
+export function PageHero({
+  kicker,
+  title,
+  description,
+  meta,
+  action,
+  actionHref,
+  as: Heading = "h1",
+}: {
+  kicker: string;
+  title: string;
+  description?: string;
+  meta?: string;
+  action?: string;
+  actionHref?: string;
+  as?: "h1" | "h2";
+}) {
+  return (
+    <header className="flex flex-col gap-2 min-w-0">
+      <p className="enhanced-kicker">{kicker}</p>
+      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between min-w-0">
+        <Heading className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 max-md:text-[1.5rem] max-md:leading-8 min-w-0">
+          {title}
+        </Heading>
+        {action && actionHref ? (
+          <a
+            href={actionHref}
+            className="text-sm font-medium shrink-0 inline-flex items-end min-h-11 pb-1"
+            style={{ color: ENHANCED_ACCENT }}
+          >
+            {action}
+          </a>
+        ) : null}
+      </div>
+      {description ? (
+        <p className="mobile-readable max-w-2xl" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+          {description}
+        </p>
+      ) : null}
+      {meta ? (
+        <p className="text-xs" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+          {meta}
+        </p>
+      ) : null}
+      <div className="desk-hairline mt-1" />
+    </header>
+  );
+}
+
+export function EmptyState({
+  kicker,
+  title,
+  body,
+  pill,
+  pillTone = "warn",
+  footnote,
+}: {
+  kicker?: string;
+  title: string;
+  body?: string;
+  pill?: string;
+  pillTone?: "accent" | "warn" | "success" | "danger";
+  footnote?: string;
+}) {
+  return (
+    <div className="flex flex-col items-center text-center gap-3 py-10 md:py-16 px-4 min-w-0">
+      {kicker ? <p className="enhanced-kicker">{kicker}</p> : null}
+      <h2 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] md:text-[40px] leading-tight max-md:text-[1.75rem]">
+        {title}
+      </h2>
+      {body ? (
+        <p className="mobile-readable max-w-lg" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+          {body}
+        </p>
+      ) : null}
+      {pill || footnote ? (
+        <div className="enhanced-card flex flex-col items-center justify-center gap-2 px-8 py-8 w-full max-w-xl">
+          {pill ? <StatusPill tone={pillTone}>{pill}</StatusPill> : null}
+          {footnote ? (
+            <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+              {footnote}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/client/src/components/playoffs/PlayoffsPage.tsx
+++ b/client/src/components/playoffs/PlayoffsPage.tsx
@@ -19,6 +19,7 @@ import { PlayoffsSkeleton } from "./PlayoffsSkeleton";
 import { SeriesCard, sortedSeriesCardsData } from "./SeriesCard";
 import { TakeawaysSection } from "./TakeawaysSection";
 import SiteHeader from "../../components/SiteHeader";
+import SiteFooter from "../../components/SiteFooter";
 import { PlayoffMoversDesk } from "./PlayoffMoversDesk";
 import { PlayoffBracketBoard } from "./PlayoffBracketBoard";
 
@@ -236,10 +237,14 @@ export function PlayoffsPage() {
         {!hydrated ? (
           <PlayoffsSkeleton />
         ) : !hasBoard ? (
-          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-8 text-center">
-            <p className="text-white/70 text-sm mb-3">Postseason telemetry is syncing — no series rows on file yet.</p>
-            <a href="/" className="text-sky-400 text-sm font-semibold">
-              ← Return to Hoops Intel Today
+          <div className="enhanced-card flex flex-col items-center text-center gap-3 px-8 py-12">
+            <p className="enhanced-kicker">Playoffs</p>
+            <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-2xl">Board idle</h1>
+            <p className="mobile-readable max-w-md" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+              Postseason telemetry is syncing — no series rows on file yet.
+            </p>
+            <a href="/" className="text-sm font-semibold min-h-11 inline-flex items-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>
+              ← Return to today&apos;s desk
             </a>
           </div>
         ) : (
@@ -272,19 +277,7 @@ export function PlayoffsPage() {
         )}
       </main>
 
-      <footer className="border-t border-white/[0.06] py-8 mt-8">
-        <div className="container px-4 flex flex-wrap items-center justify-between gap-4 text-[10px] text-white/30">
-          <span>Hoops Intel · Bloomberg-style playoff stack</span>
-          <div className="flex gap-4">
-            <a href="/pick-em" className="hover:text-sky-400/90">
-              Pick ’Em
-            </a>
-            <a href="/" className="hover:text-sky-400/90">
-              Edition
-            </a>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/client/src/lib/enhancedDesk.ts
+++ b/client/src/lib/enhancedDesk.ts
@@ -143,6 +143,16 @@ export function deskEyebrow(ctx: EditionContext = activeEditionContext()): strin
   return editionContextDeskLabel(ctx).toUpperCase();
 }
 
+export function deskKickerLine(ctx: EditionContext = activeEditionContext()): string {
+  return `${deskEyebrow(ctx)} · ${pulseEdition.edition}`;
+}
+
+export function campOpenDisplay(iso = CAMP_OPEN_ISO): string {
+  const parsed = new Date(`${iso}T12:00:00`);
+  if (Number.isNaN(parsed.getTime())) return "October 3";
+  return parsed.toLocaleDateString("en-US", { month: "long", day: "numeric" });
+}
+
 export function editionUpdatedLabel(_display = pulseEdition.date): string {
   return `Updated ${editionPublishLabel()}`;
 }

--- a/client/src/pages/Account.tsx
+++ b/client/src/pages/Account.tsx
@@ -434,7 +434,7 @@ function AccountPushAlerts({ userId }: { userId: string }) {
           disabled={busy}
           onClick={() => void handleRegister()}
           className="min-h-[44px] px-4 py-2 rounded-lg text-xs font-semibold text-white disabled:opacity-50"
-          style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)", fontFamily: "'Barlow Condensed', sans-serif" }}
+          style={{ background: "var(--hi-accent,#1ec8f5)", color: "var(--hi-accent-ink,#0a0d12)" }}
         >
           {deviceEndpoint ? "RE-SYNC THIS DEVICE" : "ENABLE PUSH ON THIS DEVICE"}
         </button>
@@ -544,7 +544,7 @@ export default function Account() {
         <div className="py-12 flex justify-center">
           <div
             className="w-8 h-8 rounded border-2 border-t-transparent animate-spin"
-            style={{ borderColor: "#0EA5E9", borderTopColor: "transparent" }}
+            style={{ borderColor: "var(--hi-accent,#1ec8f5)", borderTopColor: "transparent" }}
           />
         </div>
       </ToolPageLayout>
@@ -554,10 +554,8 @@ export default function Account() {
   if (!user || !getStoredAuthToken()) {
     return (
       <ToolPageLayout subtitle="ACCOUNT" maxWidth="lg" showRelated={false}>
-        <div className="section-label mb-2" style={{ color: "#0EA5E9" }}>
-          ACCOUNT
-        </div>
-        <h1 className="display-heading text-white text-3xl mb-3">Sign in to manage your desk</h1>
+        <p className="enhanced-kicker mb-2">Account</p>
+        <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-3xl mb-3 max-md:text-[1.5rem]">Sign in to manage your desk</h1>
         <p className="text-sm mb-8 leading-relaxed" style={{ color: "rgba(255,255,255,0.55)" }}>
           Hoops Intel accounts power Pro billing, synced favorites, and optional digest settings. Nothing here is required to
           read the free edition.
@@ -571,7 +569,7 @@ export default function Account() {
             type="button"
             onClick={() => setShowAuth(true)}
             className="w-full sm:w-auto min-h-[48px] px-6 py-3 rounded-lg text-sm font-semibold text-white"
-            style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)", fontFamily: "'Barlow Condensed', sans-serif" }}
+            style={{ background: "var(--hi-accent,#1ec8f5)", color: "var(--hi-accent-ink,#0a0d12)" }}
           >
             SIGN IN OR CREATE ACCOUNT
           </button>
@@ -592,10 +590,8 @@ export default function Account() {
 
   return (
     <ToolPageLayout subtitle="ACCOUNT" maxWidth="lg" showRelated={false}>
-      <div className="section-label mb-2" style={{ color: "#0EA5E9" }}>
-        YOUR ACCOUNT
-      </div>
-      <h1 className="display-heading text-white text-3xl mb-8">Settings &amp; billing</h1>
+      <p className="enhanced-kicker mb-2">Your account</p>
+      <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-3xl mb-8 max-md:text-[1.5rem]">Settings &amp; billing</h1>
 
       <OpsReadinessPanel />
 
@@ -667,7 +663,7 @@ export default function Account() {
               disabled={portalLoading}
               onClick={() => void handlePortal()}
               className="w-full sm:w-auto min-h-[48px] px-5 py-2.5 rounded-lg text-sm font-semibold text-white disabled:opacity-50"
-              style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)", fontFamily: "'Barlow Condensed', sans-serif" }}
+              style={{ background: "var(--hi-accent,#1ec8f5)", color: "var(--hi-accent-ink,#0a0d12)" }}
             >
               {portalLoading ? "OPENING STRIPE…" : "MANAGE BILLING & INVOICES"}
             </button>
@@ -701,7 +697,7 @@ export default function Account() {
             <a
               href="/pro"
               className="inline-flex min-h-[48px] items-center px-5 py-2.5 rounded-lg text-sm font-semibold text-white"
-              style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)", fontFamily: "'Barlow Condensed', sans-serif" }}
+              style={{ background: "var(--hi-accent,#1ec8f5)", color: "var(--hi-accent-ink,#0a0d12)" }}
             >
               {stripeCheckoutReady === false ? "VIEW PRO (OPS PENDING)" : "UPGRADE TO PRO"}
             </a>

--- a/client/src/pages/Archive.tsx
+++ b/client/src/pages/Archive.tsx
@@ -27,24 +27,25 @@ function ArchiveCard({ edition }: { edition: any }) {
   const headline = edition.headline || edition.subheadline || "Edition recap";
   const subheadline = edition.headline ? edition.subheadline : undefined;
   return (
-    <article className="glass-card archive-card rounded-lg p-5">
-      <div className="flex items-center justify-between mb-3 gap-2">
-        <div className="section-label">{displayDate}</div>
-        <div className="mono-data text-xs px-2 py-0.5 rounded shrink-0" style={{ background: "rgba(14,165,233,0.1)", color: "#0EA5E9" }}>
-          {gamesCount} {gamesCount === 1 ? "GAME" : "GAMES"}
-        </div>
+    <article className="enhanced-card archive-card p-5 min-w-0">
+      <div className="flex items-center justify-between mb-3 gap-2 min-w-0">
+        <p className="enhanced-kicker truncate">{displayDate}</p>
+        <span className="desk-chip shrink-0" style={{ background: "rgba(30,200,245,0.14)", color: "var(--hi-accent,#1ec8f5)" }}>
+          {gamesCount} {gamesCount === 1 ? "game" : "games"}
+        </span>
       </div>
-      <h2 className="display-heading text-white text-lg mb-2">{headline}</h2>
+      <h2 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-lg mb-2">{headline}</h2>
       {subheadline ? (
-        <p className="text-sm mb-3" style={{ color: "rgba(255,255,255,0.5)" }}>{subheadline}</p>
+        <p className="text-sm mb-3" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>{subheadline}</p>
       ) : null}
-      <p className="text-sm leading-relaxed mb-4" style={{ color: "rgba(255,255,255,0.65)" }}>{edition.topStory}</p>
+      <p className="text-sm leading-relaxed mb-4" style={{ color: "var(--hi-text,#f2f5fa)" }}>{edition.topStory}</p>
       {topPlayer ? (
         <p className="text-xs mb-4">
           <span style={{ color: "rgba(255,255,255,0.45)" }}>Top performer: </span>
           <a
             href={`/player/${slugify(topPlayer)}`}
-            className="font-semibold text-sky-400 hover:text-sky-300"
+            className="font-semibold"
+            style={{ color: "var(--hi-accent,#1ec8f5)" }}
           >
             {topPlayer}
           </a>
@@ -57,7 +58,7 @@ function ArchiveCard({ edition }: { edition: any }) {
       ) : null}
       <div className="flex flex-wrap gap-1.5">
         {(edition.tags || []).map((tag: string) => (
-          <span key={tag} className="text-xs px-2 py-0.5 rounded" style={{ background: "rgba(14,165,233,0.08)", color: "rgba(14,165,233,0.7)", border: "1px solid rgba(14,165,233,0.15)" }}>
+          <span key={tag} className="desk-chip" style={{ background: "rgba(30,200,245,0.1)", color: "var(--hi-accent,#1ec8f5)" }}>
             {tag}
           </span>
         ))}
@@ -99,8 +100,9 @@ export default function Archive() {
   return (
     <ToolPageLayout
       subtitle="ARCHIVE"
-      sectionLabel="PAST EDITIONS"
+      sectionLabel="Past editions"
       title="Archive"
+      description="Every morning brief the desk has published — search by topic, month, or player."
       showRelated={false}
     >
         <div className="mb-4 flex flex-wrap gap-2">
@@ -161,7 +163,7 @@ export default function Archive() {
 
         {filtered.length === 0 && (
           <div className="text-center py-12 text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-            No editions match. <button type="button" className="text-sky-400 underline" onClick={() => { setSearch(""); setTag(""); setMonth(""); }}>Clear filters</button>
+            No editions match. <button type="button" className="underline min-h-11" style={{ color: "var(--hi-accent,#1ec8f5)" }} onClick={() => { setSearch(""); setTag(""); setMonth(""); }}>Clear filters</button>
           </div>
         )}
 
@@ -172,7 +174,7 @@ export default function Archive() {
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={currentPage <= 1}
               className="px-3 py-1.5 rounded text-xs font-medium min-h-[44px]"
-              style={{ background: currentPage <= 1 ? "rgba(255,255,255,0.03)" : "rgba(14,165,233,0.1)", color: currentPage <= 1 ? "rgba(255,255,255,0.2)" : "#0EA5E9" }}
+              style={{ background: currentPage <= 1 ? "rgba(255,255,255,0.03)" : "rgba(30,200,245,0.12)", color: currentPage <= 1 ? "rgba(255,255,255,0.2)" : "var(--hi-accent,#1ec8f5)" }}
             >
               Previous
             </button>
@@ -182,7 +184,7 @@ export default function Archive() {
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={currentPage >= totalPages}
               className="px-3 py-1.5 rounded text-xs font-medium min-h-[44px]"
-              style={{ background: currentPage >= totalPages ? "rgba(255,255,255,0.03)" : "rgba(14,165,233,0.1)", color: currentPage >= totalPages ? "rgba(255,255,255,0.2)" : "#0EA5E9" }}
+              style={{ background: currentPage >= totalPages ? "rgba(255,255,255,0.03)" : "rgba(30,200,245,0.12)", color: currentPage >= totalPages ? "rgba(255,255,255,0.2)" : "var(--hi-accent,#1ec8f5)" }}
             >
               Next
             </button>

--- a/client/src/pages/AskAI.tsx
+++ b/client/src/pages/AskAI.tsx
@@ -29,30 +29,28 @@ export default function AskAI() {
         style={{ borderColor: "rgba(255,255,255,0.06)" }}
       >
         <div className="container max-w-3xl mx-auto px-4 py-6">
-          <p className="text-xs mb-4" style={{ color: "rgba(255,255,255,0.4)" }}>
+          <p className="enhanced-kicker mb-2">Ask Hoops Intel</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[28px] leading-8 mb-2 max-md:text-[1.5rem]">
+            Shorts into the desk
+          </h1>
+          <p className="text-sm mb-4" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
             AI-powered NBA analysis from daily editions
           </p>
-          <div
-            className="rounded-lg px-4 py-3"
-            style={{
-              background: "rgba(14,165,233,0.06)",
-              border: "1px solid rgba(14,165,233,0.12)",
-            }}
-          >
-            <div className="flex items-center gap-2 mb-1">
+          <div className="enhanced-card px-4 py-3">
+            <div className="flex items-center gap-2 mb-1 min-w-0">
               <span
-                className="w-1.5 h-1.5 rounded-full"
-                style={{ background: "#0EA5E9" }}
+                className="w-1.5 h-1.5 rounded-full shrink-0"
+                style={{ background: "var(--hi-accent,#1ec8f5)" }}
               />
               <span
-                className="text-xs font-medium"
-                style={{ color: "#0EA5E9" }}
+                className="text-xs font-medium truncate"
+                style={{ color: "var(--hi-accent,#1ec8f5)" }}
               >
-                Latest Edition — {pulseEdition.date}
+                Latest edition — {pulseEdition.date}
               </span>
               <span
-                className="text-xs"
-                style={{ color: "rgba(255,255,255,0.3)" }}
+                className="text-xs shrink-0"
+                style={{ color: "var(--hi-text-secondary,#8594a8)" }}
               >
                 {pulseEdition.edition}
               </span>
@@ -65,7 +63,7 @@ export default function AskAI() {
                 ? narrative.subhead.slice(0, 200) + "..."
                 : narrative.subhead}
             </p>
-            <div className="mt-4 pt-4 border-t" style={{ borderColor: "rgba(14,165,233,0.12)" }}>
+            <div className="mt-4 pt-4 border-t" style={{ borderColor: "var(--hi-border-soft, rgba(255,255,255,0.06))" }}>
               <p className="text-[10px] uppercase tracking-wider mb-2" style={{ color: "rgba(255,255,255,0.35)" }}>
                 Quick prompts
               </p>

--- a/client/src/pages/BettingIntel.tsx
+++ b/client/src/pages/BettingIntel.tsx
@@ -1,4 +1,5 @@
 import ToolPageLayout from "../components/ToolPageLayout";
+import { PageHero } from "../components/enhanced/EnhancedUi";
 import { gamePreviews, pulseEdition } from "../lib/pulseData";
 import { lineMovementForMatchup, spreadMoved } from "../lib/lineMovement";
 import { lineOpenersArchive } from "../lib/lineOpenersArchiveData";
@@ -24,12 +25,13 @@ export default function BettingIntel() {
 
   return (
     <ToolPageLayout subtitle="TOOLS">
-      <p className="section-label mb-2">MARKET CONTEXT</p>
-      <h1 className="display-heading text-white text-2xl sm:text-3xl mb-2">Betting intel</h1>
-      <p className="text-sm mb-6 max-w-3xl leading-relaxed" style={{ color: "rgba(255,255,255,0.52)" }}>
-        Openers freeze at morning edition; closers sync from the edition board; current lines refresh via The Odds API on midday and post-game runs. Cards below show
-        opener → closer → current movement plus how sharps read the number.
-      </p>
+      <div className="mb-6">
+        <PageHero
+          kicker="Market context"
+          title="Betting intel"
+          description="Openers freeze at morning edition; closers sync from the edition board; current lines refresh via The Odds API on midday and post-game runs. Cards below show opener → closer → current movement plus how sharps read the number."
+        />
+      </div>
 
       <p
         className="text-xs mb-10 max-w-3xl rounded-lg px-4 py-3 leading-relaxed"

--- a/client/src/pages/ClutchFactor.tsx
+++ b/client/src/pages/ClutchFactor.tsx
@@ -290,23 +290,15 @@ function WeeklyHighlight() {
 export default function ClutchFactor() {
   return (
     <ToolPageLayout subtitle="CLUTCH FACTOR" maxWidth="2xl" showBreadcrumbs={false}>
-        <div style={{ marginBottom: 40 }}>
-          <h1
-            style={{
-              fontSize: 36,
-              fontWeight: 900,
-              letterSpacing: -0.5,
-              margin: 0,
-              background: "linear-gradient(135deg, #FFD700, #0EA5E9)",
-              WebkitBackgroundClip: "text",
-              WebkitTextFillColor: "transparent",
-            }}
-          >
-            CLUTCH FACTOR
+        <div className="mb-10">
+          <p className="enhanced-kicker mb-2">Clutch factor</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[36px] leading-10 max-md:text-[1.75rem]">
+            Who owns the last two minutes
           </h1>
-          <div style={{ fontSize: 14, color: "rgba(255,255,255,0.4)", marginTop: 6 }}>
-            {clutchData.weekLabel} &middot; Generated {clutchData.generatedDate}
-          </div>
+          <p className="text-sm mt-2" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            {clutchData.weekLabel} · Generated {clutchData.generatedDate}
+          </p>
+          <div className="desk-hairline mt-3" />
         </div>
 
         <ClutchKingCard />

--- a/client/src/pages/GameCenter.tsx
+++ b/client/src/pages/GameCenter.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "wouter";
 import SiteHeader from "../components/SiteHeader";
+import SiteFooter from "../components/SiteFooter";
 import Breadcrumbs from "../components/Breadcrumbs";
 import ErrorBlock from "../components/ErrorBlock";
 import ShareButton from "../components/ShareButton";
@@ -119,6 +120,7 @@ export default function GameCenter() {
       <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
         <SiteHeader subtitle="GAME CENTER" />
         <Skeleton />
+        <SiteFooter />
       </div>
     );
   }
@@ -128,10 +130,11 @@ export default function GameCenter() {
       <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
         <SiteHeader subtitle="GAME CENTER" />
         <main id="main-content" tabIndex={-1} className="container py-20 text-center outline-none">
-          <div className="section-label mb-3">GAME NOT FOUND</div>
-          <h1 className="display-heading text-white text-2xl mb-4">No Game Center match for this ID</h1>
-          <a href="/#scores" className="text-sky-400 underline">Back to scores</a>
+          <p className="enhanced-kicker mb-3">Game not found</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-2xl mb-4">No Game Center match for this ID</h1>
+          <a href="/#scores" className="underline min-h-11 inline-flex items-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>Back to scores</a>
         </main>
+        <SiteFooter />
       </div>
     );
   }
@@ -376,6 +379,7 @@ export default function GameCenter() {
           </aside>
         </div>
       </main>
+      <SiteFooter />
     </div>
   );
 }

--- a/client/src/pages/HistoryEngine.tsx
+++ b/client/src/pages/HistoryEngine.tsx
@@ -174,23 +174,15 @@ export default function HistoryEngine() {
 
   return (
     <ToolPageLayout subtitle="HISTORICAL CONTEXT ENGINE">
-{/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-[10px] font-bold tracking-widest uppercase mb-1"
-            style={{ color: "rgba(255,255,255,0.35)" }}
-          >
-            HISTORICAL CONTEXT ENGINE
-          </div>
-          <h1
-            className="display-heading text-white mb-2"
-            style={{ fontSize: "clamp(1.75rem, 4vw, 2.5rem)" }}
-          >
-            Past Meets Present
+          <p className="enhanced-kicker mb-2">Historical context</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Past meets present
           </h1>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {formatContentDate(data.generatedDate)} — Connecting today's performances to NBA history
+          <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            {formatContentDate(data.generatedDate)} — Connecting today&apos;s performances to NBA history
           </p>
+          <div className="desk-hairline mt-3" />
         </div>
 
         {/* Narrative banner */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -23,10 +23,10 @@ import type { LiveGame } from "../lib/espnApi";
 import { slugify } from "../lib/searchUtils";
 import { useBodyScrollLock } from "../hooks/useBodyScrollLock";
 import { useFocusTrap } from "../hooks/useFocusTrap";
-import { subscribeDigestEmail, readDigestSignupHint } from "../lib/subscribeDigest";
 import BoxScoreCard from "../components/BoxScoreCard";
 import ReactionBar from "../components/ReactionBar";
 import SiteHeader from "../components/SiteHeader";
+import SiteFooter from "../components/SiteFooter";
 import PreferencesSetup from "../components/PreferencesSetup";
 import { LiveScoreSkeleton } from "../components/PageSkeletons";
 import { useToast } from "../contexts/ToastContext";
@@ -63,9 +63,7 @@ import PickEmHomeBanner from "../components/PickEmHomeBanner";
 import { isOffseasonDesk, offseasonPrimaryCta, editionContextDeskLabel } from "../lib/deskMode";
 import { isCampDesk } from "../lib/campDesk";
 import { hasTonightSlate } from "../lib/enhancedDesk";
-import { FOOTER_QUICK_LINKS } from "../lib/siteNav";
 import { liveScoresTrustLabel } from "../lib/dataTrust";
-import { editionHourLabel } from "../lib/pacificTime";
 import { lineMovementForMatchup, spreadMoved } from "../lib/lineMovement";
 import { formatLineMovementBadge } from "../lib/spreadMovement";
 import EnhancedDesk, { EnhancedTicker } from "../components/enhanced/EnhancedDesk";
@@ -74,10 +72,6 @@ function shortenPulsePreview(text: string, max = 110) {
   const t = text.trim();
   if (t.length <= max) return t;
   return `${t.slice(0, max).trim()}…`;
-}
-
-function footerEmailOk(raw: string) {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw.trim());
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -1721,151 +1715,14 @@ function StandingsSection() {
   return (
     <section id="standings" className="py-10 border-t" style={{ borderColor: "rgba(255,255,255,0.06)" }}>
       <div className="container">
-        <div className="section-label mb-2">CONFERENCE STANDINGS</div>
-        <h2 className="display-heading text-white text-2xl mb-6">Standings</h2>
+        <p className="enhanced-kicker mb-2">Conference standings</p>
+        <h2 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-2xl mb-6">Standings</h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {renderConference("Eastern Conference", eastStandings)}
           {renderConference("Western Conference", westStandings)}
         </div>
       </div>
     </section>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════
-// FOOTER — With email subscription + RSS
-// ═══════════════════════════════════════════════════════════
-
-function Footer() {
-  const { toast } = useToast();
-  const digestId = "footer-digest-email";
-  const [email, setEmail] = useState("");
-  const [emailError, setEmailError] = useState("");
-  const [apiError, setApiError] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [subscribed, setSubscribed] = useState(() => readDigestSignupHint());
-
-  const handleSubscribe = async () => {
-    if (!footerEmailOk(email)) {
-      setEmailError("Enter a valid email.");
-      return;
-    }
-    setEmailError("");
-    setApiError("");
-    setSubmitting(true);
-    const result = await subscribeDigestEmail(email);
-    setSubmitting(false);
-    if (result.ok) {
-      setSubscribed(true);
-      toast(`Subscribed — morning digest at ${editionHourLabel()}`);
-    } else {
-      setApiError(result.error);
-    }
-  };
-
-  const digestDescribedBy =
-    [emailError ? "footer-email-err" : "", apiError ? "footer-digest-api-err" : ""].filter(Boolean).join(" ") || undefined;
-
-  return (
-    <footer className="py-10 border-t" style={{ borderColor: "rgba(255,255,255,0.06)" }}>
-      <div className="container">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
-          {/* Brand */}
-          <div>
-            <div className="flex items-center gap-2 mb-3">
-              <div className="w-6 h-6 rounded flex items-center justify-center font-bold text-white text-xs" style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)" }}>HI</div>
-              <span className="display-heading text-white text-sm">HOOPS INTEL</span>
-            </div>
-            <p className="text-xs mb-3" style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}>
-              Daily NBA intelligence · {pulseEdition.date}
-            </p>
-            <div className="flex gap-3">
-              <a href="/archive" className="text-xs" style={{ color: "#0EA5E9" }}>Archive</a>
-              <a href="/performance" className="text-xs" style={{ color: "#0EA5E9" }}>AI Performance</a>
-              <a href="/feed.xml" className="text-xs" style={{ color: "#0EA5E9" }}>RSS Feed</a>
-            </div>
-          </div>
-
-          {/* Daily Digest Signup */}
-          <div>
-            <div className="section-label mb-2">DAILY DIGEST</div>
-            <p className="text-xs mb-3" style={{ color: "rgba(255,255,255,0.4)" }}>
-              Get the morning edition in your inbox at {editionHourLabel()}
-            </p>
-            {subscribed ? (
-              <div className="text-xs px-3 py-2 rounded" style={{ background: "rgba(16,185,129,0.1)", color: "#10B981" }}>
-                ✓ You're subscribed to the daily digest
-              </div>
-            ) : (
-              <div className="space-y-1">
-                <label htmlFor={digestId} className="sr-only">
-                  Email for daily Hoops Intel digest
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  <input
-                    id={digestId}
-                    type="email"
-                    autoComplete="email"
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value);
-                      if (emailError) setEmailError("");
-                      if (apiError) setApiError("");
-                    }}
-                    aria-invalid={emailError || apiError ? "true" : undefined}
-                    aria-describedby={digestDescribedBy}
-                    placeholder="you@domain.com"
-                    className="flex-1 min-w-[min(100%,12rem)] min-h-[44px] px-3 py-2 rounded text-xs bg-white/5 text-white border border-white/10 outline-none focus-visible:ring-2 focus-visible:ring-sky-500/50 sm:min-h-0"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => void handleSubscribe()}
-                    disabled={submitting}
-                    className="min-h-[44px] px-4 py-2 rounded text-xs font-semibold text-white sm:min-h-0 disabled:opacity-50"
-                    style={{ background: "#0EA5E9" }}
-                  >
-                    {submitting ? "Signing up…" : "Subscribe"}
-                  </button>
-                </div>
-                {emailError ? (
-                  <p id="footer-email-err" className="text-xs text-rose-400" role="alert">
-                    {emailError}
-                  </p>
-                ) : null}
-                {apiError ? (
-                  <p id="footer-digest-api-err" className="text-xs text-rose-400" role="alert">
-                    {apiError}
-                  </p>
-                ) : null}
-              </div>
-            )}
-          </div>
-
-          {/* Quick Links */}
-          <div>
-            <div className="section-label mb-2">QUICK LINKS</div>
-            <div className="grid grid-cols-2 gap-x-4 gap-y-2">
-              {FOOTER_QUICK_LINKS.map((link) => (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  className="text-xs hover:text-sky-400 transition-colors"
-                  style={{ color: "var(--hi-muted, rgba(255,255,255,0.72))" }}
-                >
-                  {link.label}
-                </a>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        <div className="text-center pt-6 border-t" style={{ borderColor: "rgba(255,255,255,0.04)" }}>
-          <p className="text-xs" style={{ color: "rgba(255,255,255,0.2)" }}>
-            © {new Date().getFullYear()} Hoops Intel · Not affiliated with the NBA · Data for entertainment purposes
-          </p>
-        </div>
-      </div>
-    </footer>
   );
 }
 
@@ -1915,7 +1772,7 @@ export default function Home() {
         />
         <StandingsSection />
       </main>
-      <Footer />
+      <SiteFooter />
       {showPrefsSetup && (
         <PreferencesSetup
           onClose={() => setShowPrefsSetup(false)}

--- a/client/src/pages/InjuryReport.tsx
+++ b/client/src/pages/InjuryReport.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import SiteHeader from "../components/SiteHeader";
-import { InjuryChip, SectionHeader } from "../components/enhanced/EnhancedUi";
+import EditorialShell from "../components/EditorialShell";
+import { EmptyState, InjuryChip, PageHero } from "../components/enhanced/EnhancedUi";
 import { editionContextDeskLabel, isOffseasonDesk } from "../lib/deskMode";
 import { injuryCounts } from "../lib/enhancedDesk";
 import { injuryUpdates, fantasyAlerts, pulseEdition, pulseIndex } from "../lib/pulseData";
@@ -325,11 +325,18 @@ export default function InjuryReport() {
   });
 
   return (
-    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
-      <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
+    <EditorialShell>
+      <div className="px-4 md:px-7 py-5 flex flex-col gap-4 max-md:gap-3.5">
         <div className="flex flex-col gap-1 md:flex-row md:items-end md:justify-between min-w-0">
-          <SectionHeader eyebrow="INJURY WIRE" title="Full report" />
+          <PageHero
+            kicker="Injury wire"
+            title="Full report"
+            description={`${shortDate} · ${editionContextDeskLabel().toLowerCase()} · ${tallies.dtd} day-to-day · ${tallies.probable} probable · ${tallies.out} out${
+              isOffseasonDesk()
+                ? " · last-known editorial tags — live injury cron is dark through September"
+                : ""
+            }`}
+          />
           <button
             type="button"
             onClick={nextClub}
@@ -339,20 +346,15 @@ export default function InjuryReport() {
             {club === "all" ? "Filter · all clubs" : `Filter · ${club}`}
           </button>
         </div>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="mobile-readable" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-            {shortDate} · {editionContextDeskLabel().toLowerCase()} · {tallies.dtd} day-to-day · {tallies.probable}{" "}
-            probable · {tallies.out} out
-            {isOffseasonDesk()
-              ? " · last-known editorial tags — live injury cron is dark through September"
-              : ""}
-          </p>
-        </div>
 
         {rows.length === 0 ? (
-          <div className="text-sm py-16 text-center" style={{ color: "var(--hi-text-secondary,#8b9bb0)" }}>
-            No injuries match this club filter.
-          </div>
+          <EmptyState
+            kicker="Injury wire"
+            title="No matches"
+            body="No injuries match this club filter."
+            pill="CLEAR FILTER"
+            pillTone="accent"
+          />
         ) : (
           <div className="flex flex-col gap-2">
             {rows.map((injury) => (
@@ -380,7 +382,7 @@ export default function InjuryReport() {
             ))}
           </div>
         )}
-      </main>
-    </div>
+      </div>
+    </EditorialShell>
   );
 }

--- a/client/src/pages/LineupIntel.tsx
+++ b/client/src/pages/LineupIntel.tsx
@@ -492,30 +492,15 @@ export default function LineupIntel() {
 
   return (
     <ToolPageLayout subtitle="LINEUP INTEL">
-{/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-xs font-semibold mb-2"
-            style={{
-              color: "rgba(255,255,255,0.4)",
-              fontFamily: "'Barlow Condensed', sans-serif",
-              letterSpacing: "0.1em",
-            }}
-          >
-            WEEKLY ANALYSIS
-          </div>
-          <h1
-            className="text-4xl font-bold mb-1 leading-tight"
-            style={{ color: "#fff", fontFamily: "'Barlow Condensed', sans-serif" }}
-          >
-            Lineup Intelligence
+          <p className="enhanced-kicker mb-2">Weekly analysis</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Lineup intelligence
           </h1>
-          <p
-            className="text-sm mb-4"
-            style={{ color: "rgba(255,255,255,0.45)", fontFamily: "'DM Sans', sans-serif" }}
-          >
+          <p className="mobile-readable mb-4" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
             AI-analyzed lineup combinations, death lineups, and rotation insights
           </p>
+          <div className="desk-hairline" />
 
           {/* Week badge + generated date */}
           <div className="flex items-center gap-3 flex-wrap">

--- a/client/src/pages/Momentum.tsx
+++ b/client/src/pages/Momentum.tsx
@@ -478,28 +478,12 @@ export default function Momentum() {
 
   return (
     <ToolPageLayout subtitle="MOMENTUM ENGINE">
-{/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-xs font-semibold mb-2"
-            style={{
-              color: "rgba(255,255,255,0.4)",
-              fontFamily: "'Barlow Condensed', sans-serif",
-              letterSpacing: "0.1em",
-            }}
-          >
-            DAILY MOMENTUM ANALYSIS
-          </div>
-          <h1
-            className="text-4xl font-bold mb-1 leading-tight"
-            style={{ color: "#fff", fontFamily: "'Barlow Condensed', sans-serif" }}
-          >
-            Momentum Engine
+          <p className="enhanced-kicker mb-2">Daily momentum analysis</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Momentum engine
           </h1>
-          <p
-            className="text-sm mb-4"
-            style={{ color: "rgba(255,255,255,0.45)", fontFamily: "'DM Sans', sans-serif" }}
-          >
+          <p className="mobile-readable mb-4" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
             AI-analyzed momentum shifts, clutch plays, and game narratives
           </p>
 

--- a/client/src/pages/MyPulse.tsx
+++ b/client/src/pages/MyPulse.tsx
@@ -77,17 +77,18 @@ export default function MyPulse() {
                 <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-white mb-3">
-              Set Up My Pulse
+            <p className="enhanced-kicker mb-2">My Pulse</p>
+            <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-2xl mb-3">
+              Set up My Pulse
             </h1>
-            <p className="text-sm mb-6" style={{ color: "rgba(255,255,255,0.5)" }}>
+            <p className="mobile-readable mb-6" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
               Pick your favorite teams and players to get a personalized daily edition tailored just for you.
             </p>
             <button
               type="button"
               onClick={() => setShowSetup(true)}
-              className="min-h-[44px] px-6 py-3 rounded-lg text-sm font-semibold text-white transition-all hover:opacity-90"
-              style={{ background: "#0EA5E9" }}
+              className="min-h-11 px-6 py-3 rounded-[10px] text-sm font-semibold transition-opacity hover:opacity-90"
+              style={{ background: "var(--hi-accent,#1ec8f5)", color: "var(--hi-accent-ink,#0a0d12)" }}
             >
               Choose Favorites
             </button>
@@ -437,9 +438,9 @@ function MyPulseHeader({
                   href={`/team/${team.toLowerCase()}`}
                   className="px-2 py-1 rounded text-xs font-bold tracking-wider whitespace-nowrap transition-colors hover:bg-sky-500/25"
                   style={{
-                    background: "rgba(14,165,233,0.15)",
-                    color: "#0EA5E9",
-                    border: "1px solid rgba(14,165,233,0.3)",
+                    background: "rgba(30,200,245,0.15)",
+                    color: "var(--hi-accent,#1ec8f5)",
+                    border: "1px solid rgba(30,200,245,0.3)",
                   }}
                 >
                   {team}

--- a/client/src/pages/PickEm.tsx
+++ b/client/src/pages/PickEm.tsx
@@ -24,8 +24,8 @@ import { isPlayoffsActive, playoffSeries } from "../lib/playoffData";
 import { playoffSnapshot, todayISOLocal } from "../lib/playoffAnalytics";
 import ToolPageLayout from "../components/ToolPageLayout";
 import PulseAccountabilityPanel from "../components/PulseAccountabilityPanel";
-import SiteHeader from "../components/SiteHeader";
-import { EnhancedButton, GamePreviewCard, SectionHeader, StatCard } from "../components/enhanced/EnhancedUi";
+import EditorialShell from "../components/EditorialShell";
+import { EnhancedButton, GamePreviewCard, PageHero, SectionHeader, StatCard } from "../components/enhanced/EnhancedUi";
 import { SAMPLE_LOCKS } from "../lib/enhancedDesk";
 
 // ═══════════════════════════════════════════════════════════
@@ -511,9 +511,7 @@ function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
   const streak = pickStats.streak > 0 ? String(pickStats.streak) : "—";
 
   return (
-    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
-      <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-5 flex flex-col gap-4 outline-none max-md:gap-3.5">
+    <EditorialShell mainClassName="px-4 md:px-7 py-5 flex flex-col gap-4 max-md:gap-3.5">
         <SectionHeader
           eyebrow="PICK 'EM"
           title="Lock tonight’s slate"
@@ -561,8 +559,7 @@ function ClosedBoardPickEm({ pickStats }: { pickStats: PickWinLoss }) {
         <div id="how-it-works" className="pt-2">
           <HowItWorksSection />
         </div>
-      </main>
-    </div>
+    </EditorialShell>
   );
 }
 
@@ -599,28 +596,11 @@ export default function PickEmPage() {
     <ToolPageLayout subtitle="PICK EM">
 {/* Page Title */}
         <div className="mb-8">
-          <div
-            className="text-xs font-semibold mb-2"
-            style={{
-              color: "#0EA5E9",
-              fontFamily: "'Barlow Condensed', sans-serif",
-              letterSpacing: "0.1em",
-            }}
-          >
-            {pulseEdition.edition} &middot; {pulseEdition.date.toUpperCase()}
-          </div>
-          <h1
-            className="text-4xl font-bold mb-2 leading-tight"
-            style={{ color: "#fff", fontFamily: "'Barlow Condensed', sans-serif" }}
-          >
-            Daily Pick&apos;em
-          </h1>
-          <p
-            className="text-sm leading-relaxed"
-            style={{ color: "rgba(255,255,255,0.5)", fontFamily: "'DM Sans', sans-serif" }}
-          >
-            {gamePreviews.length} games on the slate tonight. Pick your winners before tip-off.
-          </p>
+          <PageHero
+            kicker={`${pulseEdition.edition} · ${pulseEdition.date}`}
+            title="Daily Pick 'Em"
+            description={`${gamePreviews.length} games on the slate tonight. Pick your winners before tip-off.`}
+          />
         </div>
 
         {(pickStats.wins + pickStats.losses > 0 || pickStats.streak > 0 || slateSettled > 0) && (

--- a/client/src/pages/Player.tsx
+++ b/client/src/pages/Player.tsx
@@ -10,6 +10,7 @@ import { useMetaTags } from "../lib/useMetaTags";
 import { getPlayerIntelBySlug, type PlayerIntelResponse } from "../lib/playerIntel";
 import { getPlayerRosterStatus } from "../lib/playerRosterStatus";
 import SiteHeader from "../components/SiteHeader";
+import SiteFooter from "../components/SiteFooter";
 import Breadcrumbs from "../components/Breadcrumbs";
 import ErrorBlock from "../components/ErrorBlock";
 import { PlayerPageSkeleton } from "../components/PageSkeletons";
@@ -111,9 +112,11 @@ export default function Player() {
       <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
         <SiteHeader subtitle="PLAYER" />
         <div className="container py-20 text-center">
-          <h1 className="display-heading text-white text-2xl mb-4">Player Not Found</h1>
-          <a href="/" className="text-sky-400 underline">Back to Hoops Intel</a>
+          <p className="enhanced-kicker mb-3">Player</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-2xl mb-4">Player not found</h1>
+          <a href="/" className="underline min-h-11 inline-flex items-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>Back to Hoops Intel</a>
         </div>
+        <SiteFooter />
       </div>
     );
   }
@@ -123,6 +126,7 @@ export default function Player() {
       <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
         <SiteHeader subtitle="PLAYER" />
         <PlayerPageSkeleton />
+        <SiteFooter />
       </div>
     );
   }
@@ -166,8 +170,8 @@ export default function Player() {
             <div className="flex items-center gap-4">
               <PlayerAvatar name={player.name} team={player.teams[0]} size={72} />
               <div>
-              <div className="section-label mb-1">PLAYER PROFILE</div>
-              <h1 className="display-heading text-white text-3xl mb-2">{player.name}</h1>
+              <p className="enhanced-kicker mb-1">Player profile</p>
+              <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-3xl mb-2 max-md:text-[1.5rem]">{player.name}</h1>
               <div className="flex items-center gap-2 flex-wrap">
                 {player.teams.map((t) => (
                   <a
@@ -463,6 +467,7 @@ export default function Player() {
           </div>
         </div>
       </main>
+      <SiteFooter />
     </div>
   );
 }

--- a/client/src/pages/PodcastCompanion.tsx
+++ b/client/src/pages/PodcastCompanion.tsx
@@ -157,21 +157,14 @@ export default function PodcastCompanion() {
     <ToolPageLayout subtitle="PODCAST COMPANION">
 {/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-[10px] font-bold tracking-widest uppercase mb-1"
-            style={{ color: "rgba(255,255,255,0.35)" }}
-          >
-            PODCAST COMPANION
-          </div>
-          <h1
-            className="display-heading text-white mb-2"
-            style={{ fontSize: "clamp(1.75rem, 4vw, 2.5rem)" }}
-          >
-            Today's Episode Blueprint
+          <p className="enhanced-kicker mb-2">Podcast companion</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Today&apos;s episode blueprint
           </h1>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {data.date} — Everything you need for today's show
+          <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            {data.date} — Everything you need for today&apos;s show
           </p>
+          <div className="desk-hairline mt-3" />
         </div>
 
         {/* Episode title card */}

--- a/client/src/pages/Pro.tsx
+++ b/client/src/pages/Pro.tsx
@@ -172,11 +172,14 @@ export default function Pro() {
   return (
     <ToolPageLayout subtitle="PRO" maxWidth="xl" showRelated={false}>
         <div className="mb-10">
-          <div className="section-label mb-2" style={{ color: "#0EA5E9" }}>HOOPS INTEL PRO</div>
-          <h1 className="display-heading text-white text-4xl mb-3">Sharper basketball, earlier and ad-free.</h1>
-          <p className="text-base" style={{ color: "rgba(255,255,255,0.6)" }}>
+          <p className="enhanced-kicker mb-2">Hoops Intel Pro</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[36px] leading-10 mb-3 max-md:text-[1.75rem]">
+            Sharper basketball, earlier and ad-free.
+          </h1>
+          <p className="mobile-readable max-w-2xl" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
             Everything free readers get — plus early access, deeper analytics, and an unobstructed reading experience.
           </p>
+          <div className="desk-hairline mt-4" />
         </div>
 
         {sub.isPro ? (
@@ -204,7 +207,7 @@ export default function Pro() {
                 disabled={portalLoading}
                 onClick={() => void handlePortal()}
                 className="min-h-[48px] px-5 py-2.5 rounded-lg text-sm font-semibold text-white disabled:opacity-50"
-                style={{ background: "linear-gradient(135deg, #0EA5E9, #0284C7)", fontFamily: "'Barlow Condensed', sans-serif" }}
+                style={{ background: "var(--hi-accent,#1ec8f5)", color: "var(--hi-accent-ink,#0a0d12)", fontFamily: "'DM Sans', sans-serif" }}
               >
                 {portalLoading ? "OPENING STRIPE…" : "MANAGE BILLING"}
               </button>

--- a/client/src/pages/Projections.tsx
+++ b/client/src/pages/Projections.tsx
@@ -365,27 +365,14 @@ export default function Projections() {
 
   return (
     <ToolPageLayout subtitle="PROJECTIONS">
-{/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-xs font-semibold mb-2"
-            style={{
-              color: "rgba(255,255,255,0.4)",
-              fontFamily: "'Barlow Condensed', sans-serif",
-              letterSpacing: "0.1em",
-            }}
-          >
-            WEEKLY PROJECTIONS
-          </div>
-          <h1
-            className="text-4xl font-bold mb-1 leading-tight"
-            style={{ color: "#fff", fontFamily: "'Barlow Condensed', sans-serif" }}
-          >
-            Rest-of-Season Projections
+          <p className="enhanced-kicker mb-2">Weekly projections</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Rest-of-season projections
           </h1>
           <p
-            className="text-sm mb-4"
-            style={{ color: "rgba(255,255,255,0.45)", fontFamily: "'DM Sans', sans-serif" }}
+            className="mobile-readable mb-4"
+            style={{ color: "var(--hi-text-secondary,#8594a8)" }}
           >
             Win totals, playoff probabilities &amp; championship odds
           </p>

--- a/client/src/pages/RefReports.tsx
+++ b/client/src/pages/RefReports.tsx
@@ -195,23 +195,15 @@ export default function RefReports() {
 
   return (
     <ToolPageLayout subtitle="REFEREE REPORTS">
-{/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-[10px] font-bold tracking-widest uppercase mb-1"
-            style={{ color: "rgba(255,255,255,0.35)" }}
-          >
-            REFEREE TENDENCY REPORTS
-          </div>
-          <h1
-            className="display-heading text-white mb-2"
-            style={{ fontSize: "clamp(1.75rem, 4vw, 2.5rem)" }}
-          >
-            Know the Whistle
+          <p className="enhanced-kicker mb-2">Referee reports</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Know the whistle
           </h1>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {formatContentDate(data.generatedDate)} — Tonight's officiating crews and their tendencies
+          <p className="text-sm" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            {formatContentDate(data.generatedDate)} — Tonight&apos;s officiating crews and their tendencies
           </p>
+          <div className="desk-hairline mt-3" />
         </div>
 
         {/* Weekly trend banner */}

--- a/client/src/pages/Team.tsx
+++ b/client/src/pages/Team.tsx
@@ -9,6 +9,7 @@ import { slugify } from "../lib/searchUtils";
 import { useMetaTags } from "../lib/useMetaTags";
 import { TEAM_NAMES, canonicalizeTeamCode } from "../lib/identity";
 import SiteHeader from "../components/SiteHeader";
+import SiteFooter from "../components/SiteFooter";
 import Breadcrumbs from "../components/Breadcrumbs";
 import ErrorBlock from "../components/ErrorBlock";
 import { TeamPageSkeleton } from "../components/PageSkeletons";
@@ -76,9 +77,11 @@ export default function Team() {
       <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
         <SiteHeader subtitle="TEAMS" />
         <div className="container py-20 text-center">
-          <h1 className="display-heading text-white text-2xl mb-4">Team Not Found</h1>
-          <a href="/" className="text-sky-400 underline">Back to Hoops Intel</a>
+          <p className="enhanced-kicker mb-3">Team</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-2xl mb-4">Team not found</h1>
+          <a href="/" className="underline min-h-11 inline-flex items-center" style={{ color: "var(--hi-accent,#1ec8f5)" }}>Back to Hoops Intel</a>
         </div>
+        <SiteFooter />
       </div>
     );
   }
@@ -88,6 +91,7 @@ export default function Team() {
       <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
         <SiteHeader subtitle={`TEAM · ${abbr}`} />
         <TeamPageSkeleton />
+        <SiteFooter />
       </div>
     );
   }
@@ -129,8 +133,8 @@ export default function Team() {
             <div className="flex items-center gap-4">
               <TeamLogo team={abbr} size={64} />
               <div>
-                <div className="section-label mb-1">TEAM PROFILE</div>
-                <h1 className="display-heading text-white text-3xl mb-1">{fullName}</h1>
+                <p className="enhanced-kicker mb-1">Team profile</p>
+                <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-3xl mb-1 max-md:text-[1.5rem]">{fullName}</h1>
                 <div className="text-sm" style={{ color: "rgba(255,255,255,0.5)" }}>
                   {standing?.conf === "east" ? "Eastern" : "Western"} Conference
                 </div>
@@ -436,6 +440,7 @@ export default function Team() {
           </div>
         </div>
       </main>
+      <SiteFooter />
     </div>
   );
 }

--- a/client/src/pages/Tonight.tsx
+++ b/client/src/pages/Tonight.tsx
@@ -1,6 +1,6 @@
-import SiteHeader from "../components/SiteHeader";
-import { DeskPanel, EnhancedButton, GamePreviewCard, SectionHeader, StatCard, StatusPill } from "../components/enhanced/EnhancedUi";
-import { daysUntilIso, CAMP_OPEN_ISO, hasTonightSlate } from "../lib/enhancedDesk";
+import EditorialShell from "../components/EditorialShell";
+import { DeskPanel, EmptyState, EnhancedButton, GamePreviewCard, PageHero, StatCard } from "../components/enhanced/EnhancedUi";
+import { campOpenDisplay, daysUntilIso, CAMP_OPEN_ISO, hasTonightSlate } from "../lib/enhancedDesk";
 import { campIntelCards, campScheduleStatus } from "../lib/campDesk";
 import { gamePreviews, pulseEdition } from "../lib/pulseData";
 import { makeGameId } from "../lib/gameCenter";
@@ -10,67 +10,53 @@ export default function Tonight() {
   const slateOpen = hasTonightSlate();
   const deskCards = campIntelCards(3);
   const schedule = campScheduleStatus();
+  const openDate = campOpenDisplay();
 
   return (
-    <div className="min-h-screen has-mobile-tabbar" style={{ background: "var(--hi-bg-page,#050d1a)" }}>
-      <SiteHeader />
-      <main id="main-content" tabIndex={-1} className="px-4 md:px-7 py-6 flex flex-col gap-5 outline-none">
-        <div className="flex flex-col gap-2 min-w-0">
-          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[30px] leading-[34px] max-md:text-[1.5rem] max-md:leading-8">
-            Tonight
-          </h1>
-          <p className="mobile-readable max-w-2xl" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
-            {slateOpen
-              ? `${gamePreviews.length} games on the ESPN board.`
-              : "No games on the board. Preseason desk stays honest — we never invent tip-offs."}
-          </p>
-        </div>
-
+    <EditorialShell>
+      <div className="px-4 md:px-7 py-6 flex flex-col gap-5">
         {slateOpen ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-            {(gamePreviews as Array<{
-              gameId?: string;
-              awayTeam: string;
-              homeTeam: string;
-              time?: string;
-              tv?: string;
-              featured?: boolean;
-              storyline?: string;
-              keyMatchup?: string;
-            }>).map((preview) => (
-              <a
-                key={preview.gameId || `${preview.awayTeam}-${preview.homeTeam}`}
-                href={`/game/${preview.gameId || makeGameId(preview.awayTeam, preview.homeTeam, pulseEdition.date)}`}
-              >
-                <GamePreviewCard
-                  status={preview.featured ? "FEATURED" : "TONIGHT"}
-                  when={`${preview.time ?? ""}${preview.tv ? ` · ${preview.tv}` : ""}`}
-                  away={preview.awayTeam}
-                  home={preview.homeTeam}
-                  network={preview.tv || ""}
-                  note={preview.storyline || preview.keyMatchup || ""}
-                />
-              </a>
-            ))}
-          </div>
-        ) : (
-          <div className="enhanced-card flex flex-col items-center justify-center text-center gap-2 px-6 py-12 max-md:px-4 max-md:py-10">
-            <p className="font-semibold text-lg leading-6 text-[var(--hi-text,#f2f5fa)]">Waiting on Oct 3</p>
-            <p className="text-sm max-w-md" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
-              Camp openers land on ESPN schedule · not tonight
-              {campDays > 0 ? ` · ${campDays === 1 ? "one day" : `${campDays} days`} out` : ""}.
-            </p>
-            <StatusPill tone="warn">NOT TONIGHT</StatusPill>
-          </div>
-        )}
-
-        {!slateOpen ? (
           <>
-            <SectionHeader
-              eyebrow="ON THE DESK"
-              title="Camp / preseason intel"
-              action="Open desk →"
-              actionHref="/#camp-intel"
+            <PageHero
+              kicker="Tonight"
+              title={`${gamePreviews.length} games on the ESPN board`}
+              description="Tip-offs from today’s edition — we never invent a slate."
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+              {(gamePreviews as Array<{
+                gameId?: string;
+                awayTeam: string;
+                homeTeam: string;
+                time?: string;
+                tv?: string;
+                featured?: boolean;
+                storyline?: string;
+                keyMatchup?: string;
+              }>).map((preview) => (
+                <a
+                  key={preview.gameId || `${preview.awayTeam}-${preview.homeTeam}`}
+                  href={`/game/${preview.gameId || makeGameId(preview.awayTeam, preview.homeTeam, pulseEdition.date)}`}
+                >
+                  <GamePreviewCard
+                    status={preview.featured ? "FEATURED" : "TONIGHT"}
+                    when={`${preview.time ?? ""}${preview.tv ? ` · ${preview.tv}` : ""}`}
+                    away={preview.awayTeam}
+                    home={preview.homeTeam}
+                    network={preview.tv || ""}
+                    note={preview.storyline || preview.keyMatchup || ""}
+                  />
+                </a>
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <EmptyState
+              kicker="Tonight"
+              title={`Waiting on ${openDate}`}
+              body="The desk stays honest — empty slate until real tip-offs."
+              pill="NOT TONIGHT"
+              footnote="Camp openers land on ESPN schedule"
             />
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
               {deskCards.map((card) => (
@@ -86,6 +72,7 @@ export default function Tonight() {
                     .slice(0, 3)
                     .map((game) => `${game.away} @ ${game.home}`)
                     .join(" · ")}
+                  {campDays > 0 ? ` · ${campDays === 1 ? "one day" : `${campDays} days`} out` : ""}
                 </p>
               </DeskPanel>
             ) : null}
@@ -96,8 +83,8 @@ export default function Tonight() {
               </EnhancedButton>
             </div>
           </>
-        ) : null}
-      </main>
-    </div>
+        )}
+      </div>
+    </EditorialShell>
   );
 }

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -41,11 +41,11 @@ export default function Tools() {
 
   return (
     <ToolPageLayout subtitle="TOOLS & LABS" maxWidth="xl" showRelated={false}>
-        <p className="section-label mb-2">FEATURE DIRECTORY</p>
-        <h1 className="display-heading text-2xl sm:text-3xl mb-4" style={{ color: "var(--hi-heading,#fff)" }}>
+        <p className="enhanced-kicker mb-2">Feature directory</p>
+        <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-4 max-md:text-[1.5rem] max-md:leading-8">
           Every Hoops Intel tool
         </h1>
-        <p className="text-sm mb-6 max-w-2xl leading-relaxed" style={{ color: "var(--hi-muted,rgba(255,255,255,0.6))" }}>
+        <p className="mobile-readable mb-6 max-w-2xl" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
           Daily desk and analysis tools. Search from any page, or press{" "}
           <kbd className="mono-data text-[10px] px-1 py-0.5 rounded bg-white/10">/</kbd> to jump to a player, team, or story.
         </p>
@@ -132,7 +132,7 @@ export default function Tools() {
               if (items.length === 0) return null;
               return (
                 <section key={cat} aria-labelledby={`tools-cat-${cat}`}>
-                  <h2 id={`tools-cat-${cat}`} className="section-label mb-4" style={{ color: "rgba(148,163,184,0.95)" }}>
+                  <h2 id={`tools-cat-${cat}`} className="enhanced-kicker mb-4">
                     {TOOL_CATEGORY_LABELS[cat]}
                   </h2>
                   <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -140,7 +140,7 @@ export default function Tools() {
                       <li key={t.href + t.label}>
                         <a
                           href={t.href}
-                          className="glass-card block rounded-xl p-4 min-h-[4.75rem] transition-colors hover:border-sky-500/40 hover:bg-white/[0.05] outline-none focus-visible:ring-2 focus-visible:ring-sky-500/50"
+                          className="enhanced-card block p-4 min-h-[4.75rem] outline-none"
                         >
                           <span className="text-sm font-semibold text-[var(--hi-heading,#fff)]">{t.label}</span>
                           <p className="text-xs mt-1 leading-snug" style={{ color: "var(--hi-muted-sub,rgba(255,255,255,0.5))" }}>

--- a/client/src/pages/TradeSimulator.tsx
+++ b/client/src/pages/TradeSimulator.tsx
@@ -836,29 +836,13 @@ export default function TradeSimulator() {
 
   return (
     <ToolPageLayout subtitle="TRADE SIMULATOR">
-{/* Page header */}
         <div className="mb-8">
-          <div
-            className="text-xs font-semibold mb-2"
-            style={{
-              color: "rgba(255,255,255,0.4)",
-              fontFamily: "'Barlow Condensed', sans-serif",
-              letterSpacing: "0.1em",
-            }}
-          >
-            WEEKLY AI ANALYSIS
-          </div>
-          <h1
-            className="text-4xl font-bold mb-1 leading-tight"
-            style={{ color: "#fff", fontFamily: "'Barlow Condensed', sans-serif" }}
-          >
-            TRADE SIMULATOR
+          <p className="enhanced-kicker mb-2">Weekly AI analysis</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 mb-2 max-md:text-[1.5rem] max-md:leading-8">
+            Trade simulator
           </h1>
-          <p
-            className="text-sm mb-4"
-            style={{ color: "rgba(255,255,255,0.45)", fontFamily: "'DM Sans', sans-serif" }}
-          >
-            What If &mdash; AI-powered trade proposals and interactive trade builder
+          <p className="mobile-readable mb-4" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
+            What If — AI-powered trade proposals and interactive trade builder
           </p>
           <div className="flex items-center gap-3 flex-wrap">
             <span

--- a/client/src/pages/Unsubscribe.tsx
+++ b/client/src/pages/Unsubscribe.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import SiteHeader from "../components/SiteHeader";
+import EditorialShell from "../components/EditorialShell";
+import { PageHero } from "../components/enhanced/EnhancedUi";
 
 function loadEmail(): string {
   try {
@@ -41,14 +42,13 @@ export default function Unsubscribe() {
   };
 
   return (
-    <div className="min-h-screen" style={{ background: "var(--hi-bg-page, #050D1A)" }}>
-      <SiteHeader subtitle="DIGEST" />
-
-      <main id="main-content" tabIndex={-1} className="container py-14 max-w-md outline-none">
-        <h1 className="display-heading text-2xl text-white mb-2">Unsubscribe</h1>
-        <p className="text-sm mb-6" style={{ color: "rgba(255,255,255,0.5)" }}>
-          Turn off morning digest emails only — your Hoops Intel account (if any) stays active.
-        </p>
+    <EditorialShell header={{ subtitle: "DIGEST" }} mainClassName="container py-14 max-w-md">
+        <PageHero
+          kicker="Digest"
+          title="Unsubscribe"
+          description="Turn off morning digest emails only — your Hoops Intel account (if any) stays active."
+        />
+        <div className="mt-6">
         <label htmlFor="unsub-email" className="sr-only">
           Email
         </label>
@@ -72,8 +72,8 @@ export default function Unsubscribe() {
           disabled={status === "loading"}
           className="w-full min-h-[44px] py-3 rounded-lg font-semibold transition-opacity"
           style={{
-            background: "linear-gradient(135deg,#0EA5E9,#0284C7)",
-            color: "#fff",
+            background: "var(--hi-accent,#1ec8f5)",
+            color: "var(--hi-accent-ink,#0a0d12)",
             opacity: status === "loading" ? 0.6 : 1,
           }}
         >
@@ -84,11 +84,11 @@ export default function Unsubscribe() {
             {message}
           </p>
         )}
-        <p className="mt-10 text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>
+        <p className="mt-10 text-xs" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
           Tip: Prefer fewer emails instead? Quiet hours ship with bulk sends — ping us if something looks off after
           subscribing again from the home footer.
         </p>
-      </main>
-    </div>
+        </div>
+    </EditorialShell>
   );
 }

--- a/client/src/pages/WatchGuide.tsx
+++ b/client/src/pages/WatchGuide.tsx
@@ -302,20 +302,15 @@ export default function WatchGuide() {
         </span>
       }
     >
-{/* Title */}
-        <div className="text-center">
-          <h1
-            className="text-2xl font-black uppercase tracking-wider mb-2"
-            style={{ fontFamily: "'Barlow Condensed', sans-serif", color: "#fff" }}
-          >
-            Tonight's Watch Guide
+        <div className="mb-6">
+          <p className="enhanced-kicker mb-2">Watch guide</p>
+          <h1 className="editorial-heading text-[var(--hi-text,#f2f5fa)] text-[32px] leading-9 max-md:text-[1.5rem] max-md:leading-8">
+            Tonight&apos;s watch guide
           </h1>
-          <p
-            className="text-sm"
-            style={{ color: "rgba(255,255,255,0.4)", fontFamily: "'DM Sans', sans-serif" }}
-          >
+          <p className="text-sm mt-2" style={{ color: "var(--hi-text-secondary,#8594a8)" }}>
             {data.date}
           </p>
+          <div className="desk-hairline mt-3" />
         </div>
 
         {/* Top Pick Callout */}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -21,23 +21,26 @@ html {
 }
 
 html.dark {
-  --hi-bg-page: #050d1a;
-  --hi-shell-text: rgba(255, 255, 255, 0.85);
-  --hi-header-bg: rgba(5, 13, 26, 0.95);
-  --hi-mobile-sheet: #081018;
-  --hi-border-soft: rgba(255, 255, 255, 0.08);
-  --hi-heading: #ffffff;
-  --hi-muted: rgba(255, 255, 255, 0.72);
-  --hi-muted-sub: rgba(255, 255, 255, 0.68);
+  --hi-bg-page: #07090e;
+  --hi-shell-text: rgba(242, 245, 250, 0.88);
+  --hi-header-bg: rgba(7, 9, 14, 0.92);
+  --hi-mobile-sheet: #0b0e14;
+  --hi-border-soft: rgba(255, 255, 255, 0.06);
+  --hi-heading: #f2f5fa;
+  --hi-muted: rgba(242, 245, 250, 0.72);
+  --hi-muted-sub: rgba(242, 245, 250, 0.58);
   --hi-accent: #1ec8f5;
-  --hi-surface: #171c26;
-  --hi-surface-2: #12171f;
-  --hi-border: #293342;
+  --hi-accent-ink: #0a0d12;
+  --hi-surface: #141820;
+  --hi-surface-2: #0e1218;
+  --hi-border: #252b36;
   --hi-text: #f2f5fa;
   --hi-text-secondary: #8594a8;
   --hi-success: #40d18c;
   --hi-danger: #ff4d6a;
   --hi-warn: #f2b838;
+  --hi-card-radius: 16px;
+  --hi-inset-radius: 10px;
 }
 
 html.light {
@@ -50,6 +53,7 @@ html.light {
   --hi-muted: rgba(15, 23, 42, 0.68);
   --hi-muted-sub: rgba(15, 23, 42, 0.52);
   --hi-accent: #0284c7;
+  --hi-accent-ink: #f8fafc;
   --hi-surface: #ffffff;
   --hi-surface-2: #e2e8f0;
   --hi-border: rgba(15, 23, 42, 0.12);
@@ -58,6 +62,8 @@ html.light {
   --hi-success: #059669;
   --hi-danger: #e11d48;
   --hi-warn: #b45309;
+  --hi-card-radius: 16px;
+  --hi-inset-radius: 10px;
 }
 
 .sr-only {
@@ -122,7 +128,7 @@ input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
 [tabindex]:focus-visible {
-  outline: 2px solid #38bdf8;
+  outline: 2px solid var(--hi-accent, #1ec8f5);
   outline-offset: 3px;
   border-radius: 0.375rem;
 }
@@ -205,6 +211,15 @@ html.light .section-label {
   color: var(--hi-accent, #1ec8f5);
 }
 
+/* Page titles inherit the editorial serif — condensed lockups stay on non-h1 display-heading. */
+h1.display-heading {
+  font-family: "Newsreader", Georgia, "Times New Roman", serif;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .mono-data {
   font-family: "Geist Mono", "JetBrains Mono", ui-monospace, monospace;
   font-size: 0.85rem;
@@ -250,14 +265,21 @@ html.light .section-label {
 }
 
 .enhanced-card {
-  background: var(--hi-surface, #171c26);
-  border: 1px solid var(--hi-border, #293342);
-  border-radius: 14px;
+  background: var(--hi-surface, #141820);
+  border: 1px solid var(--hi-border, #252b36);
+  border-radius: var(--hi-card-radius, 16px);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 10px 28px rgba(0, 0, 0, 0.22);
 }
 
 .desk-inset {
-  background: var(--hi-surface-2, #12171f);
-  border-radius: 10px;
+  background: var(--hi-surface-2, #0e1218);
+  border-radius: var(--hi-inset-radius, 10px);
+}
+
+.desk-hairline {
+  height: 1px;
+  width: 100%;
+  background: var(--hi-border-soft, rgba(255, 255, 255, 0.08));
 }
 
 .desk-chip {
@@ -280,21 +302,21 @@ html.light .section-label {
   padding: 0 1rem;
 }
 
-/* Glass Card */
+/* Glass Card — same editorial surface as DeskPanel so secondary pages match the desk */
 .glass-card {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 4px 16px rgba(0, 0, 0, 0.18);
-  transition: background 0.18s ease, border-color 0.18s ease,
-    box-shadow 0.18s ease, transform 0.18s ease;
+  background: var(--hi-surface, #141820);
+  border: 1px solid var(--hi-border, #252b36);
+  border-radius: var(--hi-card-radius, 16px);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 10px 28px rgba(0, 0, 0, 0.22);
+  backdrop-filter: none;
+  transition: border-color 0.18s ease;
 }
 
 .glass-card:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(14, 165, 233, 0.2);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3), 0 12px 32px rgba(0, 0, 0, 0.28);
-  transform: translateY(-2px);
+  background: var(--hi-surface, #141820);
+  border-color: rgba(30, 200, 245, 0.28);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 10px 28px rgba(0, 0, 0, 0.22);
+  transform: none;
 }
 
 html.light .glass-card {
@@ -397,7 +419,7 @@ html.light .glass-card {
 
 /* Selection */
 ::selection {
-  background: rgba(14, 165, 233, 0.3);
+  background: rgba(30, 200, 245, 0.28);
   color: white;
 }
 
@@ -502,8 +524,8 @@ html.light .glass-card {
   z-index: 200;
   padding: 0.625rem 1rem;
   border-radius: 0.5rem;
-  background: #0ea5e9;
-  color: #fff;
+  background: var(--hi-accent, #1ec8f5);
+  color: var(--hi-accent-ink, #0a0d12);
   font-size: 0.875rem;
   font-weight: 600;
   text-decoration: none;
@@ -578,9 +600,9 @@ html.light .glass-card {
 }
 
 .desk-section-pill[data-active="true"] {
-  color: #38bdf8;
-  background: rgba(14, 165, 233, 0.12);
-  border-color: rgba(14, 165, 233, 0.28);
+  color: var(--hi-accent, #1ec8f5);
+  background: rgba(30, 200, 245, 0.12);
+  border-color: rgba(30, 200, 245, 0.28);
 }
 
 html.light .desk-section-pill {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Kyle asked to redo every page — not a Desk-only polish. This PR lifts the Sep 2026 Figma caliber language (`#1EC8F5` accent, 16px elevated cards, quieter chrome, kicker → headline → hairline) onto the shared shell and every user-facing route.

**Shared system**
- Tokens: near-black page bg, `--hi-card-radius: 16px`, accent `#1EC8F5`
- New primitives: `PageHero`, `EmptyState`, `EditorialShell`, extracted `SiteFooter`
- `ToolPageLayout` now uses PageHero + DeskPanel related rail + SiteFooter (covers ~35 tool routes)
- Header: brand lockup + “Daily NBA Intelligence”, PRESEASON chip, single date, accent nav underline

**Flagship pages**
- Desk kicker is `PRESEASON DESK · Vol. 2026 · No. 225` with a hairline under the byline
- Tonight empty matches the Figma: “Waiting on October 3” + honest `NOT TONIGHT` — no invented tip-offs
- Injuries, Archive, Ask, Pick ’Em, Tools, Pro, Account, Player/Team/Game Center, Playoffs, My Pulse, Unsubscribe restyled onto the same language

**Constraints honored**
- No invented games / tip-offs
- No cron, secrets, or Vercel clone work
- Presentation/CSS/components only — edition pipeline untouched

## Pages touched

Desk/Home, Tonight, Injuries, Archive, Ask, Pick ’Em, Tools, Pro, Account, Player, Team, Game Center, Playoffs, My Pulse, Unsubscribe, Betting Intel, Watch Guide, Lineups, Clutch, Projections, Podcast Companion, History, Refs, Trade Simulator, Momentum, plus every other `ToolPageLayout` consumer via shared chrome (Widgets, Trivia, Draft, Sentiment, Community Pulse, Badges, 82-0, Performance, Pulse History, Trade Value, Compare, Rivals, Guest Pulse, Methodology, Creator Queue, Embed analytics, etc.).

**Residual / thinner pages:** Embed (chrome-less by design), Print Edition (print stylesheet), and a handful of lab interiors (Draft, Sentiment, Trivia, Widgets) that inherit the new cards/footer but still have some local `#0EA5E9` chips. The PWA install prompt can sit over the mobile tab bar (pre-existing).

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run test:unit` passes (318 tests)
- [ ] Vercel Preview looks correct for UI changes
- [x] New secrets documented in `.env.example` / `README.md` if applicable (N/A — no secrets)

[Desk editorial](https://cursor.com/agents/bc-511911b5-038e-4563-a01e-2e8f53577cb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_editorial.webp)
[Tonight empty state](https://cursor.com/agents/bc-511911b5-038e-4563-a01e-2e8f53577cb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftonight_empty.webp)
[editorial_ux_page_walkthrough.mp4](https://cursor.com/agents/bc-511911b5-038e-4563-a01e-2e8f53577cb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feditorial_ux_page_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-511911b5-038e-4563-a01e-2e8f53577cb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-511911b5-038e-4563-a01e-2e8f53577cb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize editorial UX components and styling across all pages
> - Adds shared layout primitives `EditorialShell`, `PageHero`, `EmptyState`, and `SiteFooter` and applies them across major pages to standardize presentation.
> - Updates theme variables and typography rules in [index.css](https://github.com/hondoentertainment/hoops-intel/pull/381/files#diff-065f34d6861b830db5472fba3f56f0815fb9777d8b481e34e6927c845810e1df) to support serif page titles, accent color changes, and new radius variables.
> - Converts page headings and labels from uppercase to sentence case and replaces hardcoded blue colors with theme accent variables.
> - Behavioral Change: `glass-card` elements in [index.css](https://github.com/hondoentertainment/hoops-intel/pull/381/files#diff-065f34d6861b830db5472fba3f56f0815fb9777d8b481e34e6927c845810e1df) are now opaque editorial surfaces without backdrop blur and no longer transition background, shadow, or transform properties on hover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae90937.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->